### PR TITLE
fix: prune stale launchers and run dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ INSTALL_DIR := $(HOME)/.ynh/bin
 GOBIN := $(shell go env GOPATH)/bin
 GOIMPORTS := $(GOBIN)/goimports
 
-# Version from git: use exact tag if on one, otherwise branch+sha
-VERSION := $(shell git describe --tags --exact-match 2>/dev/null || echo "dev-$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)-$$(git rev-parse --short HEAD 2>/dev/null || echo unknown)$$(git diff --quiet 2>/dev/null || echo '-dirty')")
+# Version from git: use exact tag only if clean and on that exact commit, otherwise branch+sha
+DEV_VERSION := dev-$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)-$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)$(shell git diff --quiet 2>/dev/null || echo '-dirty')
+VERSION := $(shell git diff --quiet 2>/dev/null && git describe --tags --exact-match 2>/dev/null || echo "$(DEV_VERSION)")
 LDFLAGS := -ldflags "-X github.com/eyelock/ynh/internal/config.Version=$(VERSION)"
 
 help: ## Show this help

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -780,17 +780,66 @@ func cmdPrune() error {
 	}
 
 	orphans := log.Prune()
-	if len(orphans) == 0 {
-		fmt.Println("No orphaned installations found.")
-		return nil
-	}
-
 	for _, inst := range orphans {
 		fmt.Printf("Removing orphaned installation: %s (%s) in %s\n", inst.Persona, inst.Vendor, inst.Project)
 	}
 
-	log.RemoveOrphans(orphans)
-	return log.Save()
+	if len(orphans) > 0 {
+		log.RemoveOrphans(orphans)
+		if err := log.Save(); err != nil {
+			return err
+		}
+	}
+
+	// Scan for stale launcher scripts in ~/.ynh/bin/
+	staleLaunchers := 0
+	binDir := config.BinDir()
+	entries, err := os.ReadDir(binDir)
+	if err == nil {
+		for _, entry := range entries {
+			name := entry.Name()
+			if name == "ynh" || name == "ynd" {
+				continue
+			}
+			if persona.DetectFormat(persona.InstalledDir(name)) == "plugin" {
+				continue
+			}
+			launcherPath := filepath.Join(binDir, name)
+			data, err := os.ReadFile(launcherPath)
+			if err != nil {
+				continue
+			}
+			if !strings.Contains(string(data), "exec ynh run") {
+				continue
+			}
+			_ = os.Remove(launcherPath)
+			fmt.Printf("Removed stale launcher: %s\n", launcherPath)
+			staleLaunchers++
+		}
+	}
+
+	// Scan for stale run directories in ~/.ynh/run/
+	staleRuns := 0
+	runDir := config.RunDir()
+	runEntries, err := os.ReadDir(runDir)
+	if err == nil {
+		for _, entry := range runEntries {
+			name := entry.Name()
+			if persona.DetectFormat(persona.InstalledDir(name)) == "plugin" {
+				continue
+			}
+			staleRun := filepath.Join(runDir, name)
+			_ = os.RemoveAll(staleRun)
+			fmt.Printf("Removed stale run dir: %s\n", staleRun)
+			staleRuns++
+		}
+	}
+
+	if len(orphans) == 0 && staleLaunchers == 0 && staleRuns == 0 {
+		fmt.Println("No orphaned installations found.")
+	}
+
+	return nil
 }
 
 // symlinkIntact returns true if at least one symlink from the installation

--- a/docs/tutorial/02-vendors-and-symlinks.md
+++ b/docs/tutorial/02-vendors-and-symlinks.md
@@ -167,7 +167,9 @@ my-persona -v claude --clean
 
 ## T2.7: Prune orphaned installations
 
-If a project directory is deleted while symlinks are still registered, `ynh prune` cleans up the stale entries.
+If a project directory is deleted while symlinks are still registered, `ynh prune` cleans up the stale entries. It also removes stale launcher scripts from `~/.ynh/bin/` when their persona no longer exists.
+
+### Prune orphaned symlinks
 
 Re-create the project and install symlinks:
 
@@ -201,10 +203,46 @@ Expected:
 Removing orphaned installation: my-persona (cursor) in /tmp/ynh-tutorial/project
 ```
 
-## Clean up
+Verify the orphan was removed:
 
 ```bash
-ynh uninstall my-persona
+ynh status
+# Expected: no cursor installation for my-persona in /tmp/ynh-tutorial/project
+```
+
+### Prune stale launchers
+
+Simulate a stale launcher by removing the persona directory but leaving its launcher script:
+
+```bash
+rm -rf ~/.ynh/personas/my-persona
+ls ~/.ynh/bin/my-persona
+# Expected: file exists (stale launcher)
+```
+
+Prune detects and removes the stale launcher:
+
+```bash
+ynh prune
+```
+
+Expected:
+```
+Removed stale launcher: /Users/<you>/.ynh/bin/my-persona
+```
+
+Verify the launcher was removed:
+
+```bash
+ls ~/.ynh/bin/my-persona 2>/dev/null
+# Expected: no such file
+```
+
+Verify ynh and ynd binaries are untouched:
+
+```bash
+ls ~/.ynh/bin/ynh ~/.ynh/bin/ynd
+# Expected: both still exist
 ```
 
 ## What you learned
@@ -215,7 +253,7 @@ ynh uninstall my-persona
 - ynh **automatically prompts** to install symlinks on first run in a project
 - `--install` and `--clean` manage symlinks explicitly without launching
 - `ynh status` shows all symlink installations across projects
-- `ynh prune` cleans orphaned entries when project directories are deleted
+- `ynh prune` cleans orphaned symlink entries and stale launcher scripts
 
 ## Next
 

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -43,7 +43,14 @@ make deps      # installs Go, linter, formatter
 make install   # builds and installs to ~/.ynh/bin/
 ```
 
-After `make install`, `ynh` and `ynd` resolve to your local build everywhere (assuming `~/.ynh/bin` is on your PATH).
+After `make install`, verify you're running your local build:
+
+```bash
+ynh version
+# Expected: dev-<branch>-<sha> (not a release tag like v0.0.9)
+```
+
+If `ynh version` shows a release tag or stale version, ensure `~/.ynh/bin` is on your PATH and re-run `make install` after any code change you want to test.
 
 <!-- tabs:end -->
 


### PR DESCRIPTION
## Summary

- **`ynh prune` now cleans stale launchers** in `~/.ynh/bin/` whose persona no longer exists in `~/.ynh/personas/`, verifying each file contains `exec ynh run` before removing
- **`ynh prune` now cleans stale run dirs** in `~/.ynh/run/` for missing personas
- **Fixes `make install` version injection** — dirty trees no longer show a release tag (e.g. `v0.0.9`), correctly showing `dev-<branch>-<sha>-dirty` instead
- **Adds verification steps** to tutorial T2.7 (prune stale launchers) and build-from-source instructions (version check)

## Test plan

- [x] `make check` passes (format, lint, test, build)
- [x] Run tutorial T2.7 end-to-end: orphaned symlinks and stale launcher cleanup
- [x] `make install && ynh version` shows `dev-<branch>-<sha>` on a non-tag commit
- [x] Verify `ynh` and `ynd` binaries in `~/.ynh/bin/` are not touched by prune

🤖 Generated with [Claude Code](https://claude.com/claude-code)