### PR TITLE
feat: ynh image command and Docker optimizations for baked persona images

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,7 @@ ynh is a persona manager for AI coding assistants (Claude Code, OpenAI Codex, Cu
 
 ## Two Binaries
 
-- **`ynh`** (`cmd/ynh/`) — Persona manager: install, run, update, uninstall
+- **`ynh`** (`cmd/ynh/`) — Persona manager: init, install, uninstall, update, run, ls, info, vendors, search, registry, image, status, prune
 - **`ynd`** (`cmd/ynd/`) — Developer tools: create, lint, validate, fmt, compress, inspect
 
 Both built by `make build`, released together via goreleaser (single `v*` tag).
@@ -70,4 +70,5 @@ Follows the [Agent Skills](https://agentskills.io) open standard. See `docs/skil
 | Variable | Default | Used by |
 |----------|---------|---------|
 | `YNH_HOME` | `~/.ynh` | ynh |
+| `YNH_VENDOR` | _(none)_ | ynh run — override default vendor (between -v flag and persona default) |
 | `YND_BACKUP_DIR` | `~/.ynd/backups` | ynd compress |

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,8 +18,8 @@ ynh is a packaging and distribution tool. It has no runtime component - the AI v
 ### Package Structure
 
 ```
-cmd/ynh/                  CLI entry point: persona manager (install, run, update, search, registry)
-cmd/ynd/                  CLI entry point: developer tools (create, lint, validate, fmt, compress, export, marketplace)
+cmd/ynh/                  CLI entry point: persona manager (init, install, uninstall, update, run, ls, info, vendors, search, registry, image, status, prune)
+cmd/ynd/                  CLI entry point: developer tools (create, lint, validate, fmt, compress, export, marketplace, inspect)
 internal/
   config/                 Global config (~/.ynh/) and path management
   persona/                Persona loading, format detection, name validation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -20,6 +21,14 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: goreleaser/goreleaser-action@v7
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,6 +52,36 @@ changelog:
       - "^test:"
       - "^ci:"
 
+dockers:
+  - image_templates:
+      - "ghcr.io/eyelock/ynh:{{ .Version }}-amd64"
+    use: buildx
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=VERSION={{ .Version }}"
+    goos: linux
+    goarch: amd64
+  - image_templates:
+      - "ghcr.io/eyelock/ynh:{{ .Version }}-arm64"
+    use: buildx
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--build-arg=VERSION={{ .Version }}"
+    goos: linux
+    goarch: arm64
+
+docker_manifests:
+  - name_template: "ghcr.io/eyelock/ynh:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/eyelock/ynh:{{ .Version }}-amd64"
+      - "ghcr.io/eyelock/ynh:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/eyelock/ynh:latest"
+    image_templates:
+      - "ghcr.io/eyelock/ynh:{{ .Version }}-amd64"
+      - "ghcr.io/eyelock/ynh:{{ .Version }}-arm64"
+
 brews:
   - repository:
       owner: eyelock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # Stage 1: Build ynh and ynd
 FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
@@ -22,30 +24,42 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v \
     -ldflags "-s -w -X github.com/eyelock/ynh/internal/config.Version=${VERSION}" \
     -o /out/ynd ./cmd/ynd
 
-# Stage 2: Runtime with vendor CLIs
-FROM node:22-alpine
-
-RUN apk add --no-cache git openssh-client tini bash curl
-
-# Pin versions for reproducible builds. Update these periodically.
+# Stage 2a: Claude Code CLI (parallel)
+FROM node:22-alpine AS claude-cli
 ARG CLAUDE_CODE_VERSION=2.1.76
-ARG CODEX_VERSION=0.114.0
-RUN npm install -g \
-    "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
-    "@openai/codex@${CODEX_VERSION}" && \
-    npm cache clean --force
+RUN --mount=type=cache,target=/root/.npm \
+    npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
-# Install Cursor Agent CLI and copy binary into PATH.
+# Stage 2b: Codex CLI (parallel)
+FROM node:22-alpine AS codex-cli
+ARG CODEX_VERSION=0.114.0
+RUN --mount=type=cache,target=/root/.npm \
+    npm install -g "@openai/codex@${CODEX_VERSION}"
+
+# Stage 2c: Cursor Agent CLI (parallel)
+FROM alpine AS cursor-cli
+RUN apk add --no-cache curl bash
 # NOTE: curl|bash with no checksum verification — Cursor does not publish
 # checksums. Pin by auditing the install script if reproducibility is critical.
 RUN curl https://cursor.com/install -fsS | bash && \
     cp -L /root/.local/bin/agent /usr/local/bin/agent && \
-    chmod 755 /usr/local/bin/agent && \
-    rm -rf /root/.local/share/cursor-agent /root/.local/bin/agent
+    chmod 755 /usr/local/bin/agent
+
+# Stage 3: Runtime — assemble everything
+FROM node:22-alpine
+
+RUN apk add --no-cache git openssh-client tini bash curl
+
+# Vendor CLIs from parallel stages (scoped dirs, no overlap)
+COPY --from=claude-cli /usr/local/lib/node_modules/@anthropic-ai/ /usr/local/lib/node_modules/@anthropic-ai/
+COPY --from=claude-cli /usr/local/bin/claude /usr/local/bin/claude
+COPY --from=codex-cli  /usr/local/lib/node_modules/@openai/ /usr/local/lib/node_modules/@openai/
+COPY --from=codex-cli  /usr/local/bin/codex /usr/local/bin/codex
+COPY --from=cursor-cli /usr/local/bin/agent /usr/local/bin/agent
 
 # Copy ynh binaries from builder
-COPY --from=builder /out/ynh /usr/local/bin/ynh
-COPY --from=builder /out/ynd /usr/local/bin/ynd
+COPY --link --from=builder /out/ynh /usr/local/bin/ynh
+COPY --link --from=builder /out/ynd /usr/local/bin/ynd
 
 # Configurable UID/GID to match host user (avoids permission issues with bind mounts).
 # node:22-alpine already uses GID 1000 for 'node', so we try the requested GID
@@ -73,6 +87,8 @@ USER ynh
 
 # Image metadata — versions of all packaged binaries
 ARG VERSION=dev
+ARG CLAUDE_CODE_VERSION=2.1.76
+ARG CODEX_VERSION=0.114.0
 LABEL org.opencontainers.image.title="ynh" \
       org.opencontainers.image.description="Persona manager for AI coding assistants" \
       org.opencontainers.image.source="https://github.com/eyelock/ynh" \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean deps install build test test-coverage format lint check run docs help
+.PHONY: clean deps install build test test-coverage format lint check run docs help docker-build docker-push
 
 BINARY_NAME := ynh
 BINARY_NAME_DEV := ynd
@@ -70,5 +70,15 @@ docs: ## Serve docs locally (requires npx)
 	@command -v npx >/dev/null 2>&1 || { echo "npx not found. Install Node.js to browse docs locally."; exit 1; }
 	@echo "Starting docs server at http://localhost:3000"
 	@npx --yes docsify-cli serve docs
+
+DOCKER_IMAGE := ghcr.io/eyelock/ynh
+DOCKER_TAG := $(VERSION)
+
+docker-build: ## Build base Docker image
+	docker build --build-arg VERSION=$(VERSION) -t $(DOCKER_IMAGE):$(DOCKER_TAG) -t $(DOCKER_IMAGE):latest .
+
+docker-push: ## Push base Docker image to GHCR
+	docker push $(DOCKER_IMAGE):$(DOCKER_TAG)
+	docker push $(DOCKER_IMAGE):latest
 
 check: deps format lint test build ## Run full CI pipeline

--- a/cmd/ynh/image.go
+++ b/cmd/ynh/image.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"text/template"
+
+	"github.com/eyelock/ynh/internal/assembler"
+	"github.com/eyelock/ynh/internal/config"
+	"github.com/eyelock/ynh/internal/persona"
+	"github.com/eyelock/ynh/internal/resolver"
+	"github.com/eyelock/ynh/internal/vendor"
+)
+
+// imageTemplateData holds the data passed to the persona Dockerfile template.
+type imageTemplateData struct {
+	Base          string // e.g. ghcr.io/eyelock/ynh:latest
+	Name          string // persona name
+	DefaultVendor string // e.g. "claude"
+	YnhVersion    string // version of ynh that assembled the image
+}
+
+// imageDockerfileTmpl is the Dockerfile template for persona images.
+// It layers pre-assembled vendor layouts on top of the base ynh image.
+var imageDockerfileTmpl = template.Must(template.New("Dockerfile").Parse(`FROM {{.Base}}
+
+# Pre-assembled vendor layouts (all three, ready to use)
+COPY --link --chown=ynh:ynh vendors/claude/ /home/ynh/.ynh/run/{{.Name}}/claude/
+COPY --link --chown=ynh:ynh vendors/codex/ /home/ynh/.ynh/run/{{.Name}}/codex/
+COPY --link --chown=ynh:ynh vendors/cursor/ /home/ynh/.ynh/run/{{.Name}}/cursor/
+
+# Persona source (metadata for ynh run)
+COPY --link --chown=ynh:ynh persona/ /home/ynh/.ynh/personas/{{.Name}}/
+
+# Default vendor (override: docker run -e YNH_VENDOR=codex)
+ENV YNH_VENDOR={{.DefaultVendor}}
+
+# Baked entrypoint — just pass the prompt as CMD
+ENTRYPOINT ["tini", "-s", "--", "ynh", "run", "{{.Name}}"]
+CMD []
+
+LABEL dev.ynh.persona="{{.Name}}" \
+      dev.ynh.persona.default-vendor="{{.DefaultVendor}}" \
+      dev.ynh.assembled-by="{{.YnhVersion}}"
+`))
+
+// imageArgs holds parsed flags for the image command.
+type imageArgs struct {
+	name   string
+	tag    string
+	base   string
+	dryRun bool
+	from   string
+	path   string
+}
+
+// parseImageArgs parses flags for the image command.
+func parseImageArgs(args []string) (imageArgs, error) {
+	var ia imageArgs
+	ia.base = "ghcr.io/eyelock/ynh:latest"
+
+	var remaining []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--tag":
+			if i+1 >= len(args) {
+				return ia, fmt.Errorf("--tag requires a value")
+			}
+			i++
+			ia.tag = args[i]
+		case "--base":
+			if i+1 >= len(args) {
+				return ia, fmt.Errorf("--base requires a value")
+			}
+			i++
+			ia.base = args[i]
+		case "--dry-run":
+			ia.dryRun = true
+		case "--from":
+			if i+1 >= len(args) {
+				return ia, fmt.Errorf("--from requires a value")
+			}
+			i++
+			ia.from = args[i]
+		case "--path":
+			if i+1 >= len(args) {
+				return ia, fmt.Errorf("--path requires a value")
+			}
+			i++
+			ia.path = args[i]
+		default:
+			remaining = append(remaining, args[i])
+		}
+	}
+
+	if len(remaining) < 1 {
+		return ia, fmt.Errorf("usage: ynh image <name> [--tag <tag>] [--base <image>] [--from <source>] [--path <subdir>] [--dry-run]")
+	}
+	ia.name = remaining[0]
+
+	if ia.tag == "" {
+		ia.tag = "ynh-" + ia.name + ":latest"
+	}
+
+	return ia, nil
+}
+
+// generateDockerfile renders the persona Dockerfile template.
+func generateDockerfile(data imageTemplateData) (string, error) {
+	var buf bytes.Buffer
+	if err := imageDockerfileTmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("rendering Dockerfile template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// cmdImage builds a Docker image with a persona baked in.
+func cmdImage(args []string) error {
+	ia, err := parseImageArgs(args)
+	if err != nil {
+		return err
+	}
+
+	if err := config.EnsureDirs(); err != nil {
+		return err
+	}
+
+	// Load config for remote source checking
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	// Load persona
+	var p *persona.Persona
+	var personaSrcDir string
+
+	if ia.from != "" {
+		// Build from source (Git or local)
+		resolved, err := resolveInstallSource(ia.from, ia.path, cfg)
+		if err != nil {
+			return fmt.Errorf("resolving source: %w", err)
+		}
+
+		source := ia.from
+		pathFlag := ia.path
+		if resolved.gitURL != "" {
+			source = resolved.gitURL
+			if resolved.path != "" {
+				pathFlag = resolved.path
+			}
+		}
+
+		if isLocalPath(source) {
+			absPath, err := filepath.Abs(source)
+			if err != nil {
+				return err
+			}
+			personaSrcDir = absPath
+		} else {
+			if err := cfg.CheckRemoteSource(source); err != nil {
+				return err
+			}
+			result, err := resolver.EnsureRepo(source, "")
+			if err != nil {
+				return fmt.Errorf("resolving %s: %w", source, err)
+			}
+			personaSrcDir = result.Path
+		}
+
+		if pathFlag != "" {
+			personaSrcDir = filepath.Join(personaSrcDir, pathFlag)
+			if _, err := os.Stat(personaSrcDir); os.IsNotExist(err) {
+				return fmt.Errorf("path %q not found in source", pathFlag)
+			}
+		}
+
+		p, err = persona.LoadPluginDir(personaSrcDir)
+		if err != nil {
+			return fmt.Errorf("loading persona from source: %w", err)
+		}
+	} else {
+		// Load from installed personas
+		p, err = persona.Load(ia.name)
+		if err != nil {
+			return fmt.Errorf("persona %q not found: %w", ia.name, err)
+		}
+		personaSrcDir = persona.InstalledDir(ia.name)
+	}
+
+	// Create temp build context
+	tmpDir, err := os.MkdirTemp("", "ynh-image-*")
+	if err != nil {
+		return fmt.Errorf("creating build context: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Copy persona source into build context
+	personaDst := filepath.Join(tmpDir, "persona")
+	if err := assembler.CopyDir(personaSrcDir, personaDst); err != nil {
+		return fmt.Errorf("copying persona source: %w", err)
+	}
+
+	// Resolve includes (with remote source allow-list check)
+	resolved, err := resolver.Resolve(p, cfg)
+	if err != nil {
+		return fmt.Errorf("resolving includes: %w", err)
+	}
+
+	// Check delegates against remote source allow-list
+	for _, del := range p.DelegatesTo {
+		if err := cfg.CheckRemoteSource(del.Git); err != nil {
+			return fmt.Errorf("delegate %q: %w", del.Git, err)
+		}
+	}
+
+	// Extract ResolvedContent
+	var content []resolver.ResolvedContent
+	for _, r := range resolved {
+		content = append(content, r.Content)
+	}
+	localContent := resolver.ResolvedContent{
+		BasePath: personaSrcDir,
+	}
+	content = append(content, localContent)
+
+	// Assemble vendor layouts for all vendors
+	vendorsDir := filepath.Join(tmpDir, "vendors")
+	for _, name := range vendor.Available() {
+		adapter, err := vendor.Get(name)
+		if err != nil {
+			return fmt.Errorf("getting vendor %q: %w", name, err)
+		}
+
+		vendorDir := filepath.Join(vendorsDir, adapter.Name())
+		if err := assembler.AssembleTo(vendorDir, adapter, content); err != nil {
+			return fmt.Errorf("assembling %s layout: %w", adapter.Name(), err)
+		}
+
+		if err := assembler.AssembleDelegates(vendorDir, adapter, p.DelegatesTo); err != nil {
+			return fmt.Errorf("assembling %s delegates: %w", adapter.Name(), err)
+		}
+	}
+
+	// Determine default vendor
+	defaultVendor := p.DefaultVendor
+	if defaultVendor == "" {
+		defaultVendor = "claude"
+	}
+
+	// Generate Dockerfile
+	data := imageTemplateData{
+		Base:          ia.base,
+		Name:          p.Name,
+		DefaultVendor: defaultVendor,
+		YnhVersion:    config.Version,
+	}
+
+	dockerfile, err := generateDockerfile(data)
+	if err != nil {
+		return err
+	}
+
+	if ia.dryRun {
+		fmt.Print(dockerfile)
+		return nil
+	}
+
+	// Write Dockerfile to build context
+	if err := os.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
+		return fmt.Errorf("writing Dockerfile: %w", err)
+	}
+
+	// Verify docker is available
+	if _, err := exec.LookPath("docker"); err != nil {
+		return fmt.Errorf("docker not found in PATH: install Docker to build persona images")
+	}
+
+	// Build image
+	fmt.Fprintf(os.Stderr, "Building persona image %s...\n", ia.tag)
+	cmd := exec.Command("docker", "build", "-t", ia.tag, tmpDir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker build failed: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "\nPersona image built: %s\n", ia.tag)
+	fmt.Fprintf(os.Stderr, "Run: docker run --rm -v $(pwd):/workspace -e ANTHROPIC_API_KEY %s -- \"your prompt\"\n", ia.tag)
+	return nil
+}

--- a/cmd/ynh/image_test.go
+++ b/cmd/ynh/image_test.go
@@ -1,0 +1,341 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseImageArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantName string
+		wantTag  string
+		wantBase string
+		wantDry  bool
+		wantFrom string
+		wantPath string
+		wantErr  bool
+	}{
+		{
+			name:     "name only",
+			args:     []string{"david"},
+			wantName: "david",
+			wantTag:  "ynh-david:latest",
+			wantBase: "ghcr.io/eyelock/ynh:latest",
+		},
+		{
+			name:     "with tag",
+			args:     []string{"david", "--tag", "ghcr.io/org/david:v1"},
+			wantName: "david",
+			wantTag:  "ghcr.io/org/david:v1",
+			wantBase: "ghcr.io/eyelock/ynh:latest",
+		},
+		{
+			name:     "with base",
+			args:     []string{"david", "--base", "my-base:1.0"},
+			wantName: "david",
+			wantTag:  "ynh-david:latest",
+			wantBase: "my-base:1.0",
+		},
+		{
+			name:     "dry run",
+			args:     []string{"david", "--dry-run"},
+			wantName: "david",
+			wantTag:  "ynh-david:latest",
+			wantBase: "ghcr.io/eyelock/ynh:latest",
+			wantDry:  true,
+		},
+		{
+			name:     "from source",
+			args:     []string{"david", "--from", "github.com/org/personas"},
+			wantName: "david",
+			wantTag:  "ynh-david:latest",
+			wantBase: "ghcr.io/eyelock/ynh:latest",
+			wantFrom: "github.com/org/personas",
+		},
+		{
+			name:     "from with path",
+			args:     []string{"david", "--from", "github.com/org/monorepo", "--path", "personas/david"},
+			wantName: "david",
+			wantTag:  "ynh-david:latest",
+			wantBase: "ghcr.io/eyelock/ynh:latest",
+			wantFrom: "github.com/org/monorepo",
+			wantPath: "personas/david",
+		},
+		{
+			name:     "all flags",
+			args:     []string{"--tag", "custom:v2", "--base", "custom-base:1", "--from", "github.com/org/repo", "--path", "sub", "--dry-run", "david"},
+			wantName: "david",
+			wantTag:  "custom:v2",
+			wantBase: "custom-base:1",
+			wantDry:  true,
+			wantFrom: "github.com/org/repo",
+			wantPath: "sub",
+		},
+		{
+			name:    "no args",
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			name:    "tag without value",
+			args:    []string{"david", "--tag"},
+			wantErr: true,
+		},
+		{
+			name:    "base without value",
+			args:    []string{"david", "--base"},
+			wantErr: true,
+		},
+		{
+			name:    "from without value",
+			args:    []string{"david", "--from"},
+			wantErr: true,
+		},
+		{
+			name:    "path without value",
+			args:    []string{"david", "--path"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseImageArgs(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.name != tt.wantName {
+				t.Errorf("name = %q, want %q", got.name, tt.wantName)
+			}
+			if got.tag != tt.wantTag {
+				t.Errorf("tag = %q, want %q", got.tag, tt.wantTag)
+			}
+			if got.base != tt.wantBase {
+				t.Errorf("base = %q, want %q", got.base, tt.wantBase)
+			}
+			if got.dryRun != tt.wantDry {
+				t.Errorf("dryRun = %v, want %v", got.dryRun, tt.wantDry)
+			}
+			if got.from != tt.wantFrom {
+				t.Errorf("from = %q, want %q", got.from, tt.wantFrom)
+			}
+			if got.path != tt.wantPath {
+				t.Errorf("path = %q, want %q", got.path, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestGenerateDockerfile(t *testing.T) {
+	data := imageTemplateData{
+		Base:          "ghcr.io/eyelock/ynh:latest",
+		Name:          "david",
+		DefaultVendor: "claude",
+		YnhVersion:    "v1.2.3",
+	}
+
+	got, err := generateDockerfile(data)
+	if err != nil {
+		t.Fatalf("generateDockerfile failed: %v", err)
+	}
+
+	// Check key lines are present
+	checks := []string{
+		"FROM ghcr.io/eyelock/ynh:latest",
+		"vendors/claude/ /home/ynh/.ynh/run/david/claude/",
+		"vendors/codex/ /home/ynh/.ynh/run/david/codex/",
+		"vendors/cursor/ /home/ynh/.ynh/run/david/cursor/",
+		"persona/ /home/ynh/.ynh/personas/david/",
+		"ENV YNH_VENDOR=claude",
+		`ENTRYPOINT ["tini", "-s", "--", "ynh", "run", "david"]`,
+		`dev.ynh.persona="david"`,
+		`dev.ynh.persona.default-vendor="claude"`,
+		`dev.ynh.assembled-by="v1.2.3"`,
+	}
+
+	for _, want := range checks {
+		if !strings.Contains(got, want) {
+			t.Errorf("Dockerfile missing %q\n\nGot:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateDockerfile_CustomBase(t *testing.T) {
+	data := imageTemplateData{
+		Base:          "my-registry.io/ynh:v2",
+		Name:          "test",
+		DefaultVendor: "claude",
+	}
+
+	got, err := generateDockerfile(data)
+	if err != nil {
+		t.Fatalf("generateDockerfile failed: %v", err)
+	}
+
+	if !strings.Contains(got, "FROM my-registry.io/ynh:v2") {
+		t.Errorf("Dockerfile should use custom base image\n\nGot:\n%s", got)
+	}
+}
+
+func TestGenerateDockerfile_CustomVendor(t *testing.T) {
+	data := imageTemplateData{
+		Base:          "ghcr.io/eyelock/ynh:latest",
+		Name:          "test",
+		DefaultVendor: "codex",
+	}
+
+	got, err := generateDockerfile(data)
+	if err != nil {
+		t.Fatalf("generateDockerfile failed: %v", err)
+	}
+
+	if !strings.Contains(got, "ENV YNH_VENDOR=codex") {
+		t.Errorf("Dockerfile should set YNH_VENDOR=codex\n\nGot:\n%s", got)
+	}
+}
+
+func TestCmdImage_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	// Create a minimal installed persona
+	installTestPersona(t, "drytest")
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := cmdImage([]string{"drytest", "--dry-run"})
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("cmdImage --dry-run failed: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	if !strings.Contains(output, "FROM ghcr.io/eyelock/ynh:latest") {
+		t.Errorf("dry-run should print Dockerfile with FROM line\n\nGot:\n%s", output)
+	}
+	if !strings.Contains(output, "drytest") {
+		t.Errorf("dry-run should contain persona name\n\nGot:\n%s", output)
+	}
+}
+
+func TestCmdImage_NoArgs(t *testing.T) {
+	err := cmdImage([]string{})
+	if err == nil {
+		t.Fatal("expected error for no args")
+	}
+	if !strings.Contains(err.Error(), "usage:") {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
+func TestCmdImage_PersonaNotFound(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	err := cmdImage([]string{"nonexistent", "--dry-run"})
+	if err == nil {
+		t.Fatal("expected error for missing persona")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestCmdImage_NoDocker(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	// Create a minimal installed persona
+	installTestPersona(t, "nodockertest")
+
+	// Set PATH to empty to ensure docker isn't found
+	t.Setenv("PATH", t.TempDir())
+
+	err := cmdImage([]string{"nodockertest"})
+	if err == nil {
+		t.Fatal("expected error when docker not in PATH")
+	}
+	if !strings.Contains(err.Error(), "docker not found") {
+		t.Errorf("expected 'docker not found' error, got: %v", err)
+	}
+}
+
+func TestImageAssembly_AllVendors(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	// Create a minimal installed persona
+	installTestPersona(t, "assemblytest")
+
+	// Capture stdout (dry-run prints to stdout)
+	old := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := cmdImage([]string{"assemblytest", "--dry-run"})
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("cmdImage failed: %v", err)
+	}
+
+	// The temp dir is cleaned up by cmdImage, but we can verify via dry-run
+	// that the Dockerfile references all three vendors. The actual assembly
+	// is tested transitively through dry-run producing valid output.
+}
+
+func TestPreAssembledRunDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a pre-assembled vendor layout
+	vendorDir := filepath.Join(dir, "run", "testpersona", "claude")
+	if err := os.MkdirAll(vendorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a marker file
+	if err := os.WriteFile(filepath.Join(vendorDir, "marker.txt"), []byte("pre-assembled"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check detection: the directory should exist
+	runDir := filepath.Join(dir, "run", "testpersona")
+	vendorRunDir := filepath.Join(runDir, "claude")
+	info, err := os.Stat(vendorRunDir)
+	if err != nil {
+		t.Fatalf("pre-assembled dir should exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("pre-assembled path should be a directory")
+	}
+
+	// Verify marker file is accessible at the expected path
+	data, err := os.ReadFile(filepath.Join(vendorRunDir, "marker.txt"))
+	if err != nil {
+		t.Fatalf("marker file not accessible: %v", err)
+	}
+	if string(data) != "pre-assembled" {
+		t.Errorf("marker content = %q, want %q", string(data), "pre-assembled")
+	}
+}

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -48,6 +48,8 @@ func main() {
 		err = cmdSearch(os.Args[2:])
 	case "registry":
 		err = cmdRegistry(os.Args[2:])
+	case "image":
+		err = cmdImage(os.Args[2:])
 	case "prune":
 		err = cmdPrune()
 	case "version", "--version":
@@ -86,6 +88,7 @@ Commands:
   registry list                Show configured registries
   registry remove <url>        Remove a registry
   registry update              Refresh all cached registries
+  image <name> [flags]         Build a Docker image with a persona baked in
   status                       Show symlink installations across projects
   prune                        Clean orphaned symlink installations
   version                      Print version
@@ -492,20 +495,29 @@ func cmdRun(args []string) error {
 	// We use a stable path instead of a temp dir because syscall.Exec
 	// replaces this process — deferred cleanup would never run.
 	runDir := filepath.Join(config.RunDir(), name)
-	if err := assembler.AssembleTo(runDir, adapter, content); err != nil {
-		return fmt.Errorf("assembling config: %w", err)
-	}
-
-	// Check delegates against remote source allow-list
-	for _, del := range p.DelegatesTo {
-		if err := cfg.CheckRemoteSource(del.Git); err != nil {
-			return fmt.Errorf("delegate %q: %w", del.Git, err)
+	vendorRunDir := filepath.Join(runDir, vendorName)
+	if info, err := os.Stat(vendorRunDir); err == nil && info.IsDir() {
+		// Pre-assembled layout (baked persona image) — use directly.
+		// Skip AssembleTo, delegate allow-list check, AND AssembleDelegates —
+		// everything was vetted and assembled at image build time.
+		runDir = vendorRunDir
+	} else {
+		// Normal host flow — assemble now
+		if err := assembler.AssembleTo(runDir, adapter, content); err != nil {
+			return fmt.Errorf("assembling config: %w", err)
 		}
-	}
 
-	// Assemble delegate personas as agent files
-	if err := assembler.AssembleDelegates(runDir, adapter, p.DelegatesTo); err != nil {
-		return fmt.Errorf("assembling delegates: %w", err)
+		// Check delegates against remote source allow-list
+		for _, del := range p.DelegatesTo {
+			if err := cfg.CheckRemoteSource(del.Git); err != nil {
+				return fmt.Errorf("delegate %q: %w", del.Git, err)
+			}
+		}
+
+		// Assemble delegate personas as agent files
+		if err := assembler.AssembleDelegates(runDir, adapter, p.DelegatesTo); err != nil {
+			return fmt.Errorf("assembling delegates: %w", err)
+		}
 	}
 
 	// Dispatch based on action.
@@ -814,10 +826,13 @@ func cmdVendors() {
 	_ = w.Flush()
 }
 
-// resolveVendor picks the vendor: CLI flag > persona default > global config.
+// resolveVendor picks the vendor: CLI flag > YNH_VENDOR env > persona default > global config.
 func resolveVendor(flag string, p *persona.Persona) (string, error) {
 	if flag != "" {
 		return flag, nil
+	}
+	if v := os.Getenv("YNH_VENDOR"); v != "" {
+		return v, nil
 	}
 	if p.DefaultVendor != "" {
 		return p.DefaultVendor, nil
@@ -831,7 +846,7 @@ func resolveVendor(flag string, p *persona.Persona) (string, error) {
 		return cfg.DefaultVendor, nil
 	}
 
-	return "", fmt.Errorf("no vendor specified (use -v flag, persona default_vendor, or global config)")
+	return "", fmt.Errorf("no vendor specified (use -v flag, YNH_VENDOR env var, persona default_vendor, or global config)")
 }
 
 // parseRunArgs separates ynh's own flags from vendor pass-through args and the prompt.

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -181,6 +181,57 @@ func TestResolveVendor_GlobalConfig(t *testing.T) {
 	}
 }
 
+func TestResolveVendor_EnvVar(t *testing.T) {
+	t.Setenv("YNH_VENDOR", "codex")
+
+	p := &persona.Persona{
+		Name:          "test",
+		DefaultVendor: "claude",
+	}
+
+	got, err := resolveVendor("", p)
+	if err != nil {
+		t.Fatalf("resolveVendor failed: %v", err)
+	}
+	if got != "codex" {
+		t.Errorf("got %q, want %q", got, "codex")
+	}
+}
+
+func TestResolveVendor_FlagBeatsEnvVar(t *testing.T) {
+	t.Setenv("YNH_VENDOR", "codex")
+
+	p := &persona.Persona{
+		Name:          "test",
+		DefaultVendor: "cursor",
+	}
+
+	got, err := resolveVendor("claude", p)
+	if err != nil {
+		t.Fatalf("resolveVendor failed: %v", err)
+	}
+	if got != "claude" {
+		t.Errorf("got %q, want %q", got, "claude")
+	}
+}
+
+func TestResolveVendor_EnvVarFallthrough(t *testing.T) {
+	t.Setenv("YNH_VENDOR", "")
+
+	p := &persona.Persona{
+		Name:          "test",
+		DefaultVendor: "codex",
+	}
+
+	got, err := resolveVendor("", p)
+	if err != nil {
+		t.Fatalf("resolveVendor failed: %v", err)
+	}
+	if got != "codex" {
+		t.Errorf("got %q, want %q", got, "codex")
+	}
+}
+
 func TestGenerateLauncher(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   ynh:
+    image: ghcr.io/eyelock/ynh:latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,7 @@ Add skills, agents, rules, and commands to the persona directory. Pull from Git 
 - **[Artifacts Guide](artifacts.md)** - Skills, agents, rules, commands, and project instructions
 - **[Vendor Support](vendors.md)** - Claude, Codex, Cursor - capabilities and launch strategies
 - **[Agent Skills Standard](skills-standard.md)** - Cross-platform spec, frontmatter fields, catalog budget, discovery paths
-- **[Tutorials](tutorial/README.md)** - Progressive tutorials from first persona to marketplace generation
-- **[Manual Test Plan](tutorial/manual-test-plan.md)** - 66 tests covering every feature
+- **[Docker](docker.md)** - Run personas in containers, build persona appliance images for CI/CD
+- **[Tutorials](tutorial/README.md)** - Progressive tutorials from first persona to Docker images
+- **[Manual Test Plan](tutorial/manual-test-plan.md)** - Tests covering every feature
 - **[ynd Developer Tools](ynd.md)** - CLI for scaffolding, linting, formatting, compressing, inspecting, exporting, and marketplace building

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -18,6 +18,7 @@
   * [6. Marketplace](tutorial/06-marketplace.md)
   * [7. Registry & Discovery](tutorial/07-registry-and-discovery.md)
   * [8. Developer Tools](tutorial/08-developer-tools.md)
+  * [9. Docker Images](tutorial/09-docker-image.md)
   * [Manual Test Plan](tutorial/manual-test-plan.md)
 
 * **Project**

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -21,6 +21,88 @@ docker compose run --rm ynh install github.com/user/my-persona
 docker compose run --rm ynh install github.com/org/assistants --path personas/david
 ```
 
+## Base Image
+
+The base runtime image `ghcr.io/eyelock/ynh:latest` ships with all vendor CLIs pre-installed (Claude Code, Codex, Cursor). It's published automatically on each release via goreleaser.
+
+```bash
+# Pull the pre-built base (skip local build entirely)
+docker pull ghcr.io/eyelock/ynh:latest
+
+# Or use docker compose (pulls if available, builds if not)
+docker compose up
+```
+
+The `docker-compose.yml` specifies both `image:` and `build:` — `docker compose up` uses the pre-built image if pulled, `docker compose build` builds locally.
+
+## Persona Images
+
+Build a self-contained Docker image with a specific persona baked in using `ynh image`:
+
+```bash
+# Build from an installed persona
+ynh image david --tag ghcr.io/org/persona-david:latest
+
+# Build from a Git source
+ynh image david --from github.com/org/personas --tag persona-david:latest
+
+# Build from a monorepo subdirectory
+ynh image david --from github.com/org/monorepo --path personas/david
+
+# Preview the generated Dockerfile without building
+ynh image david --dry-run
+
+# Use a custom base image
+ynh image david --base my-registry.io/ynh:v2
+```
+
+The persona image pre-assembles vendor layouts for all three vendors at build time. At runtime, `ynh run` detects the pre-assembled layout and skips assembly entirely.
+
+### Running Persona Images
+
+```bash
+# Basic run (default vendor from persona config)
+docker run --rm -v $(pwd):/workspace -e ANTHROPIC_API_KEY \
+  persona-david:latest -- "fix this bug"
+
+# Switch vendor at runtime
+docker run --rm -v $(pwd):/workspace -e OPENAI_API_KEY \
+  -e YNH_VENDOR=codex persona-david:latest -- "refactor auth"
+```
+
+### Passing Vendor Flags
+
+Everything after the image name becomes arguments to `ynh run <persona>`. Unrecognised flags pass through to the vendor CLI:
+
+```bash
+# Model override
+docker run --rm -v $(pwd):/workspace -e ANTHROPIC_API_KEY \
+  persona-david:latest --model claude-sonnet-4-5-20250514 -- "fix this"
+
+# Skip permissions (headless CI)
+docker run --rm -v $(pwd):/workspace -e ANTHROPIC_API_KEY \
+  persona-david:latest --dangerously-skip-permissions -- "fix this"
+
+# Multiple flags + vendor switch
+docker run --rm -v $(pwd):/workspace -e OPENAI_API_KEY \
+  persona-david:latest -v codex --model gpt-4.1 --full-auto -- "refactor auth"
+```
+
+### Entrypoint Overrides
+
+Override the entrypoint for full ynh/ynd access inside the image:
+
+```bash
+# Full ynh CLI
+docker run --rm --entrypoint ynh persona-david:latest ls
+
+# ynd tools
+docker run --rm --entrypoint ynd persona-david:latest lint .
+
+# Shell access
+docker run --rm -it --entrypoint sh persona-david:latest
+```
+
 ## API Keys
 
 Set vendor API keys as environment variables before running. Create a `.env` file or export them:
@@ -73,8 +155,17 @@ docker run --rm \
   -e ANTHROPIC_API_KEY \
   -v ~/.ynh:/home/ynh/.ynh \
   -v $(pwd):/workspace \
-  ynh:latest run david "fix this bug"
+  ghcr.io/eyelock/ynh:latest run david "fix this bug"
 ```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `YNH_VENDOR` | _(none)_ | Override the default vendor (between `-v` flag and persona default in priority) |
+| `ANTHROPIC_API_KEY` | _(none)_ | API key for Claude Code |
+| `OPENAI_API_KEY` | _(none)_ | API key for Codex |
+| `CURSOR_API_KEY` | _(none)_ | API key for Cursor |
 
 ## Vendor Override
 
@@ -131,7 +222,7 @@ docker run --rm \
   -v ~/.ynh:/home/ynh/.ynh \
   -v ~/.ssh:/home/ynh/.ssh:ro \
   -v $(pwd):/workspace \
-  ynh:latest run david "deploy"
+  ghcr.io/eyelock/ynh:latest run david "deploy"
 ```
 
 ## UID/GID Mapping

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -290,5 +290,6 @@ ynh install ./my-persona
 - [Persona Reference](personas.md) - full manifest syntax
 - [Artifacts Guide](artifacts.md) - skills, agents, rules, commands
 - [Vendor Support](vendors.md) - supported vendors and switching between them
+- [Docker](docker.md) - run personas in containers, build persona appliance images for CI/CD
 - [ynd Developer Tools](ynd.md) - authoring, exporting, and marketplace building
-- [Tutorials](tutorial/README.md) - progressive walkthroughs from first persona to marketplace publishing
+- [Tutorials](tutorial/README.md) - progressive walkthroughs from first persona to Docker images

--- a/docs/tutorial/09-docker-image.md
+++ b/docs/tutorial/09-docker-image.md
@@ -1,0 +1,283 @@
+# Tutorial 9: Docker Images
+
+Build self-contained Docker images with personas baked in. No bind-mounting `~/.ynh` — just mount your workspace and pass API keys.
+
+## Prerequisites
+
+```bash
+# Clean up from any previous run
+rm -rf /tmp/ynh-tutorial
+docker rmi docker-demo:latest 2>/dev/null
+ynh uninstall docker-demo 2>/dev/null
+
+# Verify Docker is available
+docker version
+```
+
+## T9.1: Pull the base image
+
+The base image ships with all vendor CLIs pre-installed (Claude Code, Codex, Cursor):
+
+```bash
+docker pull ghcr.io/eyelock/ynh:latest
+```
+
+> **Tip:** If the base image isn't published yet, you can build it locally from the ynh repo: `make docker-build`
+
+Verify:
+
+```bash
+docker run --rm ghcr.io/eyelock/ynh:latest version
+# Expected: ynh <version>
+```
+
+## T9.2: Create and install a tutorial persona
+
+Create a persona to use throughout this tutorial:
+
+```bash
+mkdir -p /tmp/ynh-tutorial/docker-persona/.claude-plugin
+mkdir -p /tmp/ynh-tutorial/docker-persona/skills/greet
+mkdir -p /tmp/ynh-tutorial/docker-persona/rules
+
+cat > /tmp/ynh-tutorial/docker-persona/.claude-plugin/plugin.json << 'EOF'
+{"name": "docker-demo", "version": "0.1.0"}
+EOF
+
+cat > /tmp/ynh-tutorial/docker-persona/metadata.json << 'EOF'
+{
+  "ynh": {
+    "default_vendor": "claude"
+  }
+}
+EOF
+
+cat > /tmp/ynh-tutorial/docker-persona/instructions.md << 'EOF'
+You are a helpful coding assistant running inside a Docker container.
+Always mention that you are running in Docker when greeting the user.
+EOF
+
+cat > /tmp/ynh-tutorial/docker-persona/skills/greet/SKILL.md << 'EOF'
+---
+name: greet
+description: Greet the user with a friendly message
+---
+
+When asked to greet, respond with a warm welcome and mention the current environment.
+EOF
+
+cat > /tmp/ynh-tutorial/docker-persona/rules/be-concise.md << 'EOF'
+---
+name: be-concise
+description: Keep responses brief
+---
+
+Keep all responses under 3 sentences unless asked for detail.
+EOF
+```
+
+Install it:
+
+```bash
+ynh install /tmp/ynh-tutorial/docker-persona
+```
+
+Expected:
+
+```
+Installed persona "docker-demo"
+  Location: ~/.ynh/personas/docker-demo
+  Launcher: ~/.ynh/bin/docker-demo
+  Vendor:   claude
+```
+
+## T9.3: Build a persona image
+
+```bash
+ynh image docker-demo --tag docker-demo:latest
+```
+
+Expected:
+
+```
+Building persona image docker-demo:latest...
+...
+Persona image built: docker-demo:latest
+Run: docker run --rm -v $(pwd):/workspace -e ANTHROPIC_API_KEY docker-demo:latest -- "your prompt"
+```
+
+Verify the image exists:
+
+```bash
+docker images docker-demo
+# Expected: docker-demo   latest   <id>   <size>
+```
+
+## T9.4: Run the persona image
+
+The persona's instructions tell it to mention Docker when greeting, and the `be-concise` rule limits responses to 3 sentences. Try it:
+
+```bash
+docker run --rm \
+  -v $(pwd):/workspace \
+  -e ANTHROPIC_API_KEY \
+  docker-demo:latest -- "greet me and tell me about your environment"
+```
+
+Expected: the response mentions Docker (from `instructions.md`) and stays brief (from `rules/be-concise`). This confirms the baked-in persona artifacts are active.
+
+## T9.5: Switch vendors at runtime
+
+The image defaults to the persona's `default_vendor` (claude). Override with `YNH_VENDOR`:
+
+```bash
+docker run --rm \
+  -v $(pwd):/workspace \
+  -e OPENAI_API_KEY \
+  -e YNH_VENDOR=codex \
+  docker-demo:latest -- "greet me and describe your setup"
+```
+
+Or use the `-v` flag directly:
+
+```bash
+docker run --rm \
+  -v $(pwd):/workspace \
+  -e OPENAI_API_KEY \
+  docker-demo:latest -v codex -- "greet me and describe your setup"
+```
+
+Both do the same thing. `YNH_VENDOR` is more CI-friendly (see T9.10).
+
+## T9.6: Pass vendor flags
+
+Everything after the image name becomes arguments to `ynh run docker-demo`. Unrecognised flags pass through to the vendor CLI:
+
+```bash
+# Model override
+docker run --rm -v $(pwd):/workspace -e ANTHROPIC_API_KEY \
+  docker-demo:latest --model claude-sonnet-4-5-20250514 -- "greet me and tell me which model you are"
+
+# Skip permissions (headless CI)
+docker run --rm -v $(pwd):/workspace -e ANTHROPIC_API_KEY \
+  docker-demo:latest --dangerously-skip-permissions -- "greet me and tell me about your environment"
+
+# Multiple flags + vendor switch
+docker run --rm -v $(pwd):/workspace -e OPENAI_API_KEY \
+  docker-demo:latest -v codex --model gpt-4.1 --full-auto -- "greet me and describe your setup"
+```
+
+## T9.7: Inspect with --dry-run
+
+Preview the generated Dockerfile without building:
+
+```bash
+ynh image docker-demo --dry-run
+```
+
+Expected output (Dockerfile printed to stdout):
+
+```dockerfile
+FROM ghcr.io/eyelock/ynh:latest
+
+COPY --link --chown=ynh:ynh vendors/claude/ /home/ynh/.ynh/run/docker-demo/claude/
+COPY --link --chown=ynh:ynh vendors/codex/ /home/ynh/.ynh/run/docker-demo/codex/
+COPY --link --chown=ynh:ynh vendors/cursor/ /home/ynh/.ynh/run/docker-demo/cursor/
+
+COPY --link --chown=ynh:ynh persona/ /home/ynh/.ynh/personas/docker-demo/
+
+ENV YNH_VENDOR=claude
+
+ENTRYPOINT ["tini", "-s", "--", "ynh", "run", "docker-demo"]
+CMD []
+
+LABEL dev.ynh.persona="docker-demo" \
+      dev.ynh.persona.default-vendor="claude"
+```
+
+## T9.8: Build from Git source
+
+Build directly from a Git repo without installing the persona first:
+
+```bash
+ynh image tester \
+  --from github.com/eyelock/assistants \
+  --path ynh/tester \
+  --tag tester:latest
+```
+
+This clones the repo (or uses the cached clone), loads the persona from `ynh/tester/`, resolves its includes, and builds the image — all without a prior `ynh install`.
+
+Verify the remote includes were resolved and baked in:
+
+```bash
+docker run --rm --entrypoint sh tester:latest -c \
+  "find /home/ynh/.ynh/run/tester/claude -type f | sort"
+# Expected: skills from github.com/eyelock/assistants assembled into the image:
+#   /home/ynh/.ynh/run/tester/claude/.claude/skills/dev-quality/SKILL.md
+#   /home/ynh/.ynh/run/tester/claude/.claude/skills/go-lang/SKILL.md
+#   /home/ynh/.ynh/run/tester/claude/.claude/skills/go-lang/assets/...
+```
+
+## T9.9: Override entrypoint
+
+Access the full ynh/ynd CLI inside the persona image:
+
+```bash
+# List installed personas inside the image
+docker run --rm --entrypoint ynh docker-demo:latest ls
+
+# Check ynd version
+docker run --rm --entrypoint ynd docker-demo:latest version
+
+# Shell access for debugging
+docker run --rm -it --entrypoint sh docker-demo:latest
+```
+
+## T9.10: CI/CD matrix example
+
+Run the same persona across all vendors in a CI pipeline:
+
+```yaml
+# .github/workflows/ai-review.yml
+strategy:
+  matrix:
+    vendor: [claude, codex, cursor]
+    include:
+      - vendor: claude
+        api_key_secret: ANTHROPIC_API_KEY
+      - vendor: codex
+        api_key_secret: OPENAI_API_KEY
+      - vendor: cursor
+        api_key_secret: CURSOR_API_KEY
+
+steps:
+  - uses: actions/checkout@v4
+  - run: |
+      docker run --rm \
+        -v ${{ github.workspace }}:/workspace \
+        -e ${{ matrix.api_key_secret }}=${{ secrets[matrix.api_key_secret] }} \
+        -e YNH_VENDOR=${{ matrix.vendor }} \
+        ghcr.io/org/persona-review:latest \
+        --dangerously-skip-permissions -- "review the changes in this PR"
+```
+
+## Cleanup
+
+```bash
+docker rmi docker-demo:latest 2>/dev/null
+docker rmi tester:latest 2>/dev/null
+ynh uninstall docker-demo 2>/dev/null
+rm -rf /tmp/ynh-tutorial
+```
+
+## What you learned
+
+- The base image `ghcr.io/eyelock/ynh:latest` provides the runtime with all vendor CLIs
+- `ynh image` builds persona appliance images with pre-assembled vendor layouts
+- `--dry-run` previews the generated Dockerfile
+- `--from` builds from Git sources without installing first
+- `YNH_VENDOR` env var switches vendors at runtime
+- Vendor flags pass through to the underlying CLI
+- `--entrypoint` overrides give full ynh/ynd access
+- Persona images are ready for CI/CD pipelines with no host setup

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -14,6 +14,7 @@ Progressive tutorials from first steps to advanced configurations. Each tutorial
 | 6 | [Marketplace](tutorial/06-marketplace.md) | Generate marketplace indexes for team distribution |
 | 7 | [Registry & Discovery](tutorial/07-registry-and-discovery.md) | Search and install personas from curated registries |
 | 8 | [Developer Tools](tutorial/08-developer-tools.md) | Scaffold, lint, validate, format, compress, inspect with ynd |
+| 9 | [Docker Images](tutorial/09-docker-image.md) | Build persona appliance images for CI/CD |
 
 ## Manual Test Plan
 

--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -138,6 +138,23 @@ Re-run `make install` after any code change you want to test.
 | T8.7 | Compress | [T8.7](tutorial/08-developer-tools.md#t87-compress) |
 | T8.8 | Inspect | [T8.8](tutorial/08-developer-tools.md#t88-inspect) |
 
+### Tutorial 9: Docker Images
+
+Requires Docker installed and running.
+
+| ID | Test | Tutorial step |
+|---|---|---|
+| T9.1 | Pull or build base image | [T9.1](tutorial/09-docker-image.md#t91-pull-the-base-image) |
+| T9.2 | Create and install tutorial persona | [T9.2](tutorial/09-docker-image.md#t92-create-and-install-a-tutorial-persona) |
+| T9.3 | Build a persona image | [T9.3](tutorial/09-docker-image.md#t93-build-a-persona-image) |
+| T9.4 | Run the persona image | [T9.4](tutorial/09-docker-image.md#t94-run-the-persona-image) |
+| T9.5 | Switch vendors at runtime | [T9.5](tutorial/09-docker-image.md#t95-switch-vendors-at-runtime) |
+| T9.6 | Pass vendor flags | [T9.6](tutorial/09-docker-image.md#t96-pass-vendor-flags) |
+| T9.7 | Inspect with --dry-run | [T9.7](tutorial/09-docker-image.md#t97-inspect-with---dry-run) |
+| T9.8 | Build from Git source | [T9.8](tutorial/09-docker-image.md#t98-build-from-git-source) |
+| T9.9 | Override entrypoint | [T9.9](tutorial/09-docker-image.md#t99-override-entrypoint) |
+| T9.10 | CI/CD matrix example | [T9.10](tutorial/09-docker-image.md#t910-cicd-matrix-example) |
+
 ---
 
 ## Edge Cases

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -62,7 +62,7 @@ david -v codex
 {"default_vendor": "claude"}
 ```
 
-Resolution order: **CLI flag > persona default > global config**.
+Resolution order: **CLI flag (`-v`) > `YNH_VENDOR` env var > persona default > global config**.
 
 ## Vendor Notes
 


### PR DESCRIPTION
## Summary

- Adds `ynh image <persona>` command that builds Docker images with personas pre-assembled for all three vendors (Claude, Codex, Cursor)
- Optimizes the base Dockerfile with parallel BuildKit stages for vendor CLI installs, `COPY --link`, and npm cache mounts
- Adds `YNH_VENDOR` env var to the vendor resolution cascade (flag > env > persona default > global config)
- Adds pre-assembled run directory detection in `cmdRun` so baked images skip assembly entirely at startup
- Configures goreleaser for multi-arch Docker image publishing (amd64/arm64) to GHCR
- Adds Tutorial 09: Docker Images with 10 hands-on sections
- Updates all project docs for completeness (CONTRIBUTING.md, vendors.md, getting-started.md, README.md, CLAUDE.md, manual test plan, sidebar)

## Test plan

- [x] `make check` passes (format, lint, test, build)
- [x] `ynh image docker-demo --dry-run` produces correct Dockerfile
- [x] `ynh image docker-demo --tag docker-demo:latest` builds successfully
- [x] `docker run --rm docker-demo:latest -- "greet me"` runs with baked persona
- [x] `ynh image tester --from github.com/eyelock/assistants --path ynh/tester` resolves remote includes
- [x] Pre-assembled vendor layouts verified inside built image via `find`
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)