### PR TITLE
fix: support --version flag on both binaries

### DIFF
--- a/cmd/ynd/main.go
+++ b/cmd/ynd/main.go
@@ -31,7 +31,7 @@ func main() {
 		err = cmdCompress(os.Args[2:])
 	case "inspect":
 		err = cmdInspect(os.Args[2:])
-	case "version":
+	case "version", "--version", "-v":
 		fmt.Printf("ynd %s\n", config.Version)
 	case "help", "--help", "-h":
 		printUsage()

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -43,7 +43,7 @@ func main() {
 		err = cmdStatus()
 	case "prune":
 		err = cmdPrune()
-	case "version":
+	case "version", "--version":
 		fmt.Printf("ynh %s\n", config.Version)
 	case "help", "--help", "-h":
 		printUsage()


### PR DESCRIPTION
## Summary

- `ynh --version` and `ynd --version` now work (previously only the `version` subcommand was recognized)
- `ynd -v` also works as a version shorthand (`ynh -v` cannot since `-v` is the vendor flag)

Two-line change.

## Test plan
- [ ] `ynh --version` prints version
- [ ] `ynd --version` prints version
- [ ] `ynd -v` prints version
- [ ] `ynh -v codex` still works as vendor flag (not version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)