### PR TITLE
feat: add --path flag for monorepo persona installs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -305,6 +305,9 @@ The ynh project ships its own persona (skills, agents, rules) for contributors. 
 
 ```bash
 ynh install github.com/eyelock/ynh
+
+# Or install from a monorepo subdirectory:
+# ynh install github.com/org/monorepo --path personas/my-persona
 # Installed persona "ynh"
 #   Launcher: (skipped — conflicts with ynh binary, use "ynh run ynh")
 ```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Optional metadata (`metadata.json`):
 
 ```bash
 ynh install ./my-persona
+ynh install github.com/org/monorepo --path personas/david
 david
 ```
 
@@ -199,7 +200,7 @@ Global default in `~/.ynh/config.json`:
 | Command | Description |
 |---------|-------------|
 | `ynh init` | Show ynh home path and setup instructions |
-| `ynh install <source>` | Install persona from Git URL or local path |
+| `ynh install <source> [--path <subdir>]` | Install persona from Git URL or local path |
 | `ynh uninstall <name>` | Remove an installed persona and its launcher (alias: `ynh remove`) |
 | `ynh update <name>` | Refresh cached Git repos for a persona |
 | `ynh run <name> [flags] [prompt]` | Launch a persona session |

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -67,7 +67,7 @@ Usage:
 
 Commands:
   init                       Show ynh home path and setup instructions
-  install <git-url|path>     Install a persona from Git URL or local path
+  install <source> [--path <subdir>]  Install a persona from Git URL or local path
   uninstall <name>           Remove an installed persona and its launcher
   update <name>              Refresh cached Git repos for a persona
   run <name> [flags] [prompt]  Launch a persona session
@@ -89,6 +89,7 @@ Examples:
   ynh init
   ynh install github.com/david/my-persona
   ynh install ./my-local-persona
+  ynh install github.com/org/monorepo --path personas/david
   ynh run david
   ynh run david "review this PR"
   ynh run david -v codex
@@ -123,14 +124,29 @@ func cmdInit() error {
 
 func cmdInstall(args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: ynh install <git-url|local-path>")
+		return fmt.Errorf("usage: ynh install <git-url|local-path> [--path <subdir>]")
 	}
 
 	if err := config.EnsureDirs(); err != nil {
 		return err
 	}
 
-	source := args[0]
+	// Parse --path flag from args
+	var pathFlag string
+	var remaining []string
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--path" && i+1 < len(args) {
+			pathFlag = args[i+1]
+			i++ // skip value
+		} else {
+			remaining = append(remaining, args[i])
+		}
+	}
+	if len(remaining) < 1 {
+		return fmt.Errorf("usage: ynh install <git-url|local-path> [--path <subdir>]")
+	}
+
+	source := remaining[0]
 
 	// Determine if local path or Git URL
 	var srcDir string
@@ -158,6 +174,17 @@ func cmdInstall(args []string) error {
 		}
 		cloneTmpDir = repoPath
 		srcDir = repoPath
+	}
+
+	// Scope to subdirectory if --path was specified
+	if pathFlag != "" {
+		srcDir = filepath.Join(srcDir, pathFlag)
+		if _, err := os.Stat(srcDir); os.IsNotExist(err) {
+			if cloneTmpDir != "" {
+				_ = os.RemoveAll(cloneTmpDir)
+			}
+			return fmt.Errorf("path %q not found in source", pathFlag)
+		}
 	}
 
 	// Load persona from plugin format

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -362,6 +362,61 @@ func TestCmdUpdate_NoGitSources(t *testing.T) {
 	}
 }
 
+func TestCmdInstall_PathFlag(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("YNH_HOME", "")
+
+	// Create a monorepo-style layout with a persona in a subdirectory
+	monoDir := filepath.Join(dir, "monorepo")
+	pluginDir := filepath.Join(monoDir, "personas", "alice", ".claude-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"),
+		[]byte(`{"name":"alice","version":"0.1.0","description":"test persona"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install with --path flag
+	err := cmdInstall([]string{monoDir, "--path", "personas/alice"})
+	if err != nil {
+		t.Fatalf("cmdInstall with --path failed: %v", err)
+	}
+
+	// Verify persona was installed
+	installDir := persona.InstalledDir("alice")
+	if _, err := os.Stat(filepath.Join(installDir, ".claude-plugin", "plugin.json")); err != nil {
+		t.Fatal("persona plugin.json not found after install")
+	}
+}
+
+func TestCmdInstall_PathFlag_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("YNH_HOME", "")
+
+	monoDir := filepath.Join(dir, "monorepo")
+	if err := os.MkdirAll(monoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cmdInstall([]string{monoDir, "--path", "nonexistent/path"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent --path")
+	}
+	if !strings.Contains(err.Error(), "not found in source") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestCmdInstall_PathFlag_NoSource(t *testing.T) {
+	err := cmdInstall([]string{"--path", "some/dir"})
+	if err == nil {
+		t.Fatal("expected error when --path consumes the source arg")
+	}
+}
+
 func TestCmdStatus_Empty(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,6 +61,15 @@ david                              # interactive session
 david "explain what this function does"   # one-shot
 ```
 
+### Install from a monorepo
+
+Use `--path` to install a persona from a subdirectory:
+
+```bash
+ynh install github.com/org/assistants --path personas/david
+ynh install ./local-monorepo --path plugins/my-plugin
+```
+
 ## Pull Skills From Git
 
 Point your metadata at any Git repo. Skills are used as-is - no wrapping, no build step:

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -449,6 +449,48 @@ ynh uninstall ynh
 
 ---
 
+## 11b. Install from a monorepo subdirectory
+
+Use `--path` to install a persona that lives in a subdirectory of a repo:
+
+```bash
+# Create a monorepo-style layout
+mkdir -p $YNH_WALKTHROUGH/monorepo/personas/alice/.claude-plugin
+
+cat > $YNH_WALKTHROUGH/monorepo/personas/alice/.claude-plugin/plugin.json << 'EOF'
+{
+  "name": "alice",
+  "version": "0.1.0",
+  "description": "Monorepo persona"
+}
+EOF
+
+# Install from subdirectory
+ynh install $YNH_WALKTHROUGH/monorepo --path personas/alice
+```
+
+Expected:
+
+```
+Installed persona "alice"
+  Location: /Users/<you>/.ynh/personas/alice
+  Launcher: /Users/<you>/.ynh/bin/alice
+```
+
+This also works with Git URLs:
+
+```bash
+ynh install github.com/org/assistants --path personas/david
+```
+
+Clean up:
+
+```bash
+ynh uninstall alice
+```
+
+---
+
 ## 12. Pull skills from Git (with pick, path, and ref)
 
 Create a persona that composes skills from external repos:
@@ -923,6 +965,7 @@ unset YND_WALKTHROUGH YND
 | Project instructions | instructions.md -> CLAUDE.md | |
 | Install from local path | `ynh install ./path` | |
 | Install from Git URL | `ynh install github.com/user/repo` | |
+| Install from monorepo | `ynh install github.com/org/repo --path personas/name` | |
 | List personas | `ynh ls` / `ynh list` | |
 | Interactive session | `walkthrough` | |
 | Non-interactive session | `walkthrough "prompt"` | |

--- a/skills/ynh-create-persona/SKILL.md
+++ b/skills/ynh-create-persona/SKILL.md
@@ -108,6 +108,12 @@ Show them how to install:
 ynh install <output-dir>
 ```
 
+If the persona lives inside a monorepo, use `--path`:
+
+```bash
+ynh install <repo-url> --path <subdir>
+```
+
 Offer to run this command for them. Then show how to use it:
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds `--path <subdir>` flag to `ynh install` for installing personas from subdirectories within a Git repo or local path
- Enables monorepo workflows: `ynh install github.com/org/assistants --path personas/david`
- Updates help text, docs (README, getting-started, walkthrough, CONTRIBUTING), and the create-persona skill

## Test plan
- [x] `TestCmdInstall_PathFlag` — installs from a monorepo-style subdirectory
- [x] `TestCmdInstall_PathFlag_NotFound` — errors when subdirectory doesn't exist
- [x] `TestCmdInstall_PathFlag_NoSource` — errors when `--path` consumes the source arg
- [x] `make check` passes (format, lint, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)