### PR TITLE
fix: add cursor vendor support to ynd (T8.7, T8.8)

### DIFF
--- a/cmd/ynd/llm.go
+++ b/cmd/ynd/llm.go
@@ -11,9 +11,14 @@ var lookPathFunc = exec.LookPath
 
 // detectVendorCLI checks for supported LLM CLIs on PATH.
 func detectVendorCLI() string {
-	for _, name := range []string{"claude", "codex"} {
-		if _, err := lookPathFunc(name); err == nil {
-			return name
+	checks := []struct{ vendor, binary string }{
+		{"claude", "claude"},
+		{"codex", "codex"},
+		{"cursor", "agent"},
+	}
+	for _, c := range checks {
+		if _, err := lookPathFunc(c.binary); err == nil {
+			return c.vendor
 		}
 	}
 	return ""
@@ -35,6 +40,8 @@ func queryLLMImpl(vendor, prompt string) (string, error) {
 		cmd = exec.Command("claude", "-p", "-", "--output-format", "text")
 	case "codex":
 		cmd = exec.Command("codex", "-q", "-")
+	case "cursor":
+		cmd = exec.Command("agent", "-p", "-")
 	default:
 		return "", fmt.Errorf("unsupported vendor %q", vendor)
 	}

--- a/cmd/ynd/llm_test.go
+++ b/cmd/ynd/llm_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDetectVendorCLI(t *testing.T) {
+	tests := []struct {
+		name      string
+		available map[string]bool // binary name → available
+		want      string
+	}{
+		{
+			name:      "claude available",
+			available: map[string]bool{"claude": true},
+			want:      "claude",
+		},
+		{
+			name:      "codex available",
+			available: map[string]bool{"codex": true},
+			want:      "codex",
+		},
+		{
+			name:      "cursor agent available",
+			available: map[string]bool{"agent": true},
+			want:      "cursor",
+		},
+		{
+			name:      "claude preferred over codex",
+			available: map[string]bool{"claude": true, "codex": true},
+			want:      "claude",
+		},
+		{
+			name:      "claude preferred over cursor",
+			available: map[string]bool{"claude": true, "agent": true},
+			want:      "claude",
+		},
+		{
+			name:      "codex preferred over cursor",
+			available: map[string]bool{"codex": true, "agent": true},
+			want:      "codex",
+		},
+		{
+			name:      "none available",
+			available: map[string]bool{},
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origLookPath := lookPathFunc
+			t.Cleanup(func() { lookPathFunc = origLookPath })
+
+			lookPathFunc = func(name string) (string, error) {
+				if tt.available[name] {
+					return "/mock/" + name, nil
+				}
+				return "", fmt.Errorf("not found")
+			}
+
+			got := detectVendorCLI()
+			if got != tt.want {
+				t.Errorf("detectVendorCLI() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryLLMImpl_UnsupportedVendor(t *testing.T) {
+	_, err := queryLLMImpl("unknown", "test prompt")
+	if err == nil {
+		t.Fatal("expected error for unsupported vendor")
+	}
+	want := `unsupported vendor "unknown"`
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestQueryLLMImpl_CursorVendorAccepted(t *testing.T) {
+	// We can't run the real agent binary, but we can verify cursor
+	// doesn't hit the "unsupported vendor" error path by checking
+	// it tries to exec (which will fail with a different error).
+	_, err := queryLLMImpl("cursor", "test prompt")
+	if err == nil {
+		// Agent CLI is actually available — that's fine
+		return
+	}
+	// Should NOT be "unsupported vendor"
+	if err.Error() == `unsupported vendor "cursor"` {
+		t.Error("cursor vendor should be supported")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds cursor (`agent` binary) to `detectVendorCLI` and `queryLLMImpl` in `cmd/ynd/llm.go`
- `ynd compress` (T8.7) and `ynd inspect -v cursor` (T8.8) now work as the tutorial documents
- Adds `cmd/ynd/llm_test.go` with detection priority and vendor acceptance tests

## Test plan

- [x] `make test FILE=./cmd/ynd` — all tests pass
- [x] `make lint` — 0 issues
- [ ] Manual: `ynd inspect -y -v cursor` runs without "unsupported vendor" error (T8.8)
- [ ] Manual: `ynd compress -y -v cursor skills/*/SKILL.md` works (T8.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)