### PR TITLE
feat: install provenance tracking, richer ynh ls, ynh info command

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -279,6 +279,38 @@ The `name` field is required and becomes the launcher command name. Only fields 
 
 ynh-specific config lives under the `"ynh"` key, keeping the file extensible for other tools.
 
+### Install Lifecycle
+
+There are two copies of `metadata.json` in a persona's life:
+
+1. **Source copy** — git-tracked in the persona's repo. Author-managed. Contains `includes`, `delegates_to`, `default_vendor`.
+2. **Installed copy** — at `~/.ynh/personas/<name>/metadata.json`. Created by `ynh install` via `copyTree`. Local-only, not git-tracked.
+
+During install:
+- `ynh install` copies the entire persona directory (including `metadata.json`) to `~/.ynh/personas/<name>/`.
+- After the copy, ynh injects `installed_from` provenance into the installed `metadata.json`. This records where the persona was installed from (source type, URL/path, timestamp).
+- The source `metadata.json` is never modified.
+
+At runtime:
+- `ynh run` reads the installed copy at `~/.ynh/personas/<name>/metadata.json` to resolve includes, delegates, and vendor settings.
+
+The `installed_from` field looks like:
+
+```json
+{
+  "ynh": {
+    "installed_from": {
+      "source_type": "git",
+      "source": "github.com/eyelock/assistants",
+      "path": "ynh/david",
+      "installed_at": "2026-03-22T10:30:00Z"
+    }
+  }
+}
+```
+
+Possible `source_type` values: `"local"`, `"git"`, `"registry"`. Registry installs also include `"registry_name"`.
+
 ### Environment Variables
 
 | Variable | Description | Default |

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Global default in `~/.ynh/config.json`:
 | `ynh update <name>` | Refresh cached Git repos for a persona |
 | `ynh run <name> [flags] [prompt]` | Launch a persona session |
 | `ynh ls` | List installed personas (alias: `ynh list`) |
+| `ynh info <name>` | Show detailed persona information |
 | `ynh vendors` | List supported vendor adapters |
 | `ynh status` | Show symlink installations across projects |
 | `ynh prune` | Clean orphaned symlink installations |

--- a/cmd/ynh/install_resolve.go
+++ b/cmd/ynh/install_resolve.go
@@ -9,9 +9,13 @@ import (
 )
 
 // resolvedSource holds the result of disambiguating an install source.
+// sourceType is always set and is the single source of truth for provenance.
+// gitURL is only set when the source was resolved from a registry lookup.
 type resolvedSource struct {
-	gitURL string // non-empty if resolved to a Git URL (from registry)
-	path   string // monorepo subdir (from registry entry)
+	gitURL       string // non-empty if resolved to a Git URL (from registry)
+	path         string // monorepo subdir (from registry entry)
+	sourceType   string // "local", "git", "registry"
+	registryName string // non-empty for registry lookups
 }
 
 // resolveInstallSource applies disambiguation rules to determine the source type.
@@ -20,17 +24,17 @@ type resolvedSource struct {
 func resolveInstallSource(source, existingPath string, cfg *config.Config) (resolvedSource, error) {
 	// Rule 1: local path — handled by isLocalPath() in caller
 	if isLocalPath(source) {
-		return resolvedSource{}, nil
+		return resolvedSource{sourceType: "local"}, nil
 	}
 
 	// Rule 2: Git SSH URL
 	if strings.HasPrefix(source, "git@") {
-		return resolvedSource{}, nil
+		return resolvedSource{sourceType: "git"}, nil
 	}
 
 	// Rule 3: Git HTTPS/HTTP URL
 	if strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "http://") {
-		return resolvedSource{}, nil
+		return resolvedSource{sourceType: "git"}, nil
 	}
 
 	// Rule 4: Contains @ → registry lookup as name@registry-name
@@ -43,7 +47,7 @@ func resolveInstallSource(source, existingPath string, cfg *config.Config) (reso
 
 	// Rule 5: Contains / → Git URL shorthand
 	if strings.Contains(source, "/") {
-		return resolvedSource{}, nil
+		return resolvedSource{sourceType: "git"}, nil
 	}
 
 	// Rule 6: Plain word → registry search
@@ -67,8 +71,10 @@ func lookupFromRegistry(name, regName string, cfg *config.Config) (resolvedSourc
 
 	entry := results[0].Entry
 	return resolvedSource{
-		gitURL: entry.Repo,
-		path:   entry.Path,
+		gitURL:       entry.Repo,
+		path:         entry.Path,
+		sourceType:   "registry",
+		registryName: regName,
 	}, nil
 }
 
@@ -89,8 +95,10 @@ func searchFromRegistry(name string, cfg *config.Config) (resolvedSource, error)
 	if len(results) == 1 {
 		entry := results[0].Entry
 		return resolvedSource{
-			gitURL: entry.Repo,
-			path:   entry.Path,
+			gitURL:       entry.Repo,
+			path:         entry.Path,
+			sourceType:   "registry",
+			registryName: results[0].RegistryName,
 		}, nil
 	}
 

--- a/cmd/ynh/install_resolve_test.go
+++ b/cmd/ynh/install_resolve_test.go
@@ -18,6 +18,9 @@ func TestResolveInstallSourceLocalPath(t *testing.T) {
 	if result.gitURL != "" {
 		t.Error("local path should not resolve to gitURL")
 	}
+	if result.sourceType != "local" {
+		t.Errorf("sourceType = %q, want %q", result.sourceType, "local")
+	}
 
 	result, err = resolveInstallSource("/abs/path", "", cfg)
 	if err != nil {
@@ -25,6 +28,9 @@ func TestResolveInstallSourceLocalPath(t *testing.T) {
 	}
 	if result.gitURL != "" {
 		t.Error("absolute path should not resolve to gitURL")
+	}
+	if result.sourceType != "local" {
+		t.Errorf("sourceType = %q, want %q", result.sourceType, "local")
 	}
 }
 
@@ -38,6 +44,9 @@ func TestResolveInstallSourceGitSSH(t *testing.T) {
 	if result.gitURL != "" {
 		t.Error("SSH URL should pass through without registry lookup")
 	}
+	if result.sourceType != "git" {
+		t.Errorf("sourceType = %q, want %q", result.sourceType, "git")
+	}
 }
 
 func TestResolveInstallSourceGitHTTPS(t *testing.T) {
@@ -50,6 +59,9 @@ func TestResolveInstallSourceGitHTTPS(t *testing.T) {
 	if result.gitURL != "" {
 		t.Error("HTTPS URL should pass through without registry lookup")
 	}
+	if result.sourceType != "git" {
+		t.Errorf("sourceType = %q, want %q", result.sourceType, "git")
+	}
 }
 
 func TestResolveInstallSourceGitShorthand(t *testing.T) {
@@ -61,6 +73,9 @@ func TestResolveInstallSourceGitShorthand(t *testing.T) {
 	}
 	if result.gitURL != "" {
 		t.Error("shorthand URL should pass through without registry lookup")
+	}
+	if result.sourceType != "git" {
+		t.Errorf("sourceType = %q, want %q", result.sourceType, "git")
 	}
 }
 
@@ -98,5 +113,8 @@ func TestResolveInstallSourceHTTPNotRegistry(t *testing.T) {
 	}
 	if result.gitURL != "" {
 		t.Error("HTTP URL should pass through")
+	}
+	if result.sourceType != "git" {
+		t.Errorf("sourceType = %q, want %q", result.sourceType, "git")
 	}
 }

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -7,10 +7,12 @@ import (
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/eyelock/ynh/internal/assembler"
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/persona"
+	"github.com/eyelock/ynh/internal/plugin"
 	"github.com/eyelock/ynh/internal/resolver"
 	"github.com/eyelock/ynh/internal/symlink"
 	"github.com/eyelock/ynh/internal/vendor"
@@ -36,6 +38,8 @@ func main() {
 		err = cmdRun(os.Args[2:])
 	case "ls", "list":
 		err = cmdList()
+	case "info":
+		err = cmdInfo(os.Args[2:])
 	case "vendors":
 		cmdVendors()
 	case "status":
@@ -75,6 +79,7 @@ Commands:
   update <name>              Refresh cached Git repos for a persona
   run <name> [flags] [prompt]  Launch a persona session
   ls                           List installed personas
+  info <name>                  Show detailed persona information
   vendors                      List supported vendor adapters
   search <term>                Search registries for personas
   registry add <url>           Add a persona registry
@@ -159,6 +164,7 @@ func cmdInstall(args []string) error {
 	}
 
 	source := remaining[0]
+	originalSource := source
 
 	// Determine source type using disambiguation rules:
 	// 1. Starts with . or / → local path
@@ -235,6 +241,34 @@ func cmdInstall(args []string) error {
 
 	if err := copyTree(srcDir, installDir); err != nil {
 		return err
+	}
+
+	// Inject install provenance into the copied metadata.json
+	provSource := source
+	if resolved.sourceType == "local" {
+		provSource = originalSource
+	}
+	prov := &plugin.ProvenanceMeta{
+		SourceType:   resolved.sourceType,
+		Source:       provSource,
+		Path:         pathFlag,
+		RegistryName: resolved.registryName,
+		InstalledAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	// Load existing ynh metadata from the copied file (preserves includes, delegates, etc.)
+	meta, err := plugin.LoadMetadataJSON(installDir)
+	if err != nil {
+		return fmt.Errorf("loading installed metadata: %w", err)
+	}
+	var ynh *plugin.YNHMetadata
+	if meta != nil && meta.YNH != nil {
+		ynh = meta.YNH
+	} else {
+		ynh = &plugin.YNHMetadata{}
+	}
+	ynh.InstalledFrom = prov
+	if err := plugin.SaveMetadataJSON(installDir, ynh); err != nil {
+		return fmt.Errorf("saving provenance: %w", err)
 	}
 
 	// Generate launcher script (skip for reserved names that conflict with the binary)
@@ -523,12 +557,12 @@ func cmdList() error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "NAME\tVENDOR\tINCLUDES\tDELEGATES TO")
+	_, _ = fmt.Fprintln(w, "NAME\tVENDOR\tSOURCE\tARTIFACTS\tINCLUDES\tDELEGATES TO")
 
 	for _, name := range names {
 		p, err := persona.Load(name)
 		if err != nil {
-			_, _ = fmt.Fprintf(w, "%s\t(error: %v)\t\t\n", name, err)
+			_, _ = fmt.Fprintf(w, "%s\t(error: %v)\t\t\t\t\n", name, err)
 			continue
 		}
 
@@ -537,35 +571,189 @@ func cmdList() error {
 			vendorName = "-"
 		}
 
-		includes := formatSources(len(p.Includes), gitURLs(p.Includes, func(i persona.Include) string { return i.Git }))
-		delegates := formatSources(len(p.DelegatesTo), gitURLs(p.DelegatesTo, func(d persona.Delegate) string { return d.Git }))
+		source := formatProvenance(p.InstalledFrom)
+		artifacts := formatArtifactSummary(name)
+		includes := formatIncludes(p.Includes)
+		delegates := formatDelegates(p.DelegatesTo)
 
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.Name, vendorName, includes, delegates)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", p.Name, vendorName, source, artifacts, includes, delegates)
 	}
 
 	_ = w.Flush()
 	return nil
 }
 
-// gitURLs extracts Git URLs from a slice using the given accessor.
-func gitURLs[T any](items []T, getGit func(T) string) []string {
-	urls := make([]string, 0, len(items))
-	for _, item := range items {
-		urls = append(urls, getGit(item))
+func cmdInfo(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: ynh info <persona-name>")
 	}
-	return urls
+
+	name := args[0]
+	p, err := persona.Load(name)
+	if err != nil {
+		return fmt.Errorf("persona %q not found: %w", name, err)
+	}
+
+	vendorName := p.DefaultVendor
+	if vendorName == "" {
+		vendorName = "-"
+	}
+
+	fmt.Printf("Name:         %s\n", p.Name)
+	fmt.Printf("Vendor:       %s\n", vendorName)
+
+	if p.InstalledFrom != nil {
+		fmt.Printf("Installed:    %s\n", p.InstalledFrom.InstalledAt)
+		fmt.Printf("Source:       %s (%s)\n", p.InstalledFrom.Source, p.InstalledFrom.SourceType)
+		if p.InstalledFrom.Path != "" {
+			fmt.Printf("Path:         %s\n", p.InstalledFrom.Path)
+		}
+		if p.InstalledFrom.RegistryName != "" {
+			fmt.Printf("Registry:     %s\n", p.InstalledFrom.RegistryName)
+		}
+	} else {
+		fmt.Printf("Installed:    -\n")
+		fmt.Printf("Source:       -\n")
+	}
+
+	// Local artifacts
+	arts, _ := persona.ScanArtifacts(name)
+	fmt.Println()
+	fmt.Println("Artifacts:")
+	if arts.Total() == 0 {
+		fmt.Println("  (none)")
+	} else {
+		if len(arts.Skills) > 0 {
+			fmt.Printf("  skills:    %s\n", strings.Join(arts.Skills, ", "))
+		}
+		if len(arts.Agents) > 0 {
+			fmt.Printf("  agents:    %s\n", strings.Join(arts.Agents, ", "))
+		}
+		if len(arts.Rules) > 0 {
+			fmt.Printf("  rules:     %s\n", strings.Join(arts.Rules, ", "))
+		}
+		if len(arts.Commands) > 0 {
+			fmt.Printf("  commands:  %s\n", strings.Join(arts.Commands, ", "))
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Includes:")
+	if len(p.Includes) == 0 {
+		fmt.Println("  (none)")
+	} else {
+		for _, inc := range p.Includes {
+			line := "  " + inc.Git
+			if inc.Path != "" {
+				line += "  path=" + inc.Path
+			}
+			if inc.Ref != "" {
+				line += "  ref=" + inc.Ref
+			}
+			if len(inc.Pick) > 0 {
+				line += "  pick=[" + strings.Join(inc.Pick, ", ") + "]"
+			}
+			fmt.Println(line)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Delegates to:")
+	if len(p.DelegatesTo) == 0 {
+		fmt.Println("  (none)")
+	} else {
+		for _, del := range p.DelegatesTo {
+			line := "  " + del.Git
+			if del.Path != "" {
+				line += "  path=" + del.Path
+			}
+			if del.Ref != "" {
+				line += "  ref=" + del.Ref
+			}
+			fmt.Println(line)
+		}
+	}
+
+	return nil
 }
 
-// formatSources formats a count with abbreviated git URLs.
-func formatSources(count int, urls []string) string {
-	if count == 0 {
+// formatArtifactSummary formats the ARTIFACTS column for ynh ls.
+// Shows a compact summary like "1s 2a 1r 1c" (skills, agents, rules, commands).
+func formatArtifactSummary(name string) string {
+	arts, _ := persona.ScanArtifacts(name)
+	if arts.Total() == 0 {
 		return "0"
 	}
-	short := make([]string, 0, len(urls))
-	for _, u := range urls {
-		short = append(short, shortGitURL(u))
+	var parts []string
+	if len(arts.Skills) > 0 {
+		parts = append(parts, fmt.Sprintf("%ds", len(arts.Skills)))
 	}
-	return strings.Join(short, ", ")
+	if len(arts.Agents) > 0 {
+		parts = append(parts, fmt.Sprintf("%da", len(arts.Agents)))
+	}
+	if len(arts.Rules) > 0 {
+		parts = append(parts, fmt.Sprintf("%dr", len(arts.Rules)))
+	}
+	if len(arts.Commands) > 0 {
+		parts = append(parts, fmt.Sprintf("%dc", len(arts.Commands)))
+	}
+	return strings.Join(parts, " ")
+}
+
+// formatProvenance formats the SOURCE column for ynh ls.
+func formatProvenance(prov *persona.Provenance) string {
+	if prov == nil {
+		return "-"
+	}
+	short := shortGitURL(prov.Source)
+	if prov.Path != "" {
+		short += "/" + prov.Path
+	}
+	if prov.RegistryName != "" {
+		short += " (" + prov.RegistryName + ")"
+	}
+	return short
+}
+
+// formatIncludes formats the INCLUDES column for ynh ls.
+func formatIncludes(includes []persona.Include) string {
+	if len(includes) == 0 {
+		return "0"
+	}
+	parts := make([]string, 0, len(includes))
+	for _, inc := range includes {
+		s := shortGitURL(inc.Git)
+		if inc.Path != "" {
+			s += "/" + inc.Path
+		}
+		if inc.Ref != "" && inc.Ref != "main" && inc.Ref != "HEAD" {
+			s += "@" + inc.Ref
+		}
+		if len(inc.Pick) > 0 {
+			s += fmt.Sprintf(" [%d]", len(inc.Pick))
+		}
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// formatDelegates formats the DELEGATES TO column for ynh ls.
+func formatDelegates(delegates []persona.Delegate) string {
+	if len(delegates) == 0 {
+		return "0"
+	}
+	parts := make([]string, 0, len(delegates))
+	for _, del := range delegates {
+		s := shortGitURL(del.Git)
+		if del.Path != "" {
+			s += "/" + del.Path
+		}
+		if del.Ref != "" && del.Ref != "main" && del.Ref != "HEAD" {
+			s += "@" + del.Ref
+		}
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // shortGitURL abbreviates a git URL for display.

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -322,6 +322,218 @@ func TestCmdList_WithPersonas(t *testing.T) {
 	}
 }
 
+func TestFormatProvenance(t *testing.T) {
+	tests := []struct {
+		name string
+		prov *persona.Provenance
+		want string
+	}{
+		{"nil", nil, "-"},
+		{"local", &persona.Provenance{SourceType: "local", Source: "./my-persona"}, "./my-persona"},
+		{"git no path", &persona.Provenance{SourceType: "git", Source: "github.com/eyelock/assistants"}, "eyelock/assistants"},
+		{"git with path", &persona.Provenance{SourceType: "git", Source: "github.com/eyelock/assistants", Path: "ynh/david"}, "eyelock/assistants/ynh/david"},
+		{"registry", &persona.Provenance{SourceType: "registry", Source: "github.com/eyelock/assistants", RegistryName: "my-reg"}, "eyelock/assistants (my-reg)"},
+		{"registry with path", &persona.Provenance{SourceType: "registry", Source: "github.com/eyelock/assistants", Path: "ynh/david", RegistryName: "my-reg"}, "eyelock/assistants/ynh/david (my-reg)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatProvenance(tt.prov)
+			if got != tt.want {
+				t.Errorf("formatProvenance() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatIncludes(t *testing.T) {
+	tests := []struct {
+		name     string
+		includes []persona.Include
+		want     string
+	}{
+		{"empty", nil, "0"},
+		{"single no pick", []persona.Include{
+			{GitSource: persona.GitSource{Git: "github.com/example/skills", Path: "dev"}},
+		}, "example/skills/dev"},
+		{"single with pick", []persona.Include{
+			{GitSource: persona.GitSource{Git: "github.com/example/skills", Path: "dev"}, Pick: []string{"a", "b"}},
+		}, "example/skills/dev [2]"},
+		{"with ref", []persona.Include{
+			{GitSource: persona.GitSource{Git: "github.com/example/skills", Path: "dev", Ref: "v1.2.0"}},
+		}, "example/skills/dev@v1.2.0"},
+		{"main ref omitted", []persona.Include{
+			{GitSource: persona.GitSource{Git: "github.com/example/skills", Ref: "main"}},
+		}, "example/skills"},
+		{"multiple", []persona.Include{
+			{GitSource: persona.GitSource{Git: "github.com/example/skills", Path: "dev"}, Pick: []string{"a", "b"}},
+			{GitSource: persona.GitSource{Git: "github.com/example/skills", Path: "infra"}, Pick: []string{"c"}},
+		}, "example/skills/dev [2], example/skills/infra [1]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatIncludes(tt.includes)
+			if got != tt.want {
+				t.Errorf("formatIncludes() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatDelegates(t *testing.T) {
+	tests := []struct {
+		name      string
+		delegates []persona.Delegate
+		want      string
+	}{
+		{"empty", nil, "0"},
+		{"single", []persona.Delegate{
+			{GitSource: persona.GitSource{Git: "github.com/example/team"}},
+		}, "example/team"},
+		{"with path and ref", []persona.Delegate{
+			{GitSource: persona.GitSource{Git: "github.com/example/mono", Path: "personas/ops", Ref: "v2"}},
+		}, "example/mono/personas/ops@v2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatDelegates(tt.delegates)
+			if got != tt.want {
+				t.Errorf("formatDelegates() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatArtifactSummary(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("YNH_HOME", "")
+
+	// Create a persona with artifacts
+	personaDir := filepath.Join(dir, ".ynh", "personas", "artfmt")
+	installDir := filepath.Join(personaDir, ".claude-plugin")
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installDir, "plugin.json"),
+		[]byte(`{"name":"artfmt","version":"0.1.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add 2 skills, 1 agent
+	for _, skill := range []string{"a", "b"} {
+		sd := filepath.Join(personaDir, "skills", skill)
+		if err := os.MkdirAll(sd, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(sd, "SKILL.md"), []byte("#"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	agentDir := filepath.Join(personaDir, "agents")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "x.md"), []byte("#"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := formatArtifactSummary("artfmt")
+	if got != "2s 1a" {
+		t.Errorf("formatArtifactSummary() = %q, want %q", got, "2s 1a")
+	}
+}
+
+func TestFormatArtifactSummary_Empty(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("YNH_HOME", "")
+
+	installTestPersona(t, "neart")
+	got := formatArtifactSummary("neart")
+	if got != "0" {
+		t.Errorf("formatArtifactSummary() = %q, want %q", got, "0")
+	}
+}
+
+func TestCmdInfo_Success(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	installTestPersona(t, "david")
+
+	err := cmdInfo([]string{"david"})
+	if err != nil {
+		t.Fatalf("cmdInfo failed: %v", err)
+	}
+}
+
+func TestCmdInfo_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh", "personas"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cmdInfo([]string{"nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent persona")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCmdInfo_NoArgs(t *testing.T) {
+	err := cmdInfo([]string{})
+	if err == nil {
+		t.Fatal("expected error for no args")
+	}
+	if !strings.Contains(err.Error(), "usage") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCmdInstall_WritesProvenance(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("YNH_HOME", "")
+
+	// Create a local persona source
+	srcDir := filepath.Join(dir, "my-persona")
+	pluginDir := filepath.Join(srcDir, ".claude-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"),
+		[]byte(`{"name":"provtest","version":"0.1.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cmdInstall([]string{srcDir})
+	if err != nil {
+		t.Fatalf("cmdInstall failed: %v", err)
+	}
+
+	// Load installed persona and check provenance
+	p, err := persona.Load("provtest")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if p.InstalledFrom == nil {
+		t.Fatal("InstalledFrom is nil after install")
+	}
+	if p.InstalledFrom.SourceType != "local" {
+		t.Errorf("SourceType = %q, want %q", p.InstalledFrom.SourceType, "local")
+	}
+	if p.InstalledFrom.Source != srcDir {
+		t.Errorf("Source = %q, want %q", p.InstalledFrom.Source, srcDir)
+	}
+	if p.InstalledFrom.InstalledAt == "" {
+		t.Error("InstalledAt is empty")
+	}
+}
+
 func TestCmdUpdate_NoArgs(t *testing.T) {
 	err := cmdUpdate([]string{})
 	if err == nil {

--- a/docs/tutorial/01-first-persona.md
+++ b/docs/tutorial/01-first-persona.md
@@ -145,8 +145,37 @@ ynh ls
 
 Expected:
 ```
-NAME        VENDOR  INCLUDES  DELEGATES TO
-my-persona  claude  0         0
+NAME        VENDOR  SOURCE                          ARTIFACTS      INCLUDES  DELEGATES TO
+my-persona  claude  /tmp/ynh-tutorial/my-persona     1s 1a 1r 1c   0         0
+```
+
+The ARTIFACTS column shows a compact count: skills (s), agents (a), rules (r), commands (c).
+The SOURCE column shows where the persona was installed from.
+
+## T1.5b: Inspect persona detail
+
+```bash
+ynh info my-persona
+```
+
+Expected:
+```
+Name:         my-persona
+Vendor:       claude
+Installed:    <timestamp>
+Source:       /tmp/ynh-tutorial/my-persona (local)
+
+Artifacts:
+  skills:    greet
+  agents:    nitpicker
+  rules:     be-brief
+  commands:  hello
+
+Includes:
+  (none)
+
+Delegates to:
+  (none)
 ```
 
 Check the launcher script:

--- a/docs/tutorial/04-delegation.md
+++ b/docs/tutorial/04-delegation.md
@@ -92,8 +92,8 @@ ynh ls
 
 Expected:
 ```
-NAME       VENDOR  INCLUDES  DELEGATES TO
-team-lead  claude  0         /tmp/ynh-tutorial/specialist, eyelock/ynh
+NAME       VENDOR  SOURCE                          ARTIFACTS  INCLUDES  DELEGATES TO
+team-lead  claude  /tmp/ynh-tutorial/team-lead      ...        0         /tmp/ynh-tutorial/specialist, eyelock/ynh
 ```
 
 ## T4.4: Inspect delegate agent files

--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -36,6 +36,7 @@ Re-run `make install` after any code change you want to test.
 | T1.3 | Verify structure | [T1.3](tutorial/01-first-persona.md#t13-verify-structure) |
 | T1.4 | Install from local path | [T1.4](tutorial/01-first-persona.md#t14-install-from-local-path) |
 | T1.5 | List installed personas | [T1.5](tutorial/01-first-persona.md#t15-list-installed-personas) |
+| T1.5b | Inspect persona detail | [T1.5b](tutorial/01-first-persona.md#t15b-inspect-persona-detail) |
 | T1.6 | Run interactive | [T1.6](tutorial/01-first-persona.md#t16-run-interactive) |
 | T1.7 | Run non-interactive | [T1.7](tutorial/01-first-persona.md#t17-run-non-interactive) |
 | T1.8 | Run with vendor flags | [T1.8](tutorial/01-first-persona.md#t18-run-with-vendor-flags) |
@@ -289,13 +290,34 @@ my-dev "hello" 2>&1 | head -1
 mv ~/.ynh/config.json.bak ~/.ynh/config.json
 ```
 
+### E16: Info on installed persona
+
+```bash
+ynh info my-persona
+# Expected: Name, Vendor, Installed timestamp, Source (local path), no includes, no delegates
+```
+
+### E17: Info on non-existent persona
+
+```bash
+ynh info nonexistent
+# Expected: Error: persona "nonexistent" not found
+```
+
+### E18: Info with no args
+
+```bash
+ynh info
+# Expected: Error: usage: ynh info <persona-name>
+```
+
 ---
 
 ## Summary
 
 | Section | Tests |
 |---------|-------|
-| Tutorial 1: First Persona | 10 |
+| Tutorial 1: First Persona | 11 |
 | Tutorial 2: Vendors & Symlinks | 7 |
 | Tutorial 3: Composition | 12 |
 | Tutorial 4: Delegation | 5 |
@@ -303,5 +325,5 @@ mv ~/.ynh/config.json.bak ~/.ynh/config.json
 | Tutorial 6: Marketplace | 7 |
 | Tutorial 7: Registry & Discovery | 11 |
 | Tutorial 8: Developer Tools | 8 |
-| Edge Cases | 15 |
-| **Total** | **85** |
+| Edge Cases | 18 |
+| **Total** | **89** |

--- a/internal/persona/persona.go
+++ b/internal/persona/persona.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strings"
 
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/plugin"
@@ -30,12 +32,22 @@ type Delegate struct {
 	GitSource
 }
 
+// Provenance records where a persona was installed from.
+type Provenance struct {
+	SourceType   string
+	Source       string
+	Path         string
+	RegistryName string
+	InstalledAt  string
+}
+
 type Persona struct {
 	Name          string
 	Description   string
 	DefaultVendor string
 	Includes      []Include
 	DelegatesTo   []Delegate
+	InstalledFrom *Provenance
 }
 
 // DetectFormat returns "plugin" if dir contains .claude-plugin/plugin.json,
@@ -112,7 +124,82 @@ func LoadPluginDir(dir string) (*Persona, error) {
 				GitSource: GitSource{Git: del.Git, Ref: del.Ref, Path: del.Path},
 			})
 		}
+		if meta.YNH.InstalledFrom != nil {
+			prov := meta.YNH.InstalledFrom
+			p.InstalledFrom = &Provenance{
+				SourceType:   prov.SourceType,
+				Source:       prov.Source,
+				Path:         prov.Path,
+				RegistryName: prov.RegistryName,
+				InstalledAt:  prov.InstalledAt,
+			}
+		}
 	}
 
 	return p, nil
+}
+
+// Artifacts holds the names of local artifacts found in a persona directory,
+// keyed by artifact type (skills, agents, rules, commands).
+type Artifacts struct {
+	Skills   []string
+	Agents   []string
+	Rules    []string
+	Commands []string
+}
+
+// Total returns the total number of local artifacts.
+func (a *Artifacts) Total() int {
+	return len(a.Skills) + len(a.Agents) + len(a.Rules) + len(a.Commands)
+}
+
+// ScanArtifacts discovers local artifacts in a persona's installed directory.
+// Skills are directories containing SKILL.md; agents, rules, and commands are .md files.
+func ScanArtifacts(name string) (*Artifacts, error) {
+	dir := InstalledDir(name)
+	a := &Artifacts{}
+
+	// Skills: subdirectories with SKILL.md
+	a.Skills = scanSkillDirs(filepath.Join(dir, "skills"))
+
+	// Agents, rules, commands: .md files
+	a.Agents = scanMDFiles(filepath.Join(dir, "agents"))
+	a.Rules = scanMDFiles(filepath.Join(dir, "rules"))
+	a.Commands = scanMDFiles(filepath.Join(dir, "commands"))
+
+	return a, nil
+}
+
+// scanSkillDirs returns names of subdirectories that contain a SKILL.md file.
+func scanSkillDirs(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			if _, err := os.Stat(filepath.Join(dir, entry.Name(), "SKILL.md")); err == nil {
+				names = append(names, entry.Name())
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// scanMDFiles returns names (without .md extension) of markdown files in dir.
+func scanMDFiles(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".md") {
+			names = append(names, strings.TrimSuffix(entry.Name(), ".md"))
+		}
+	}
+	sort.Strings(names)
+	return names
 }

--- a/internal/persona/persona_test.go
+++ b/internal/persona/persona_test.go
@@ -250,6 +250,190 @@ func TestInstalledDir(t *testing.T) {
 	}
 }
 
+func TestLoadPluginDir_WithProvenance(t *testing.T) {
+	dir := t.TempDir()
+	writeTestPlugin(t, dir, "prov")
+	meta := `{
+		"ynh": {
+			"default_vendor": "claude",
+			"installed_from": {
+				"source_type": "git",
+				"source": "github.com/example/repo",
+				"path": "personas/prov",
+				"installed_at": "2026-03-22T10:30:00Z"
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := LoadPluginDir(dir)
+	if err != nil {
+		t.Fatalf("LoadPluginDir failed: %v", err)
+	}
+	if p.InstalledFrom == nil {
+		t.Fatal("InstalledFrom is nil")
+	}
+	if p.InstalledFrom.SourceType != "git" {
+		t.Errorf("SourceType = %q, want %q", p.InstalledFrom.SourceType, "git")
+	}
+	if p.InstalledFrom.Source != "github.com/example/repo" {
+		t.Errorf("Source = %q, want %q", p.InstalledFrom.Source, "github.com/example/repo")
+	}
+	if p.InstalledFrom.Path != "personas/prov" {
+		t.Errorf("Path = %q, want %q", p.InstalledFrom.Path, "personas/prov")
+	}
+	if p.InstalledFrom.InstalledAt != "2026-03-22T10:30:00Z" {
+		t.Errorf("InstalledAt = %q", p.InstalledFrom.InstalledAt)
+	}
+}
+
+func TestLoadPluginDir_WithoutProvenance(t *testing.T) {
+	dir := t.TempDir()
+	writeTestPlugin(t, dir, "noprov")
+	meta := `{"ynh": {"default_vendor": "claude"}}`
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := LoadPluginDir(dir)
+	if err != nil {
+		t.Fatalf("LoadPluginDir failed: %v", err)
+	}
+	if p.InstalledFrom != nil {
+		t.Errorf("InstalledFrom should be nil, got %+v", p.InstalledFrom)
+	}
+}
+
+func TestLoadPluginDir_RegistryProvenance(t *testing.T) {
+	dir := t.TempDir()
+	writeTestPlugin(t, dir, "regprov")
+	meta := `{
+		"ynh": {
+			"default_vendor": "claude",
+			"installed_from": {
+				"source_type": "registry",
+				"source": "github.com/example/repo",
+				"registry_name": "my-registry",
+				"installed_at": "2026-03-22T10:30:00Z"
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := LoadPluginDir(dir)
+	if err != nil {
+		t.Fatalf("LoadPluginDir failed: %v", err)
+	}
+	if p.InstalledFrom == nil {
+		t.Fatal("InstalledFrom is nil")
+	}
+	if p.InstalledFrom.RegistryName != "my-registry" {
+		t.Errorf("RegistryName = %q, want %q", p.InstalledFrom.RegistryName, "my-registry")
+	}
+}
+
+func TestScanArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("YNH_HOME", "")
+
+	personaDir := filepath.Join(dir, ".ynh", "personas", "arttest")
+	writeTestPlugin(t, personaDir, "arttest")
+
+	// Create skills (directories with SKILL.md)
+	for _, skill := range []string{"greet", "review"} {
+		skillDir := filepath.Join(personaDir, "skills", skill)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# "+skill), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create agents, rules, commands (.md files)
+	for _, artType := range []string{"agents", "rules", "commands"} {
+		artDir := filepath.Join(personaDir, artType)
+		if err := os.MkdirAll(artDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(artDir, "test-one.md"), []byte("# test"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	arts, err := ScanArtifacts("arttest")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(arts.Skills) != 2 {
+		t.Errorf("Skills = %v, want 2", arts.Skills)
+	}
+	if arts.Skills[0] != "greet" || arts.Skills[1] != "review" {
+		t.Errorf("Skills = %v, want [greet review]", arts.Skills)
+	}
+	if len(arts.Agents) != 1 || arts.Agents[0] != "test-one" {
+		t.Errorf("Agents = %v, want [test-one]", arts.Agents)
+	}
+	if len(arts.Rules) != 1 {
+		t.Errorf("Rules = %v, want 1", arts.Rules)
+	}
+	if len(arts.Commands) != 1 {
+		t.Errorf("Commands = %v, want 1", arts.Commands)
+	}
+	if arts.Total() != 5 {
+		t.Errorf("Total() = %d, want 5", arts.Total())
+	}
+}
+
+func TestScanArtifacts_Empty(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("YNH_HOME", "")
+
+	personaDir := filepath.Join(dir, ".ynh", "personas", "empty")
+	writeTestPlugin(t, personaDir, "empty")
+
+	arts, err := ScanArtifacts("empty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if arts.Total() != 0 {
+		t.Errorf("Total() = %d, want 0", arts.Total())
+	}
+}
+
+func TestScanArtifacts_SkillWithoutManifest(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("YNH_HOME", "")
+
+	personaDir := filepath.Join(dir, ".ynh", "personas", "nosk")
+	writeTestPlugin(t, personaDir, "nosk")
+
+	// Create a directory in skills/ but without SKILL.md — should not be counted
+	badSkill := filepath.Join(personaDir, "skills", "bad")
+	if err := os.MkdirAll(badSkill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(badSkill, "README.md"), []byte("not a skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	arts, err := ScanArtifacts("nosk")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(arts.Skills) != 0 {
+		t.Errorf("Skills = %v, want empty (no SKILL.md)", arts.Skills)
+	}
+}
+
 // writeTestPlugin creates a minimal .claude-plugin/plugin.json in dir.
 func writeTestPlugin(t *testing.T, dir, name string) {
 	t.Helper()

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -30,9 +30,19 @@ type MetadataJSON struct {
 
 // YNHMetadata holds ynh-specific persona configuration.
 type YNHMetadata struct {
-	DefaultVendor string         `json:"default_vendor,omitempty"`
-	Includes      []IncludeMeta  `json:"includes,omitempty"`
-	DelegatesTo   []DelegateMeta `json:"delegates_to,omitempty"`
+	DefaultVendor string          `json:"default_vendor,omitempty"`
+	Includes      []IncludeMeta   `json:"includes,omitempty"`
+	DelegatesTo   []DelegateMeta  `json:"delegates_to,omitempty"`
+	InstalledFrom *ProvenanceMeta `json:"installed_from,omitempty"`
+}
+
+// ProvenanceMeta records where a persona was installed from.
+type ProvenanceMeta struct {
+	SourceType   string `json:"source_type"`
+	Source       string `json:"source"`
+	Path         string `json:"path,omitempty"`
+	RegistryName string `json:"registry_name,omitempty"`
+	InstalledAt  string `json:"installed_at"`
 }
 
 // IncludeMeta is the JSON representation of a Git include.
@@ -92,4 +102,44 @@ func LoadMetadataJSON(dir string) (*MetadataJSON, error) {
 	}
 
 	return &meta, nil
+}
+
+// SaveMetadataJSON merges ynh metadata into the existing metadata.json at dir,
+// preserving any non-ynh keys. Creates the file if it doesn't exist.
+func SaveMetadataJSON(dir string, ynh *YNHMetadata) error {
+	path := filepath.Join(dir, "metadata.json")
+
+	// Read existing file into a raw map to preserve non-ynh keys.
+	existing := make(map[string]any)
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if err := json.Unmarshal(data, &existing); err != nil {
+			return fmt.Errorf("parsing existing metadata.json: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("reading metadata.json: %w", err)
+	}
+
+	// Marshal the typed YNHMetadata to a raw value, then inject into the map.
+	ynhBytes, err := json.Marshal(ynh)
+	if err != nil {
+		return fmt.Errorf("marshaling ynh metadata: %w", err)
+	}
+	var ynhRaw any
+	if err := json.Unmarshal(ynhBytes, &ynhRaw); err != nil {
+		return fmt.Errorf("converting ynh metadata: %w", err)
+	}
+	existing["ynh"] = ynhRaw
+
+	out, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling metadata.json: %w", err)
+	}
+	out = append(out, '\n')
+
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return fmt.Errorf("writing metadata.json: %w", err)
+	}
+
+	return nil
 }

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -150,6 +150,147 @@ func TestLoadMetadataJSON_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestSaveMetadataJSON_NewFile(t *testing.T) {
+	dir := t.TempDir()
+	ynh := &YNHMetadata{
+		DefaultVendor: "claude",
+		InstalledFrom: &ProvenanceMeta{
+			SourceType:  "git",
+			Source:      "github.com/example/repo",
+			Path:        "personas/test",
+			InstalledAt: "2026-03-22T10:30:00Z",
+		},
+	}
+
+	if err := SaveMetadataJSON(dir, ynh); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read back and verify
+	meta, err := LoadMetadataJSON(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.YNH == nil {
+		t.Fatal("YNH is nil after save")
+	}
+	if meta.YNH.DefaultVendor != "claude" {
+		t.Errorf("DefaultVendor = %q, want %q", meta.YNH.DefaultVendor, "claude")
+	}
+	if meta.YNH.InstalledFrom == nil {
+		t.Fatal("InstalledFrom is nil after save")
+	}
+	if meta.YNH.InstalledFrom.SourceType != "git" {
+		t.Errorf("SourceType = %q, want %q", meta.YNH.InstalledFrom.SourceType, "git")
+	}
+	if meta.YNH.InstalledFrom.Source != "github.com/example/repo" {
+		t.Errorf("Source = %q, want %q", meta.YNH.InstalledFrom.Source, "github.com/example/repo")
+	}
+	if meta.YNH.InstalledFrom.Path != "personas/test" {
+		t.Errorf("Path = %q, want %q", meta.YNH.InstalledFrom.Path, "personas/test")
+	}
+}
+
+func TestSaveMetadataJSON_PreservesNonYNHKeys(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a file with a non-ynh key
+	initial := []byte(`{"other_tool": {"setting": true}, "ynh": {"default_vendor": "codex"}}`)
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), initial, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save new ynh metadata (overwrites ynh, preserves other_tool)
+	ynh := &YNHMetadata{
+		DefaultVendor: "claude",
+		InstalledFrom: &ProvenanceMeta{
+			SourceType:  "local",
+			Source:      "./my-persona",
+			InstalledAt: "2026-03-22T10:30:00Z",
+		},
+	}
+	if err := SaveMetadataJSON(dir, ynh); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read raw JSON and check other_tool is preserved
+	data, err := os.ReadFile(filepath.Join(dir, "metadata.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	otherTool, ok := raw["other_tool"]
+	if !ok {
+		t.Fatal("other_tool key was lost during save")
+	}
+	otherMap, ok := otherTool.(map[string]any)
+	if !ok {
+		t.Fatal("other_tool is not an object")
+	}
+	if otherMap["setting"] != true {
+		t.Errorf("other_tool.setting = %v, want true", otherMap["setting"])
+	}
+
+	// Also verify ynh was updated
+	meta, err := LoadMetadataJSON(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.YNH.DefaultVendor != "claude" {
+		t.Errorf("DefaultVendor = %q, want %q", meta.YNH.DefaultVendor, "claude")
+	}
+}
+
+func TestSaveMetadataJSON_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write full metadata with includes and provenance
+	ynh := &YNHMetadata{
+		DefaultVendor: "claude",
+		Includes: []IncludeMeta{
+			{Git: "github.com/example/repo", Path: "skills/dev", Pick: []string{"review"}},
+		},
+		DelegatesTo: []DelegateMeta{
+			{Git: "github.com/example/team"},
+		},
+		InstalledFrom: &ProvenanceMeta{
+			SourceType:   "registry",
+			Source:       "github.com/example/repo",
+			RegistryName: "my-registry",
+			InstalledAt:  "2026-03-22T10:30:00Z",
+		},
+	}
+
+	if err := SaveMetadataJSON(dir, ynh); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, err := LoadMetadataJSON(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(meta.YNH.Includes) != 1 {
+		t.Fatalf("Includes = %d, want 1", len(meta.YNH.Includes))
+	}
+	if meta.YNH.Includes[0].Path != "skills/dev" {
+		t.Errorf("Include.Path = %q, want %q", meta.YNH.Includes[0].Path, "skills/dev")
+	}
+	if len(meta.YNH.DelegatesTo) != 1 {
+		t.Fatalf("DelegatesTo = %d, want 1", len(meta.YNH.DelegatesTo))
+	}
+	if meta.YNH.InstalledFrom == nil {
+		t.Fatal("InstalledFrom is nil after round-trip")
+	}
+	if meta.YNH.InstalledFrom.RegistryName != "my-registry" {
+		t.Errorf("RegistryName = %q, want %q", meta.YNH.InstalledFrom.RegistryName, "my-registry")
+	}
+}
+
 func writePluginJSON(t *testing.T, dir string, pj PluginJSON) {
 	t.Helper()
 	pluginDir := filepath.Join(dir, ".claude-plugin")


### PR DESCRIPTION
## Summary

- **Provenance tracking**: `ynh install` now records where a persona was installed from (local path, git URL, or registry) in `metadata.json` under `ynh.installed_from`
- **Richer `ynh ls`**: New SOURCE column (install origin), ARTIFACTS column (compact local artifact counts like `1s 2a 1r 1c`), and richer INCLUDES format showing repo/path with pick counts
- **`ynh info <name>`**: New command showing full persona detail — provenance, local artifacts by name, includes with full git/path/ref/pick detail, and delegates

## Test plan

- [x] `make check` passes (0 lint issues, all tests green)
- [x] Run Tutorial 1 (`docs/tutorial/01-first-persona.md`) — exercises T1.5 (new ls format) and T1.5b (new info command)
- [x] Verify pre-provenance personas show `-` in SOURCE column
- [x] Verify `ynh info nonexistent` errors cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)