### PR TITLE
fix: goreleaser Docker build context missing source files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,6 +57,11 @@ dockers:
       - "ghcr.io/eyelock/ynh:{{ .Version }}-amd64"
     use: buildx
     dockerfile: Dockerfile
+    extra_files:
+      - go.mod
+      - go.sum
+      - cmd/
+      - internal/
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=VERSION={{ .Version }}"
@@ -66,6 +71,11 @@ dockers:
       - "ghcr.io/eyelock/ynh:{{ .Version }}-arm64"
     use: buildx
     dockerfile: Dockerfile
+    extra_files:
+      - go.mod
+      - go.sum
+      - cmd/
+      - internal/
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--build-arg=VERSION={{ .Version }}"


### PR DESCRIPTION
## Summary

- Adds `extra_files` to goreleaser Docker config so the builder stage has `go.mod`, `go.sum`, and source directories
- Fixes release workflow failure where `COPY go.mod go.sum ./` failed because goreleaser's minimal build context only included pre-built binaries

## Test plan

- [ ] CI passes
- [ ] Re-tag release after merge to verify Docker image builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)