### PR TITLE
feat: add Dockerfile and docker-compose for containerised ynh

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+bin/
+*.out
+coverage.out
+.idea/
+.vscode/
+.DS_Store
+.env
+.env.*
+node_modules/
+Dockerfile
+docker-compose.yml
+.claude/sessions/
+.claude/plans/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,89 @@
+# Stage 1: Build ynh and ynd
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+
+RUN apk add --no-cache git
+
+WORKDIR /src
+
+# Copy module files first for layer caching (currently zero deps, but
+# this avoids invalidating the module cache when source changes)
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG VERSION=dev
+ARG TARGETOS=linux
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v \
+    -ldflags "-s -w -X github.com/eyelock/ynh/internal/config.Version=${VERSION}" \
+    -o /out/ynh ./cmd/ynh && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v \
+    -ldflags "-s -w -X github.com/eyelock/ynh/internal/config.Version=${VERSION}" \
+    -o /out/ynd ./cmd/ynd
+
+# Stage 2: Runtime with vendor CLIs
+FROM node:22-alpine
+
+RUN apk add --no-cache git openssh-client tini bash curl
+
+# Pin versions for reproducible builds. Update these periodically.
+ARG CLAUDE_CODE_VERSION=2.1.76
+ARG CODEX_VERSION=0.114.0
+RUN npm install -g \
+    "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    "@openai/codex@${CODEX_VERSION}" && \
+    npm cache clean --force
+
+# Install Cursor Agent CLI and copy binary into PATH.
+# NOTE: curl|bash with no checksum verification — Cursor does not publish
+# checksums. Pin by auditing the install script if reproducibility is critical.
+RUN curl https://cursor.com/install -fsS | bash && \
+    cp -L /root/.local/bin/agent /usr/local/bin/agent && \
+    chmod 755 /usr/local/bin/agent && \
+    rm -rf /root/.local/share/cursor-agent /root/.local/bin/agent
+
+# Copy ynh binaries from builder
+COPY --from=builder /out/ynh /usr/local/bin/ynh
+COPY --from=builder /out/ynd /usr/local/bin/ynd
+
+# Configurable UID/GID to match host user (avoids permission issues with bind mounts).
+# node:22-alpine already uses GID 1000 for 'node', so we try the requested GID
+# first and fall back to letting Alpine assign one.
+ARG USER_UID=1000
+ARG USER_GID=1000
+RUN addgroup -g ${USER_GID} ynh 2>/dev/null || addgroup ynh; \
+    adduser -u ${USER_UID} -G ynh -D ynh 2>/dev/null || adduser -G ynh -D ynh
+
+# Default YNH_HOME inside container
+ENV YNH_HOME=/home/ynh/.ynh
+
+# Create directory structure
+RUN mkdir -p /home/ynh/.ynh/personas \
+             /home/ynh/.ynh/cache \
+             /home/ynh/.ynh/run \
+             /home/ynh/.ynh/bin && \
+    chown -R ynh:ynh /home/ynh
+
+# Working directory for project mounts
+RUN mkdir -p /workspace && chown ynh:ynh /workspace
+WORKDIR /workspace
+
+USER ynh
+
+# Image metadata — versions of all packaged binaries
+ARG VERSION=dev
+LABEL org.opencontainers.image.title="ynh" \
+      org.opencontainers.image.description="Persona manager for AI coding assistants" \
+      org.opencontainers.image.source="https://github.com/eyelock/ynh" \
+      org.opencontainers.image.version="${VERSION}" \
+      dev.ynh.version="${VERSION}" \
+      dev.ynh.claude-code.version="${CLAUDE_CODE_VERSION}" \
+      dev.ynh.codex.version="${CODEX_VERSION}" \
+      dev.ynh.cursor-agent.version="latest"
+
+# tini handles PID 1 signal forwarding correctly for both:
+# - Claude's syscall.Exec (process replacement)
+# - Codex/Cursor's child process signal forwarding
+ENTRYPOINT ["tini", "-s", "--", "ynh"]
+CMD ["help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  ynh:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VERSION: "${VERSION:-dev}"
+        USER_UID: "${USER_UID:-1000}"
+        USER_GID: "${USER_GID:-1000}"
+
+    environment:
+      # Vendor API keys — set in .env or export before running
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - CURSOR_API_KEY=${CURSOR_API_KEY:-}
+
+    volumes:
+      # Persona config, cache, and state
+      - ${YNH_HOME:-~/.ynh}:/home/ynh/.ynh
+
+      # Project working directory
+      - ${PROJECT_DIR:-.}:/workspace
+
+      # SSH keys for private Git repos (optional, read-only)
+      # Uncomment if your personas reference private repos:
+      # - ~/.ssh:/home/ynh/.ssh:ro
+
+    # Non-interactive by default
+    stdin_open: false
+    tty: false
+
+  # Granular volume mounts — use when you want to share cache across
+  # CI jobs but isolate config, or mount individual directories.
+  #
+  # Usage: docker compose run --rm ynh-granular run david "fix this"
+  ynh-granular:
+    extends:
+      service: ynh
+    volumes:
+      - ynh-personas:/home/ynh/.ynh/personas
+      - ynh-cache:/home/ynh/.ynh/cache
+      - ynh-run:/home/ynh/.ynh/run
+      - ynh-bin:/home/ynh/.ynh/bin
+      - ${PROJECT_DIR:-.}:/workspace
+
+volumes:
+  ynh-personas:
+  ynh-cache:
+  ynh-run:
+  ynh-bin:

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -6,6 +6,7 @@
   * [Vendor Support](vendors.md)
   * [Agent Skills Standard](skills-standard.md)
   * [ynd Developer Tools](ynd.md)
+  * [Docker](docker.md)
 
 * **Tutorials**
   * [Full Walkthrough](walkthrough.md)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -16,6 +16,9 @@ docker compose run --rm ynh ls
 
 # Install a persona from Git
 docker compose run --rm ynh install github.com/user/my-persona
+
+# Install from a monorepo subdirectory
+docker compose run --rm ynh install github.com/org/assistants --path personas/david
 ```
 
 ## API Keys

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,188 @@
+# Docker
+
+Run ynh in a container with all vendor CLIs pre-installed. Designed for non-interactive use — CI pipelines, automation, and scripted runs.
+
+## Quick Start
+
+```bash
+# Build the image
+docker compose build
+
+# Run a persona non-interactively
+docker compose run --rm ynh run david "fix this bug"
+
+# List installed personas
+docker compose run --rm ynh ls
+
+# Install a persona from Git
+docker compose run --rm ynh install github.com/user/my-persona
+```
+
+## API Keys
+
+Set vendor API keys as environment variables before running. Create a `.env` file or export them:
+
+```bash
+# .env (git-ignored)
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+CURSOR_API_KEY=...
+```
+
+| Variable | Vendor |
+|----------|--------|
+| `ANTHROPIC_API_KEY` | Claude Code |
+| `OPENAI_API_KEY` | Codex |
+| `CURSOR_API_KEY` | Cursor |
+
+## Volumes
+
+### Simple: bind-mount ~/.ynh
+
+The default `docker-compose.yml` mounts your host `~/.ynh` into the container. Personas, cache, and config are shared between host and container:
+
+```bash
+docker compose run --rm ynh run david "review this PR"
+```
+
+Git cache reuse works automatically — cloned repos persist in `~/.ynh/cache/` across runs.
+
+### Granular: named volumes
+
+Use the `ynh-granular` service to mount subdirectories individually. Useful in CI where you want shared cache but isolated config:
+
+```bash
+docker compose run --rm ynh-granular run david "deploy"
+```
+
+### Project directory
+
+The current directory is mounted at `/workspace` by default. Override with `PROJECT_DIR`:
+
+```bash
+PROJECT_DIR=/path/to/project docker compose run --rm ynh run david "fix tests"
+```
+
+### Direct docker run
+
+```bash
+docker run --rm \
+  -e ANTHROPIC_API_KEY \
+  -v ~/.ynh:/home/ynh/.ynh \
+  -v $(pwd):/workspace \
+  ynh:latest run david "fix this bug"
+```
+
+## Vendor Override
+
+```bash
+# Use Codex
+docker compose run --rm ynh run david -v codex "refactor auth"
+
+# Use Cursor
+docker compose run --rm ynh run david -v cursor "review changes"
+
+# Pass vendor-specific flags
+docker compose run --rm ynh run david --model opus -- "explain this function"
+```
+
+## Claude Code Permissions
+
+Claude Code has a permission system that prompts for approval on tool use. In a headless container there is no TTY to approve prompts.
+
+Pass `--dangerously-skip-permissions` as a vendor flag when running non-interactively:
+
+```bash
+docker compose run --rm ynh run david \
+  --dangerously-skip-permissions -- "fix the failing test"
+```
+
+> **Security note:** This flag disables all permission checks. Only use it in trusted environments where the prompt and codebase are controlled.
+
+## ynd in Docker
+
+Override the entrypoint to use ynd:
+
+```bash
+docker compose run --rm --entrypoint ynd ynh lint .
+docker compose run --rm --entrypoint ynd ynh validate
+docker compose run --rm --entrypoint ynd ynh fmt
+```
+
+## Private Git Repos
+
+If your personas reference private repos via `includes` or `delegates_to`, mount your SSH keys (read-only):
+
+Uncomment the SSH volume in `docker-compose.yml`:
+
+```yaml
+volumes:
+  - ~/.ssh:/home/ynh/.ssh:ro
+```
+
+Or pass with `docker run`:
+
+```bash
+docker run --rm \
+  -e ANTHROPIC_API_KEY \
+  -v ~/.ynh:/home/ynh/.ynh \
+  -v ~/.ssh:/home/ynh/.ssh:ro \
+  -v $(pwd):/workspace \
+  ynh:latest run david "deploy"
+```
+
+## UID/GID Mapping
+
+When bind-mounting `~/.ynh` from the host, file ownership can mismatch between host and container. Set `USER_UID` and `USER_GID` at build time to match your host user:
+
+```bash
+# macOS default UID is 501
+docker compose build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g)
+```
+
+Or set in `.env`:
+
+```bash
+USER_UID=501
+USER_GID=20
+```
+
+## Building with a Specific Version
+
+```bash
+VERSION=0.1.0 docker compose build
+```
+
+The version is injected into the ynh/ynd binaries via ldflags.
+
+Vendor CLI versions are pinned in the Dockerfile via build args (`CLAUDE_CODE_VERSION`, `CODEX_VERSION`). Update these periodically:
+
+```bash
+docker compose build --build-arg CLAUDE_CODE_VERSION=2.2.0 --build-arg CODEX_VERSION=0.115.0
+```
+
+## Image Metadata
+
+The image includes OCI and ynh-specific labels with version information:
+
+```bash
+docker inspect ynh-ynh:latest --format '{{json .Config.Labels}}' | jq .
+```
+
+| Label | Description |
+|-------|-------------|
+| `dev.ynh.version` | ynh/ynd binary version |
+| `dev.ynh.claude-code.version` | Claude Code CLI version |
+| `dev.ynh.codex.version` | Codex CLI version |
+| `dev.ynh.cursor-agent.version` | Cursor Agent CLI version |
+
+## Image Contents
+
+| Component | Source |
+|-----------|--------|
+| ynh, ynd | Built from source (Go, static binary) |
+| Claude Code (`claude`) | `npm install -g @anthropic-ai/claude-code` (pinned) |
+| Codex (`codex`) | `npm install -g @openai/codex` (pinned) |
+| Cursor (`agent`) | `curl https://cursor.com/install` (latest) |
+| Git, SSH, bash | Alpine packages |
+| tini | PID 1 signal handler |


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile packaging ynh/ynd with all three vendor CLIs (Claude Code, Codex, Cursor)
- docker-compose.yml with two services: simple bind-mount and granular named volumes for CI
- Designed for non-interactive use — CI pipelines, automation, and scripted runs
- Configurable UID/GID, pinned vendor versions, tini for PID 1, OCI labels

## What's included
| File | Purpose |
|------|---------|
| `Dockerfile` | Multi-stage build: Go builder → node:22-alpine runtime |
| `docker-compose.yml` | Two services, API key passthrough, volume configs |
| `.dockerignore` | Excludes build artifacts, IDE files, secrets |
| `docs/docker.md` | Full usage docs (volumes, API keys, permissions, UID/GID, ynd) |
| `docs/_sidebar.md` | Links Docker page in docsify sidebar |

## Test plan
- [ ] `docker compose build` completes successfully
- [ ] `docker compose run --rm ynh help` shows usage
- [ ] `docker compose run --rm ynh ls` lists personas
- [ ] Bind-mount `~/.ynh` persists across runs
- [ ] UID/GID mapping works with `--build-arg USER_UID=$(id -u)`
- [ ] `make check` passes on the branch (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)