### PR TITLE
fix: Claude export generates CLAUDE.md with @AGENTS.md import

### DIFF
--- a/.claude/skills/vendor-adapters/SKILL.md
+++ b/.claude/skills/vendor-adapters/SKILL.md
@@ -229,10 +229,18 @@ What ynh calls each concept vs what each vendor calls it and where it lives.
 | ynh runtime:      | --append-system-prompt           | Written as codex.md in           | Written as .cursorrules in       |
 |                   | (injected, no file conflict)     |   staging dir                    |   staging dir                    |
 +-------------------+----------------------------------+----------------------------------+----------------------------------+
-| ynh export:       | AGENTS.md (avoids CLAUDE.md      | AGENTS.md                        | .cursorrules + AGENTS.md         |
-|                   |  conflict with project's own)    |                                  |                                  |
+| ynh export:       | AGENTS.md + CLAUDE.md            | AGENTS.md                        | .cursorrules + AGENTS.md         |
+|                   |  (CLAUDE.md contains @AGENTS.md  |                                  |                                  |
+|                   |   import — see workaround below) |                                  |                                  |
 +-------------------+----------------------------------+----------------------------------+----------------------------------+
 ```
+
+**Claude AGENTS.md workaround:** Claude Code does not read `AGENTS.md` natively
+(see https://code.claude.com/docs/en/memory). ynh exports a `CLAUDE.md` containing
+just `@AGENTS.md` which uses Claude's `@`-import syntax to pull in the cross-vendor
+instructions file. This avoids duplicating content while ensuring Claude reads the
+instructions. The plugin's `CLAUDE.md` lives inside the plugin directory, so it does
+not conflict with the project's own `CLAUDE.md`.
 
 ### Launch Strategy
 
@@ -267,8 +275,8 @@ What ynh calls each concept vs what each vendor calls it and where it lives.
 | HIGH | Codex MCP format wrong                   | Codex      |
 |      |   (TOML should be JSON .mcp.json)        |            |
 | HIGH | Codex marketplace not generated           | Codex      |
-| MED  | Claude export writes AGENTS.md           | Claude     |
-|      |   (Claude doesn't read AGENTS.md)        |            |
+| ---  | Claude AGENTS.md: RESOLVED               | Claude     |
+|      |   (CLAUDE.md with @AGENTS.md import)     |            |
 | MED  | Cursor plugin hooks format               | Cursor     |
 |      |   (flat legacy vs three-level settings)  |            |
 | MED  | Cursor .mdc rules format                 | Cursor     |

--- a/.claude/skills/vendor-adapters/references/anthropic.md
+++ b/.claude/skills/vendor-adapters/references/anthropic.md
@@ -111,5 +111,5 @@ command, http, prompt, agent
 
 - `--plugin-dir` auto-activates skills/commands but NOT hooks/MCP (need `/plugin enable` + `/reload-plugins`)
 - Plugin `settings.json` only supports `agent` key (not hooks)
-- Export writes AGENTS.md for instructions — Claude doesn't read AGENTS.md natively
+- Claude doesn't read AGENTS.md natively — export writes CLAUDE.md with `@AGENTS.md` import to bridge this
 - Environment vars available: `${CLAUDE_PLUGIN_ROOT}`, `${CLAUDE_PLUGIN_DATA}`

--- a/docs/tutorial/05-export.md
+++ b/docs/tutorial/05-export.md
@@ -82,20 +82,31 @@ ls -Ra /tmp/ynh-tutorial/export-output/claude/
 Expected:
 ```
 .claude-plugin/               # plugin manifest directory
-  plugin.json                 # copied from source
+  plugin.json                 # generated from harness.json
 agents/
   checker.md                  # local agent
 skills/
   review/SKILL.md             # local skill
   take-a-moment/SKILL.md      # picked from remote include
-AGENTS.md                     # from instructions.md
+AGENTS.md                     # instructions (cross-vendor format)
+CLAUDE.md                     # @AGENTS.md import (Claude reads this)
 ```
 
 Key points:
-- No `CLAUDE.md` — distributable plugins don't include it (would conflict with project's own)
+- `AGENTS.md` contains the actual instructions (read by Codex, Cursor, Copilot, etc.)
+- `CLAUDE.md` contains just `@AGENTS.md` — Claude Code reads this and imports the instructions. No duplication, no conflict with the project's own `CLAUDE.md` (the plugin lives in its own directory).
 - No `.claude/` wrapper — artifacts are at the plugin root
-- `AGENTS.md` is the universal instruction format
 - Remote includes are resolved and flattened
+
+### Verify Claude reads the instructions
+
+```bash
+cat /tmp/ynh-tutorial/export-output/claude/CLAUDE.md
+# Expected: @AGENTS.md
+
+cat /tmp/ynh-tutorial/export-output/claude/AGENTS.md
+# Expected: You are a code quality harness. Focus on correctness and security.
+```
 
 ### Validate the Claude export
 
@@ -104,11 +115,22 @@ claude plugin validate /tmp/ynh-tutorial/export-output/claude
 # Expected: validation passes
 ```
 
-### Load as a plugin
+### Verify the @-import works
+
+The exported `CLAUDE.md` contains `@AGENTS.md` — Claude's import syntax. Verify Claude reads the instructions by launching from the export directory:
 
 ```bash
-claude --plugin-dir /tmp/ynh-tutorial/export-output/claude
-# Expected: interactive session with review and take-a-moment skills available
+cd /tmp/ynh-tutorial/export-output/claude
+git init && git add -A && git commit -m "init"
+claude -p "What should you focus on? Answer in one sentence."
+```
+
+Expected: Claude should respond mentioning **code quality**, **correctness**, and **security** — the instructions from `AGENTS.md` imported via `CLAUDE.md`'s `@AGENTS.md` reference.
+
+Return to your previous directory before continuing:
+
+```bash
+cd -
 ```
 
 ## T5.4: Verify Cursor export
@@ -191,6 +213,7 @@ skills/
 
 .cursorrules
 AGENTS.md
+CLAUDE.md
 ```
 
 One physical directory with both vendor manifests — serves Claude and Cursor from the same files.
@@ -256,8 +279,8 @@ rm -rf /tmp/ynh-tutorial/no-inst-out
 - `--merged` produces a single dir with dual manifests (marketplace-ready)
 - Remote includes are resolved and flattened into the export
 - Pick filtering carries through to the export
-- No `CLAUDE.md` in exports (would conflict with project's own)
-- `AGENTS.md` is the universal instruction format
+- `AGENTS.md` is the universal instruction format (read by Codex, Cursor, Copilot, etc.)
+- `CLAUDE.md` is generated with `@AGENTS.md` import — Claude reads this, no duplication
 
 ## Next
 

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -33,6 +33,9 @@ func (m *mockAdapter) LaunchInteractive(configPath string, extraArgs []string) e
 func (m *mockAdapter) LaunchNonInteractive(configPath string, prompt string, extraArgs []string) error {
 	return nil
 }
+func (m *mockAdapter) GenerateSystemPrompt(content []byte) map[string][]byte {
+	return map[string][]byte{"AGENTS.md": content}
+}
 func (m *mockAdapter) GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[string][]byte {
 	return nil
 }

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -179,18 +179,8 @@ func exportMerged(opts ExportOptions, pj *plugin.HarnessJSON, p *harness.Harness
 
 	// Instructions
 	if instructionsPath != "" {
-		// Write AGENTS.md always
-		if err := assembler.CopyFile(instructionsPath, filepath.Join(outputDir, "AGENTS.md")); err != nil {
+		if err := WriteMergedSystemPrompt(instructionsPath, outputDir, vendors); err != nil {
 			return nil, err
-		}
-		// Write .cursorrules if Cursor is a target
-		for _, v := range vendors {
-			if v == "cursor" {
-				if err := assembler.CopyFile(instructionsPath, filepath.Join(outputDir, ".cursorrules")); err != nil {
-					return nil, err
-				}
-				break
-			}
 		}
 	}
 
@@ -307,11 +297,7 @@ func exportForVendor(vendorName string, outputDir string, pj *plugin.HarnessJSON
 
 	// Instructions
 	if instructionsPath != "" {
-		vendorInstructionsFile := ""
-		if vendorName == "cursor" {
-			vendorInstructionsFile = adapter.InstructionsFile() // .cursorrules
-		}
-		if err := GenerateInstructions(instructionsPath, outputDir, vendorInstructionsFile); err != nil {
+		if err := WriteSystemPrompt(instructionsPath, outputDir, adapter); err != nil {
 			return result, err
 		}
 	}

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -68,8 +68,13 @@ func TestExportSingleVendorClaude(t *testing.T) {
 	// Check AGENTS.md (from instructions.md)
 	assertFileExists(t, filepath.Join(claudeDir, "AGENTS.md"))
 
-	// No CLAUDE.md in export
-	assertFileNotExists(t, filepath.Join(claudeDir, "CLAUDE.md"))
+	// CLAUDE.md with @AGENTS.md import (Claude doesn't read AGENTS.md natively)
+	claudeMDPath := filepath.Join(claudeDir, "CLAUDE.md")
+	assertFileExists(t, claudeMDPath)
+	claudeMD, _ := os.ReadFile(claudeMDPath)
+	if string(claudeMD) != "@AGENTS.md\n" {
+		t.Errorf("CLAUDE.md = %q, want %q", string(claudeMD), "@AGENTS.md\n")
+	}
 
 	// No .cursorrules in Claude export
 	assertFileNotExists(t, filepath.Join(claudeDir, ".cursorrules"))
@@ -322,10 +327,10 @@ func TestExportWithInstructions(t *testing.T) {
 		t.Fatalf("Export failed: %v", err)
 	}
 
-	// Claude: AGENTS.md only
+	// Claude: AGENTS.md + CLAUDE.md (with @-import)
 	claudeAgents := filepath.Join(outputDir, "claude", "AGENTS.md")
 	assertFileExists(t, claudeAgents)
-	assertFileNotExists(t, filepath.Join(outputDir, "claude", "CLAUDE.md"))
+	assertFileExists(t, filepath.Join(outputDir, "claude", "CLAUDE.md"))
 
 	// Cursor: .cursorrules + AGENTS.md
 	assertFileExists(t, filepath.Join(outputDir, "cursor", ".cursorrules"))
@@ -446,6 +451,7 @@ func TestExportMergedMode(t *testing.T) {
 
 	// Instructions
 	assertFileExists(t, filepath.Join(outputDir, "AGENTS.md"))
+	assertFileExists(t, filepath.Join(outputDir, "CLAUDE.md"))
 	assertFileExists(t, filepath.Join(outputDir, ".cursorrules"))
 }
 

--- a/internal/exporter/instructions.go
+++ b/internal/exporter/instructions.go
@@ -1,27 +1,67 @@
 package exporter
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/eyelock/ynh/internal/assembler"
 	"github.com/eyelock/ynh/internal/resolver"
+	"github.com/eyelock/ynh/internal/vendor"
 )
 
-// GenerateInstructions writes instruction files from the harness's instructions.
-//
-// Always writes outputDir/AGENTS.md (the universal format).
-// If vendorInstructionsFile is non-empty and differs from "AGENTS.md",
-// also writes outputDir/<vendorInstructionsFile> (same content).
-func GenerateInstructions(instructionsPath string, outputDir string, vendorInstructionsFile string) error {
-	// Always write AGENTS.md
-	if err := assembler.CopyFile(instructionsPath, filepath.Join(outputDir, "AGENTS.md")); err != nil {
-		return err
+// WriteSystemPrompt reads instructions from instructionsPath and writes
+// vendor-native instruction files to outputDir using the adapter's
+// GenerateSystemPrompt method.
+func WriteSystemPrompt(instructionsPath string, outputDir string, adapter vendor.Adapter) error {
+	content, err := os.ReadFile(instructionsPath)
+	if err != nil {
+		return fmt.Errorf("reading instructions: %w", err)
 	}
 
-	// Write vendor-specific file if different from AGENTS.md
-	if vendorInstructionsFile != "" && vendorInstructionsFile != "AGENTS.md" {
-		if err := assembler.CopyFile(instructionsPath, filepath.Join(outputDir, vendorInstructionsFile)); err != nil {
+	files := adapter.GenerateSystemPrompt(content)
+	for relPath, data := range files {
+		absPath := filepath.Join(outputDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 			return err
+		}
+		if err := os.WriteFile(absPath, data, 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", relPath, err)
+		}
+	}
+
+	return nil
+}
+
+// WriteMergedSystemPrompt writes instruction files for multiple vendors
+// into a single output directory. Used by merged export mode.
+func WriteMergedSystemPrompt(instructionsPath string, outputDir string, vendors []string) error {
+	content, err := os.ReadFile(instructionsPath)
+	if err != nil {
+		return fmt.Errorf("reading instructions: %w", err)
+	}
+
+	// Collect files from all vendor adapters, deduplicating by path.
+	// If multiple vendors write the same file (e.g. AGENTS.md), last wins
+	// — content is identical so order doesn't matter.
+	files := make(map[string][]byte)
+	for _, v := range vendors {
+		adapter, err := vendor.Get(v)
+		if err != nil {
+			continue
+		}
+		for path, data := range adapter.GenerateSystemPrompt(content) {
+			files[path] = data
+		}
+	}
+
+	for relPath, data := range files {
+		absPath := filepath.Join(outputDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(absPath, data, 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", relPath, err)
 		}
 	}
 

--- a/internal/vendor/adapter.go
+++ b/internal/vendor/adapter.go
@@ -56,6 +56,12 @@ type Adapter interface {
 	// extraArgs are passed through verbatim to the vendor CLI.
 	LaunchNonInteractive(configPath string, prompt string, extraArgs []string) error
 
+	// GenerateSystemPrompt produces vendor-native instruction files from the
+	// harness instructions content. Returns a map of relative file paths to
+	// file contents. Always includes AGENTS.md (cross-vendor); vendors add
+	// their own files as needed (e.g. CLAUDE.md, .cursorrules).
+	GenerateSystemPrompt(content []byte) map[string][]byte
+
 	// GenerateHookConfig translates canonical hook declarations to vendor-native
 	// hook configuration files. Returns a map of relative file paths to file contents.
 	// Returns nil if hooks is nil or empty.

--- a/internal/vendor/claude.go
+++ b/internal/vendor/claude.go
@@ -29,6 +29,16 @@ func (c *Claude) InstructionsFile() string { return "CLAUDE.md" }
 
 func (c *Claude) ArtifactDirs() map[string]string { return DefaultArtifactDirs() }
 
+func (c *Claude) GenerateSystemPrompt(content []byte) map[string][]byte {
+	// AGENTS.md: cross-vendor instructions (read by Codex, Cursor, Copilot, etc.)
+	// CLAUDE.md: @-import of AGENTS.md (Claude doesn't read AGENTS.md natively)
+	// See: https://code.claude.com/docs/en/memory
+	return map[string][]byte{
+		"AGENTS.md": content,
+		"CLAUDE.md": []byte("@AGENTS.md\n"),
+	}
+}
+
 func (c *Claude) NeedsSymlinks() bool { return false }
 
 func (c *Claude) Install(stagingDir string, projectDir string) ([]SymlinkEntry, error) {

--- a/internal/vendor/codex.go
+++ b/internal/vendor/codex.go
@@ -27,6 +27,13 @@ func (c *Codex) InstructionsFile() string { return "codex.md" }
 
 func (c *Codex) ArtifactDirs() map[string]string { return DefaultArtifactDirs() }
 
+func (c *Codex) GenerateSystemPrompt(content []byte) map[string][]byte {
+	// AGENTS.md: Codex natively reads this
+	return map[string][]byte{
+		"AGENTS.md": content,
+	}
+}
+
 func (c *Codex) NeedsSymlinks() bool { return true }
 
 func (c *Codex) Install(stagingDir string, projectDir string) ([]SymlinkEntry, error) {

--- a/internal/vendor/cursor.go
+++ b/internal/vendor/cursor.go
@@ -28,6 +28,15 @@ func (c *Cursor) InstructionsFile() string { return ".cursorrules" }
 
 func (c *Cursor) ArtifactDirs() map[string]string { return DefaultArtifactDirs() }
 
+func (c *Cursor) GenerateSystemPrompt(content []byte) map[string][]byte {
+	// AGENTS.md: cross-vendor format
+	// .cursorrules: Cursor-native instructions
+	return map[string][]byte{
+		"AGENTS.md":    content,
+		".cursorrules": content,
+	}
+}
+
 func (c *Cursor) NeedsSymlinks() bool { return true }
 
 func (c *Cursor) Install(stagingDir string, projectDir string) ([]SymlinkEntry, error) {


### PR DESCRIPTION
## Summary

Claude Code doesn't read `AGENTS.md` natively. Exported Claude plugins had instructions that were never loaded.

- Add `GenerateSystemPrompt()` to the Adapter interface — each vendor declares its instruction files
- Claude: `AGENTS.md` (content) + `CLAUDE.md` (`@AGENTS.md` import)
- Codex: `AGENTS.md`
- Cursor: `AGENTS.md` + `.cursorrules`
- Exporter has zero vendor-specific instruction logic — all in adapters
- Removes old `GenerateInstructions` function with vendor switches

## Proof

Tutorial 5 verification: `cd` into Claude export dir, run `claude -p "What should you focus on?"` — Claude responds with the instructions from `AGENTS.md` imported via `CLAUDE.md`.

## Test plan

- [x] `make check` passes
- [x] Claude export includes both `AGENTS.md` and `CLAUDE.md`
- [x] `CLAUDE.md` contains `@AGENTS.md`
- [x] Manual verification: Claude reads instructions via @-import
- [x] Merged export includes `CLAUDE.md`
- [x] Vendor-adapters skill updated with workaround documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)