### PR TITLE
feat: add verbose resolution and launch output to ynh run

### DIFF
--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -398,12 +398,6 @@ func cmdRun(args []string) error {
 		return err
 	}
 
-	// Show progress when there are Git sources to resolve
-	sources := len(p.Includes) + len(p.DelegatesTo)
-	if sources > 0 {
-		fmt.Fprintf(os.Stderr, "Assembling %d source(s)...\n", sources)
-	}
-
 	// Load config for remote source checking
 	cfg, err := config.Load()
 	if err != nil {
@@ -411,9 +405,31 @@ func cmdRun(args []string) error {
 	}
 
 	// Resolve Git includes (with remote source allow-list check)
-	content, err := resolver.Resolve(p, cfg)
+	if len(p.Includes) > 0 {
+		fmt.Fprintf(os.Stderr, "Resolving %d include(s)...\n", len(p.Includes))
+	}
+	resolved, err := resolver.Resolve(p, cfg)
 	if err != nil {
 		return fmt.Errorf("resolving includes: %w", err)
+	}
+
+	// Print per-source status
+	for _, r := range resolved {
+		source := r.Source
+		if r.Path != "" {
+			source += " → " + r.Path
+		}
+		if r.Cloned {
+			fmt.Fprintf(os.Stderr, "  Cloned %s\n", source)
+		} else {
+			fmt.Fprintf(os.Stderr, "  Cached %s\n", source)
+		}
+	}
+
+	// Extract ResolvedContent for the assembler
+	var content []resolver.ResolvedContent
+	for _, r := range resolved {
+		content = append(content, r.Content)
 	}
 
 	// Also include any local content from the persona's installed directory
@@ -500,6 +516,7 @@ func cmdRun(args []string) error {
 		}
 
 		// Launch
+		fmt.Fprintf(os.Stderr, "Launching %s...\n", adapter.CLIName())
 		if prompt != "" {
 			return adapter.LaunchNonInteractive(runDir, prompt, vendorArgs)
 		}

--- a/internal/assembler/delegates.go
+++ b/internal/assembler/delegates.go
@@ -31,7 +31,7 @@ func AssembleDelegates(workDir string, adapter vendor.Adapter, delegates []perso
 	}
 
 	for _, del := range delegates {
-		basePath, err := resolver.ResolveGitSource(del.GitSource)
+		basePath, _, err := resolver.ResolveGitSource(del.GitSource)
 		if err != nil {
 			return fmt.Errorf("delegate: %w", err)
 		}

--- a/internal/assembler/integration_test.go
+++ b/internal/assembler/integration_test.go
@@ -90,10 +90,11 @@ func TestIntegration_MultiSourceComposition(t *testing.T) {
 	}
 
 	// Resolve all includes
-	content, err := resolver.Resolve(p, nil)
+	resolved, err := resolver.Resolve(p, nil)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
+	content := extractContent(resolved)
 
 	// Add embedded persona content (simulating what cmdRun does)
 	content = append(content, resolver.ResolvedContent{
@@ -164,13 +165,13 @@ func TestIntegration_MonorepoNoPickIncludesAll(t *testing.T) {
 		},
 	}
 
-	content, err := resolver.Resolve(p, nil)
+	resolved, err := resolver.Resolve(p, nil)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
 
 	adapter, _ := vendor.Get("claude")
-	workDir, err := Assemble(adapter, content)
+	workDir, err := Assemble(adapter, extractContent(resolved))
 	if err != nil {
 		t.Fatalf("Assemble failed: %v", err)
 	}
@@ -204,13 +205,13 @@ func TestIntegration_SkillsRepoFullInclude(t *testing.T) {
 		},
 	}
 
-	content, err := resolver.Resolve(p, nil)
+	resolved, err := resolver.Resolve(p, nil)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
 
 	adapter, _ := vendor.Get("claude")
-	workDir, err := Assemble(adapter, content)
+	workDir, err := Assemble(adapter, extractContent(resolved))
 	if err != nil {
 		t.Fatalf("Assemble failed: %v", err)
 	}
@@ -245,10 +246,11 @@ func TestIntegration_CrossVendorAssembly(t *testing.T) {
 		},
 	}
 
-	content, err := resolver.Resolve(p, nil)
+	resolved, err := resolver.Resolve(p, nil)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
+	content := extractContent(resolved)
 
 	// Assemble for Claude
 	claudeAdapter, _ := vendor.Get("claude")

--- a/internal/assembler/subpath_test.go
+++ b/internal/assembler/subpath_test.go
@@ -43,15 +43,24 @@ func makeGitRepo(t *testing.T, files map[string]string) string {
 	return dir
 }
 
+// extractContent converts ResolveResults to ResolvedContent for the assembler.
+func extractContent(results []resolver.ResolveResult) []resolver.ResolvedContent {
+	var content []resolver.ResolvedContent
+	for _, r := range results {
+		content = append(content, r.Content)
+	}
+	return content
+}
+
 // resolveAndAssemble is a test helper that resolves and assembles a persona for Claude.
 func resolveAndAssemble(t *testing.T, p *persona.Persona, extraContent ...resolver.ResolvedContent) string {
 	t.Helper()
 
-	content, err := resolver.Resolve(p, nil)
+	resolved, err := resolver.Resolve(p, nil)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}
-	content = append(content, extraContent...)
+	content := append(extractContent(resolved), extraContent...)
 
 	adapter, _ := vendor.Get("claude")
 	workDir, err := Assemble(adapter, content)

--- a/internal/exporter/delegates.go
+++ b/internal/exporter/delegates.go
@@ -23,7 +23,7 @@ func ExportDelegates(outputDir string, delegates []persona.Delegate) error {
 	}
 
 	for _, del := range delegates {
-		basePath, err := resolver.ResolveGitSource(del.GitSource)
+		basePath, _, err := resolver.ResolveGitSource(del.GitSource)
 		if err != nil {
 			return fmt.Errorf("delegate: %w", err)
 		}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -70,9 +70,15 @@ func Export(opts ExportOptions) ([]ExportResult, error) {
 	}
 
 	// Resolve all remote includes
-	content, err := resolver.Resolve(p, opts.Config)
+	resolved, err := resolver.Resolve(p, opts.Config)
 	if err != nil {
 		return nil, fmt.Errorf("resolving includes: %w", err)
+	}
+
+	// Extract ResolvedContent for assembly
+	var content []resolver.ResolvedContent
+	for _, r := range resolved {
+		content = append(content, r.Content)
 	}
 
 	// Add SourceDir as local content (persona's own embedded artifacts)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -21,29 +21,39 @@ type ResolvedContent struct {
 	Paths []string
 }
 
+// ResolveResult pairs a ResolvedContent with metadata about how it was resolved.
+type ResolveResult struct {
+	Content ResolvedContent
+	Source  string // short display name (e.g., "eyelock/assistants")
+	Path    string // subpath within repo, if any
+	Cloned  bool   // true if freshly cloned (first time)
+	Cached  bool   // true if already in cache (not first time)
+}
+
 // ResolveGitSource clones/updates a GitSource and returns the resolved base path,
 // scoped to the optional sub-path within the repo.
-func ResolveGitSource(gs persona.GitSource) (string, error) {
+func ResolveGitSource(gs persona.GitSource) (string, *RepoResult, error) {
 	result, err := EnsureRepo(gs.Git, gs.Ref)
 	if err != nil {
-		return "", fmt.Errorf("resolving %s: %w", gs.Git, err)
+		return "", nil, fmt.Errorf("resolving %s: %w", gs.Git, err)
 	}
 
 	basePath := result.Path
 	if gs.Path != "" {
 		basePath = filepath.Join(result.Path, gs.Path)
 		if _, err := os.Stat(basePath); os.IsNotExist(err) {
-			return "", fmt.Errorf("path %q not found in %s", gs.Path, gs.Git)
+			return "", nil, fmt.Errorf("path %q not found in %s", gs.Path, gs.Git)
 		}
 	}
 
-	return basePath, nil
+	return basePath, &result, nil
 }
 
-// Resolve fetches all includes for a persona and returns resolved content.
+// Resolve fetches all includes for a persona and returns resolved content
+// with resolution metadata (cloned vs cached).
 // If cfg is non-nil, remote sources are checked against the allowed sources list.
-func Resolve(p *persona.Persona, cfg *config.Config) ([]ResolvedContent, error) {
-	var results []ResolvedContent
+func Resolve(p *persona.Persona, cfg *config.Config) ([]ResolveResult, error) {
+	var results []ResolveResult
 
 	for _, inc := range p.Includes {
 		if cfg != nil {
@@ -52,18 +62,39 @@ func Resolve(p *persona.Persona, cfg *config.Config) ([]ResolvedContent, error) 
 			}
 		}
 
-		basePath, err := ResolveGitSource(inc.GitSource)
+		basePath, repoResult, err := ResolveGitSource(inc.GitSource)
 		if err != nil {
 			return nil, err
 		}
 
-		results = append(results, ResolvedContent{
-			BasePath: basePath,
-			Paths:    inc.Pick,
+		results = append(results, ResolveResult{
+			Content: ResolvedContent{
+				BasePath: basePath,
+				Paths:    inc.Pick,
+			},
+			Source: shortGitURL(inc.Git),
+			Path:   inc.Path,
+			Cloned: repoResult.Cloned,
+			Cached: !repoResult.Cloned,
 		})
 	}
 
 	return results, nil
+}
+
+// shortGitURL abbreviates a git URL for display.
+// "github.com/eyelock/assistants" -> "eyelock/assistants"
+func shortGitURL(url string) string {
+	// Local paths: keep as-is
+	if strings.HasPrefix(url, "/") || strings.HasPrefix(url, ".") {
+		return url
+	}
+	// Strip host prefix
+	parts := strings.SplitN(url, "/", 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return url
 }
 
 // CloneToTemp clones a Git repo to a temporary directory (shallow, depth 1).

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -192,12 +192,12 @@ func TestResolve_WithLocalRepo(t *testing.T) {
 		t.Fatalf("expected 1 result, got %d", len(results))
 	}
 
-	if len(results[0].Paths) != 1 || results[0].Paths[0] != "skills/hello" {
-		t.Errorf("unexpected paths: %v", results[0].Paths)
+	if len(results[0].Content.Paths) != 1 || results[0].Content.Paths[0] != "skills/hello" {
+		t.Errorf("unexpected paths: %v", results[0].Content.Paths)
 	}
 
 	// Verify the file exists in the resolved base path
-	skillPath := filepath.Join(results[0].BasePath, "skills", "hello", "SKILL.md")
+	skillPath := filepath.Join(results[0].Content.BasePath, "skills", "hello", "SKILL.md")
 	if _, err := os.Stat(skillPath); err != nil {
 		t.Errorf("skill not found in resolved content: %v", err)
 	}
@@ -256,7 +256,7 @@ func TestResolve_WithPath_Monorepo(t *testing.T) {
 	}
 
 	// BasePath should point to the subdirectory, not the repo root
-	expectedBase := filepath.Join(results[0].BasePath)
+	expectedBase := filepath.Join(results[0].Content.BasePath)
 	skillPath := filepath.Join(expectedBase, "skills", "deploy", "SKILL.md")
 	if _, err := os.Stat(skillPath); err != nil {
 		t.Errorf("skill not found at monorepo path: %v", err)
@@ -346,16 +346,16 @@ func TestResolve_WithPath_NoPickIncludesAll(t *testing.T) {
 	}
 
 	// No pick means Paths should be empty (include all)
-	if len(results[0].Paths) != 0 {
-		t.Errorf("expected empty paths for no-pick, got %v", results[0].Paths)
+	if len(results[0].Content.Paths) != 0 {
+		t.Errorf("expected empty paths for no-pick, got %v", results[0].Content.Paths)
 	}
 
 	// Verify both artifacts are reachable from base path
-	skillPath := filepath.Join(results[0].BasePath, "skills", "lint", "SKILL.md")
+	skillPath := filepath.Join(results[0].Content.BasePath, "skills", "lint", "SKILL.md")
 	if _, err := os.Stat(skillPath); err != nil {
 		t.Errorf("skill not found: %v", err)
 	}
-	rulePath := filepath.Join(results[0].BasePath, "rules", "strict.md")
+	rulePath := filepath.Join(results[0].Content.BasePath, "rules", "strict.md")
 	if _, err := os.Stat(rulePath); err != nil {
 		t.Errorf("rule not found: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Replace generic "Assembling N source(s)..." with per-source status (Cloned/Cached + repo name + subpath)
- Add "Launching <cli>..." message before vendor CLI handoff
- Add `ResolveResult` type wrapping `ResolvedContent` with source metadata

## Example output
```
Resolving 2 include(s)...
  Cloned eyelock/assistants → skills/dev
  Cached anthropics/skills
Launching claude...
```

## Test plan
- [x] All tests pass (`make test`)
- [ ] Manual: `ynh run <persona>` shows Cloned on first run, Cached on subsequent
- [ ] Manual: "Launching claude..." appears before TUI starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)