### PR TITLE
fix: fetch includes and delegates at install time

### DIFF
--- a/.claude/skills/ynh-dev/references/architecture.md
+++ b/.claude/skills/ynh-dev/references/architecture.md
@@ -7,7 +7,7 @@
 ```
 
 1. **Detect** persona format and load manifest (`internal/persona/`, `internal/plugin/`)
-2. **Resolve** Git includes by cloning/caching repos (`internal/resolver/`)
+2. **Resolve** Git includes from local cache (`internal/resolver/`) — repos are pre-fetched at install time; run uses cache-only with fallback fetch on miss
 3. **Assemble** vendor config into `~/.ynh/run/<name>/` (`internal/assembler/`)
 4. **Launch** vendor CLI, adapting to each vendor's capabilities (`internal/vendor/`)
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -289,10 +289,12 @@ There are two copies of `metadata.json` in a persona's life:
 During install:
 - `ynh install` copies the entire persona directory (including `metadata.json`) to `~/.ynh/personas/<name>/`.
 - After the copy, ynh injects `installed_from` provenance into the installed `metadata.json`. This records where the persona was installed from (source type, URL/path, timestamp).
+- ynh then pre-fetches all `includes` and `delegates_to` Git repos into `~/.ynh/cache/`. This ensures `ynh run` works offline and validates all Git refs at install time. If any fetch fails, the install fails with a clear error.
 - The source `metadata.json` is never modified.
 
 At runtime:
 - `ynh run` reads the installed copy at `~/.ynh/personas/<name>/metadata.json` to resolve includes, delegates, and vendor settings.
+- Cached repos are used as-is without hitting the network. If a cache entry is missing (e.g. manually cleared), ynh falls back to a network fetch with a warning.
 
 The `installed_from` field looks like:
 

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -271,6 +271,33 @@ func cmdInstall(args []string) error {
 		return fmt.Errorf("saving provenance: %w", err)
 	}
 
+	// Pre-fetch includes and delegates so ynh run works offline
+	if len(p.Includes) > 0 || len(p.DelegatesTo) > 0 {
+		fmt.Printf("Fetching %d include(s) and %d delegate(s)...\n", len(p.Includes), len(p.DelegatesTo))
+	}
+	for _, inc := range p.Includes {
+		if !isLocalPath(inc.Git) {
+			if err := cfg.CheckRemoteSource(inc.Git); err != nil {
+				return fmt.Errorf("include %q: %w", inc.Git, err)
+			}
+		}
+		if _, err := resolver.EnsureRepo(inc.Git, inc.Ref); err != nil {
+			return fmt.Errorf("fetching include %s: %w", inc.Git, err)
+		}
+		fmt.Printf("  Fetched %s\n", resolver.ShortGitURL(inc.Git))
+	}
+	for _, del := range p.DelegatesTo {
+		if !isLocalPath(del.Git) {
+			if err := cfg.CheckRemoteSource(del.Git); err != nil {
+				return fmt.Errorf("delegate %q: %w", del.Git, err)
+			}
+		}
+		if _, err := resolver.EnsureRepo(del.Git, del.Ref); err != nil {
+			return fmt.Errorf("fetching delegate %s: %w", del.Git, err)
+		}
+		fmt.Printf("  Fetched %s\n", resolver.ShortGitURL(del.Git))
+	}
+
 	// Generate launcher script (skip for reserved names that conflict with the binary)
 	if !reservedName {
 		if err := generateLauncher(p.Name); err != nil {
@@ -424,11 +451,11 @@ func cmdRun(args []string) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	// Resolve Git includes (with remote source allow-list check)
+	// Resolve Git includes from cache (no network access unless cache miss)
 	if len(p.Includes) > 0 {
 		fmt.Fprintf(os.Stderr, "Resolving %d include(s)...\n", len(p.Includes))
 	}
-	resolved, err := resolver.Resolve(p, cfg)
+	resolved, err := resolver.ResolveFromCache(p, cfg)
 	if err != nil {
 		return fmt.Errorf("resolving includes: %w", err)
 	}
@@ -438,6 +465,9 @@ func cmdRun(args []string) error {
 		source := r.Source
 		if r.Path != "" {
 			source += " → " + r.Path
+		}
+		if len(r.Content.Paths) > 0 {
+			source += " [" + strings.Join(r.Content.Paths, ", ") + "]"
 		}
 		if r.Cloned {
 			fmt.Fprintf(os.Stderr, "  Cloned %s\n", source)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,6 +94,8 @@ Point your metadata at any Git repo. Skills are used as-is - no wrapping, no bui
 }
 ```
 
+All included repos are fetched at install time and cached locally. This means `ynh run` works offline - no network access needed unless the cache is cleared.
+
 Reinstall to pick up changes:
 
 ```bash

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -161,7 +161,7 @@ At runtime, ynh generates a vendor-native agent file for each delegate containin
 
 **Embedded** artifacts live directly in the persona directory. They're always included.
 
-**External** artifacts are pulled from Git repos via `includes`. They're fetched at runtime, cached locally.
+**External** artifacts are pulled from Git repos via `includes`. They're fetched at install time and cached locally. At runtime, cached repos are used without network access (with a fallback fetch on cache miss).
 
 Both are assembled into the same vendor config. Use embedded for persona-specific customizations, external for shared libraries.
 

--- a/docs/tutorial/03-composition.md
+++ b/docs/tutorial/03-composition.md
@@ -63,6 +63,15 @@ This demonstrates:
 - **`pick`** — cherry-pick specific skills (ynh's unique differentiator — no vendor supports this natively)
 - **Multiple includes** — skills from different categories in the same repo
 
+During install, ynh fetches all included repos and caches them locally. You should see output like:
+
+```
+Fetching 3 include(s) and 0 delegate(s)...
+  Fetched eyelock/assistants
+  Fetched eyelock/assistants
+  Fetched eyelock/assistants
+```
+
 Run it once to trigger assembly, then verify only the picked skills are included:
 
 ```bash
@@ -452,7 +461,7 @@ full-stack "hello" 2>&1
 # Expected error: resolving includes: include "github.com/anthropics/skills": remote source not allowed
 ```
 
-> **Note:** `ynh install` from a local path doesn't check includes — it just copies the persona directory. The allow-list is enforced at **run time** when includes are actually resolved from Git.
+> **Note:** `ynh install` now fetches all includes at install time, so the allow-list is enforced during install as well as at run time. If an include is blocked by the allow-list, `ynh install` will fail with an error.
 
 ## T3.12: Allow-list — allow a source
 
@@ -507,9 +516,10 @@ ynh uninstall my-dev with-anthropic with-vercel full-stack mixed local-ref pinne
 - **Embedded skills:** Put skills directly in the persona's `skills/` directory
 - **`pick` is the differentiator:** No vendor natively supports cherry-picking individual skills from a larger repo. ynh does.
 - **Mixing sources:** Combine your own skills, third-party skills, and local skills in one persona
+- **Offline-ready:** All includes are fetched at install time — `ynh run` works offline
 - `ref` pins to branches, tags, or commits
 - `ynh update` refreshes cached repos
-- `allowed_remote_sources` restricts which repos are permitted
+- `allowed_remote_sources` restricts which repos are permitted (enforced at both install and run time)
 
 ## Next
 

--- a/docs/tutorial/04-delegation.md
+++ b/docs/tutorial/04-delegation.md
@@ -87,6 +87,17 @@ EOF
 
 ```bash
 ynh install /tmp/ynh-tutorial/team-lead
+```
+
+Expected install output includes delegate fetching:
+```
+Fetching 0 include(s) and 2 delegate(s)...
+  Fetched /tmp/ynh-tutorial/specialist
+  Fetched eyelock/ynh
+Installed persona "team-lead"
+```
+
+```bash
 ynh ls
 ```
 
@@ -98,7 +109,7 @@ team-lead  claude  /tmp/ynh-tutorial/team-lead      ...        0         /tmp/yn
 
 ## T4.4: Inspect delegate agent files
 
-Delegates are resolved at runtime. Run the persona to trigger resolution:
+Delegate repos are fetched at install time and cached locally. Agent files are generated at runtime from the cached repos. Run the persona to trigger assembly:
 
 ```bash
 team-lead "list your available agents"
@@ -144,7 +155,8 @@ ynh uninstall team-lead
 - Delegates must be Git repos (local or remote)
 - ynh generates vendor-native agent files from delegate personas at runtime
 - Agent files inline the delegate's instructions, rules, and skill list
-- Delegates are resolved every `ynh run` (always fresh)
+- Delegate repos are fetched at install time and cached — `ynh run` works offline
+- Use `ynh update` to refresh cached delegate repos
 
 ## Next
 

--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -282,7 +282,7 @@ rm -rf broken-test
 cp ~/.ynh/config.json ~/.ynh/config.json.bak
 echo '{"default_vendor":"claude","allowed_remote_sources":[]}' > ~/.ynh/config.json
 
-# Any persona with remote includes should fail at run time
+# Any persona with remote includes should fail at both install and run time
 # (install my-dev first if not already installed)
 my-dev "hello" 2>&1 | head -1
 # Expected: Error about remote source not allowed

--- a/internal/assembler/delegates.go
+++ b/internal/assembler/delegates.go
@@ -31,7 +31,7 @@ func AssembleDelegates(workDir string, adapter vendor.Adapter, delegates []perso
 	}
 
 	for _, del := range delegates {
-		basePath, _, err := resolver.ResolveGitSource(del.GitSource)
+		basePath, _, err := resolver.ResolveGitSourceFromCache(del.GitSource)
 		if err != nil {
 			return fmt.Errorf("delegate: %w", err)
 		}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -72,7 +72,7 @@ func Resolve(p *persona.Persona, cfg *config.Config) ([]ResolveResult, error) {
 				BasePath: basePath,
 				Paths:    inc.Pick,
 			},
-			Source: shortGitURL(inc.Git),
+			Source: ShortGitURL(inc.Git),
 			Path:   inc.Path,
 			Cloned: repoResult.Cloned,
 			Cached: !repoResult.Cloned,
@@ -82,9 +82,9 @@ func Resolve(p *persona.Persona, cfg *config.Config) ([]ResolveResult, error) {
 	return results, nil
 }
 
-// shortGitURL abbreviates a git URL for display.
+// ShortGitURL abbreviates a git URL for display.
 // "github.com/eyelock/assistants" -> "eyelock/assistants"
-func shortGitURL(url string) string {
+func ShortGitURL(url string) string {
 	// Local paths: keep as-is
 	if strings.HasPrefix(url, "/") || strings.HasPrefix(url, ".") {
 		return url
@@ -148,6 +148,73 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 
 	after := gitHead(repoDir)
 	return RepoResult{Path: repoDir, Changed: before != after}, nil
+}
+
+// CacheOnlyRepo returns a cached repo without hitting the network.
+// If the cache entry exists, it is returned as-is. If not, it falls back to
+// EnsureRepo (which clones from the network) and prints a warning to stderr.
+func CacheOnlyRepo(gitURL string, ref string) (RepoResult, error) {
+	cacheDir := config.CacheDir()
+	repoDir := filepath.Join(cacheDir, repoDirName(gitURL, ref))
+
+	if _, err := os.Stat(filepath.Join(repoDir, ".git")); err == nil {
+		return RepoResult{Path: repoDir}, nil
+	}
+
+	// Cache miss — fall back to network fetch with warning
+	fmt.Fprintf(os.Stderr, "  Cache miss for %s, fetching...\n", ShortGitURL(gitURL))
+	return EnsureRepo(gitURL, ref)
+}
+
+// ResolveGitSourceFromCache is like ResolveGitSource but uses CacheOnlyRepo
+// to avoid network access when the cache is warm.
+func ResolveGitSourceFromCache(gs persona.GitSource) (string, *RepoResult, error) {
+	result, err := CacheOnlyRepo(gs.Git, gs.Ref)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolving %s: %w", gs.Git, err)
+	}
+
+	basePath := result.Path
+	if gs.Path != "" {
+		basePath = filepath.Join(result.Path, gs.Path)
+		if _, err := os.Stat(basePath); os.IsNotExist(err) {
+			return "", nil, fmt.Errorf("path %q not found in %s", gs.Path, gs.Git)
+		}
+	}
+
+	return basePath, &result, nil
+}
+
+// ResolveFromCache is like Resolve but uses CacheOnlyRepo to avoid network
+// access when the cache is warm. Falls back to a network fetch on cache miss.
+func ResolveFromCache(p *persona.Persona, cfg *config.Config) ([]ResolveResult, error) {
+	var results []ResolveResult
+
+	for _, inc := range p.Includes {
+		if cfg != nil {
+			if err := cfg.CheckRemoteSource(inc.Git); err != nil {
+				return nil, fmt.Errorf("include %q: %w", inc.Git, err)
+			}
+		}
+
+		basePath, repoResult, err := ResolveGitSourceFromCache(inc.GitSource)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, ResolveResult{
+			Content: ResolvedContent{
+				BasePath: basePath,
+				Paths:    inc.Pick,
+			},
+			Source: ShortGitURL(inc.Git),
+			Path:   inc.Path,
+			Cloned: repoResult.Cloned,
+			Cached: !repoResult.Cloned,
+		})
+	}
+
+	return results, nil
 }
 
 // gitHead returns the short HEAD SHA for a repo, or empty string on error.

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -564,6 +564,271 @@ func TestResolve_NilConfigAllowsAll(t *testing.T) {
 	}
 }
 
+func TestCacheOnlyRepo_CacheHit(t *testing.T) {
+	// Create a local git repo and clone it via EnsureRepo first
+	srcDir := t.TempDir()
+	runGit(t, srcDir, "init")
+	runGit(t, srcDir, "config", "user.email", "test@test.com")
+	runGit(t, srcDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(srcDir, "test.txt"), []byte("cached"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, srcDir, "add", ".")
+	runGit(t, srcDir, "commit", "-m", "init")
+
+	t.Setenv("YNH_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	// Populate cache via EnsureRepo
+	ensureResult, err := EnsureRepo(srcDir, "")
+	if err != nil {
+		t.Fatalf("EnsureRepo failed: %v", err)
+	}
+
+	// Now remove the source repo so any network fetch would fail
+	if err := os.RemoveAll(filepath.Join(srcDir, ".git")); err != nil {
+		t.Fatal(err)
+	}
+
+	// CacheOnlyRepo should return cached result without hitting the network
+	result, err := CacheOnlyRepo(srcDir, "")
+	if err != nil {
+		t.Fatalf("CacheOnlyRepo should succeed on cache hit: %v", err)
+	}
+	if result.Path != ensureResult.Path {
+		t.Errorf("expected same path %q, got %q", ensureResult.Path, result.Path)
+	}
+	if result.Cloned {
+		t.Error("expected Cloned=false for cache hit")
+	}
+
+	// Verify content is still accessible
+	data, err := os.ReadFile(filepath.Join(result.Path, "test.txt"))
+	if err != nil {
+		t.Fatalf("cached file not readable: %v", err)
+	}
+	if string(data) != "cached" {
+		t.Errorf("cached content = %q, want %q", string(data), "cached")
+	}
+}
+
+func TestCacheOnlyRepo_CacheMiss(t *testing.T) {
+	// Create a local git repo — cache is empty, so CacheOnlyRepo should clone
+	srcDir := t.TempDir()
+	runGit(t, srcDir, "init")
+	runGit(t, srcDir, "config", "user.email", "test@test.com")
+	runGit(t, srcDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(srcDir, "test.txt"), []byte("fresh"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, srcDir, "add", ".")
+	runGit(t, srcDir, "commit", "-m", "init")
+
+	t.Setenv("YNH_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	// CacheOnlyRepo with empty cache should fall back to EnsureRepo
+	result, err := CacheOnlyRepo(srcDir, "")
+	if err != nil {
+		t.Fatalf("CacheOnlyRepo should fall back to clone: %v", err)
+	}
+	if !result.Cloned {
+		t.Error("expected Cloned=true for cache miss fallback")
+	}
+
+	data, err := os.ReadFile(filepath.Join(result.Path, "test.txt"))
+	if err != nil {
+		t.Fatalf("cloned file not readable: %v", err)
+	}
+	if string(data) != "fresh" {
+		t.Errorf("cloned content = %q, want %q", string(data), "fresh")
+	}
+}
+
+func TestResolveFromCache_UsesCache(t *testing.T) {
+	// Create a local git repo with skills
+	srcDir := t.TempDir()
+	runGit(t, srcDir, "init")
+	runGit(t, srcDir, "config", "user.email", "test@test.com")
+	runGit(t, srcDir, "config", "user.name", "Test")
+	if err := os.MkdirAll(filepath.Join(srcDir, "skills", "hello"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "skills", "hello", "SKILL.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, srcDir, "add", ".")
+	runGit(t, srcDir, "commit", "-m", "init")
+
+	t.Setenv("YNH_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	// Pre-populate cache
+	if _, err := EnsureRepo(srcDir, ""); err != nil {
+		t.Fatalf("EnsureRepo failed: %v", err)
+	}
+
+	// Remove source so network access would fail
+	if err := os.RemoveAll(filepath.Join(srcDir, ".git")); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &persona.Persona{
+		Name: "test-cached",
+		Includes: []persona.Include{
+			{
+				GitSource: persona.GitSource{Git: srcDir},
+				Pick:      []string{"skills/hello"},
+			},
+		},
+	}
+
+	// ResolveFromCache should succeed from cache alone
+	results, err := ResolveFromCache(p, nil)
+	if err != nil {
+		t.Fatalf("ResolveFromCache failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Cloned {
+		t.Error("expected Cloned=false (served from cache)")
+	}
+	if !results[0].Cached {
+		t.Error("expected Cached=true")
+	}
+}
+
+func TestResolveFromCache_BlockedByAllowList(t *testing.T) {
+	cfg := &config.Config{
+		AllowedRemoteSources: []string{
+			"github.com/trusted-org/*",
+		},
+	}
+
+	p := &persona.Persona{
+		Name: "test-blocked-cache",
+		Includes: []persona.Include{
+			{
+				GitSource: persona.GitSource{Git: "github.com/untrusted-org/repo"},
+			},
+		},
+	}
+
+	_, err := ResolveFromCache(p, cfg)
+	if err == nil {
+		t.Fatal("expected error for blocked remote source")
+	}
+	if !strings.Contains(err.Error(), "not in the allowed sources list") {
+		t.Errorf("error should mention allow list, got: %v", err)
+	}
+}
+
+func TestResolveGitSourceFromCache_WithPath(t *testing.T) {
+	// Create a repo with a subdirectory
+	srcDir := t.TempDir()
+	runGit(t, srcDir, "init")
+	runGit(t, srcDir, "config", "user.email", "test@test.com")
+	runGit(t, srcDir, "config", "user.name", "Test")
+	if err := os.MkdirAll(filepath.Join(srcDir, "sub", "skills", "s1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "sub", "skills", "s1", "SKILL.md"), []byte("s1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, srcDir, "add", ".")
+	runGit(t, srcDir, "commit", "-m", "init")
+
+	t.Setenv("YNH_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	// Pre-populate cache
+	if _, err := EnsureRepo(srcDir, ""); err != nil {
+		t.Fatalf("EnsureRepo failed: %v", err)
+	}
+
+	// Resolve with valid path
+	gs := persona.GitSource{Git: srcDir, Path: "sub"}
+	basePath, _, err := ResolveGitSourceFromCache(gs)
+	if err != nil {
+		t.Fatalf("ResolveGitSourceFromCache failed: %v", err)
+	}
+	skillPath := filepath.Join(basePath, "skills", "s1", "SKILL.md")
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Errorf("skill not found at resolved path: %v", err)
+	}
+
+	// Resolve with invalid path
+	gsBad := persona.GitSource{Git: srcDir, Path: "nonexistent"}
+	_, _, err = ResolveGitSourceFromCache(gsBad)
+	if err == nil {
+		t.Fatal("expected error for nonexistent path")
+	}
+}
+
+func TestResolveFromCache_WithPath(t *testing.T) {
+	// Create a monorepo-style repo
+	srcDir := t.TempDir()
+	runGit(t, srcDir, "init")
+	runGit(t, srcDir, "config", "user.email", "test@test.com")
+	runGit(t, srcDir, "config", "user.name", "Test")
+	if err := os.MkdirAll(filepath.Join(srcDir, "pkg", "skills", "deploy"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "pkg", "skills", "deploy", "SKILL.md"), []byte("deploy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, srcDir, "add", ".")
+	runGit(t, srcDir, "commit", "-m", "init")
+
+	t.Setenv("YNH_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	// Pre-populate cache
+	if _, err := EnsureRepo(srcDir, ""); err != nil {
+		t.Fatalf("EnsureRepo failed: %v", err)
+	}
+
+	p := &persona.Persona{
+		Name: "test-path-cache",
+		Includes: []persona.Include{
+			{
+				GitSource: persona.GitSource{Git: srcDir, Path: "pkg"},
+				Pick:      []string{"skills/deploy"},
+			},
+		},
+	}
+
+	results, err := ResolveFromCache(p, nil)
+	if err != nil {
+		t.Fatalf("ResolveFromCache failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Path != "pkg" {
+		t.Errorf("expected Path=%q, got %q", "pkg", results[0].Path)
+	}
+}
+
+func TestShortGitURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"github.com/eyelock/assistants", "eyelock/assistants"},
+		{"/tmp/local", "/tmp/local"},
+		{"./relative", "./relative"},
+		{"solo", "solo"},
+	}
+	for _, tt := range tests {
+		got := ShortGitURL(tt.input)
+		if got != tt.want {
+			t.Errorf("ShortGitURL(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	gitArgs := append([]string{"-C", dir}, args...)


### PR DESCRIPTION
## Summary

- `ynh install` now pre-fetches all Git includes and delegates into `~/.ynh/cache/`, failing fast if any ref is unreachable
- `ynh run` uses cache-only resolution (no network access); falls back to fetch on cache miss with a warning
- `ynh update` unchanged — still does a full network fetch
- Run log output now shows the pick list for each include (e.g. `Cached eyelock/assistants → skills/dev [skills/dev-project, skills/dev-quality]`)

## Test plan

- [x] New unit tests for `CacheOnlyRepo` (cache hit, cache miss), `ResolveFromCache` (cache, allow-list, path), `ResolveGitSourceFromCache` (path valid/invalid), `ShortGitURL`
- [x] Resolver package coverage: 82.7% → 87.3%
- [x] `make check` passes (format, lint, test, build)
- [ ] Manual: Tutorial 3 (T3.1–T3.12) — composition with remote includes
- [ ] Manual: Tutorial 4 (T4.1–T4.5) — delegation with remote delegates

🤖 Generated with [Claude Code](https://claude.com/claude-code)