### PR TITLE
docs: unify story arc, reorder tutorials for progressive discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,246 +1,73 @@
 # ynh
 
-A harness template manager for AI coding assistants. Bundle skills, agents, rules, and commands into named harnesses, then launch them with any vendor CLI.
-
-> **Note**: This is a personal project developed in my spare time. It's an exploration of the varying approaches to marketplace/distribution across AI vendors.
-
-**[Full Documentation](https://eyelock.github.io/ynh)**
+**Your name. Your AI.**
 
 ```bash
 ynh install github.com/myorg/david
-david                                    # interactive session
-david "review this PR"                   # non-interactive mode
-david -v codex                           # same harness, different vendor
-david --model opus -- "fix this bug"     # pass flags through to vendor CLI
-```
-
-## Quick Start
-
-### 1. Install
-
-```bash
-brew tap eyelock/tap
-brew install ynh
-```
-
-Add the launcher directory to your PATH (one-time):
-
-```bash
-echo 'export PATH="$HOME/.ynh/bin:$PATH"' >> ~/.zshrc
-source ~/.zshrc
-```
-
-### 2. Create a harness
-
-Create a directory with a `harness.json` and your artifacts:
-
-```
-david/
-├── harness.json              # required - name, version, vendor config
-├── instructions.md           # optional - project-level instructions
-├── skills/
-│   └── review/
-│       └── SKILL.md
-├── agents/
-│   └── code-reviewer.md
-├── rules/
-│   └── always-test.md
-└── commands/
-    └── check.md
-```
-
-The harness manifest (`harness.json`):
-
-```json
-{
-  "name": "david",
-  "version": "0.1.0",
-  "description": "David's personal coding harness",
-  "default_vendor": "claude"
-}
-```
-
-### 3. Install and run
-
-```bash
-ynh install ./david
-ynh install github.com/org/monorepo --path harnesses/david
 david
 ```
 
-## Project Instructions
+That's it. `david` is now a command. It knows your skills, your team's rules, your coding standards. It works on Claude today. Switch to Codex with `-v codex`. Same harness, different engine.
 
-A harness can include an `instructions.md` that maps to the vendor's project instructions file:
+## What this gives you
 
-```
-david/
-├── harness.json
-└── instructions.md       # becomes CLAUDE.md, codex.md, or .cursorrules
-```
-
-If multiple sources provide `instructions.md`, the harness's own file takes priority. See the [Artifacts Guide](docs/artifacts.md#project-instructions) for details.
-
-## Adding Artifacts
-
-Artifacts are standard-format files. No build step, no wrapper. A skill from [skills.sh](https://skills.sh) or any Git repo works as-is.
-
-### Skills
-
-A directory with a `SKILL.md` file following the [Agent Skills](https://agentskills.io) open specification:
-
-```
-skills/review/SKILL.md
-```
-
-### Agents
-
-A markdown file with YAML frontmatter:
-
-```
-agents/code-reviewer.md
-```
-
-### Rules
-
-A markdown file loaded as context:
-
-```
-rules/always-test.md
-```
-
-### Commands
-
-A markdown file describing a command:
-
-```
-commands/check.md
-```
-
-### Embedding vs Including
-
-Artifacts can live **directly in your harness** (embedded) or be **pulled from Git repos** (included):
-
-```json
-{
-  "name": "david",
-  "version": "0.1.0",
-  "default_vendor": "claude",
-  "includes": [
-    {
-      "git": "github.com/eyelock/claude-config-toolkit",
-      "ref": "v2.0.0",
-      "pick": ["skills/commit", "skills/tdd"]
-    },
-    {
-      "git": "git@github.com:company/internal-tools.git",
-      "path": "packages/ai-config",
-      "pick": ["agents/reviewer"]
-    }
-  ],
-  "delegates_to": [
-    {"git": "github.com/eyelock/team-dev-harness"}
-  ]
-}
-```
-
-Embedded artifacts (files in the harness directory) are always included. External artifacts are fetched from Git at runtime. Shorthand URLs (`github.com/...`) and `git@` URLs both use SSH. Use `https://` explicitly for HTTPS.
-
-## Vendor Support
-
-ynh supports multiple AI vendors. The vendor determines which CLI is launched and where config files are placed. Run `ynh vendors` to see what's available.
-
-Each vendor gets the launch strategy that matches its capabilities:
-- **Claude** uses `--plugin-dir` for native plugin loading (clean `exec`, no running process)
-- **Codex/Cursor** use symlink-based installation (managed child process with signal forwarding)
-
-Vendor resolution order: **CLI flag > harness default > global config**.
+**You become a command.** Not "claude with some config files." A named identity that carries your entire AI working environment — tools, standards, style — all behind your name.
 
 ```bash
-david                    # uses harness's default_vendor
-david -v codex           # override to codex
+david                              # your configured AI
+david "review this PR"             # it knows how you review
+david -v codex                     # same harness, different vendor
 ```
 
-All flags except `-v`, `--install`, and `--clean` are passed through to the vendor CLI. Use `--` to separate vendor flags from the prompt:
+**Compose from anywhere.** Cherry-pick skills from community repos, your team's private config, open-source libraries — and mix them with your own. Like a package manager for AI capabilities, backed by Git.
+
+**Zero runtime.** ynh resolves your config, assembles it, launches the vendor CLI, and gets out of the way. No process sitting between you and the AI.
+
+## The 60-second version
 
 ```bash
-david --model opus -- "fix this bug"
-david -v codex -- "refactor auth"
+# Install
+brew tap eyelock/tap && brew install ynh
+
+# Create a harness
+mkdir david && cat > david/harness.json << 'EOF'
+{"name":"david","version":"0.1.0","default_vendor":"claude"}
+EOF
+
+# Install and run
+ynh install ./david
+david
 ```
 
-### Symlink Installation (Codex/Cursor)
+Add skills, agents, rules, and commands to the harness directory. Pull from Git repos. Compose across sources. Switch vendors. Delegate to team harnesses.
 
-Vendors that don't support plugin directories use symlinks installed into your project:
+## Why harness management?
 
-```bash
-david -v cursor --install     # creates .cursor/ symlinks in current project
-david -v cursor               # launches normally
-david -v cursor --clean       # removes symlinks
-```
+> **Agent = Model + Harness.** Weak results are usually harness problems, not model problems.
 
-Symlink installations are tracked in `~/.ynh/symlinks.json`. Use `ynh status` to see all installations and `ynh prune` to clean up orphaned ones.
+The term "harness" was formalized by [Martin Fowler](https://martinfowler.com/articles/harness-engineering.html) and adopted by [OpenAI](https://openai.com/index/harness-engineering/) and [Anthropic](https://www.anthropic.com/engineering/harness-design-long-running-apps). A harness is everything in an AI coding agent except the model itself — the skills, rules, context, and constraints that shape its behavior.
 
-Global default in `~/.ynh/config.json`:
+ynh manages the **guide layer** of that harness: the proactive steering that happens *before* the agent acts. One harness definition, assembled for Claude, Codex, or Cursor. Read more in [Harness Engineering](https://eyelock.github.io/ynh/#/harness-engineering).
 
-```json
-{"default_vendor": "claude"}
-```
+## What you can do
 
-## Commands
+**Build** — Create harnesses with skills, agents, rules, and commands. Pull artifacts from any Git repo with cherry-picking (`pick`). Declare hooks, MCP servers, and environment-specific profiles.
 
-### ynh (Harness Template Manager)
+**Refine** — Scaffold with `ynd create`, lint and validate with `ynd lint`/`ynd validate`, compress prompts with `ynd compress`, preview assembled output with `ynd preview`, diff across vendors with `ynd diff`.
 
-| Command | Description |
-|---------|-------------|
-| `ynh init` | Show ynh home path and setup instructions |
-| `ynh install <source> [--path <subdir>]` | Install harness from Git URL or local path |
-| `ynh uninstall <name>` | Remove an installed harness and its launcher (alias: `ynh remove`) |
-| `ynh update <name>` | Refresh cached Git repos for a harness |
-| `ynh run <name> [flags] [prompt]` | Launch a harness session |
-| `ynh ls` | List installed harnesses (alias: `ynh list`) |
-| `ynh info <name>` | Show detailed harness information |
-| `ynh search <query>` | Search registries for harnesses by name or keyword |
-| `ynh registry <subcommand>` | Manage harness registries (add, remove, list) |
-| `ynh vendors` | List supported vendor adapters |
-| `ynh status` | Show symlink installations across projects |
-| `ynh prune` | Clean orphaned symlink installations |
-| `ynh version` | Print version |
-
-### ynd (Developer Tools)
-
-| Command | Description |
-|---------|-------------|
-| `ynd create <type> <name>` | Scaffold a harness, skill, agent, rule, or command |
-| `ynd lint [files]` | Lint markdown, shell blocks, and config files |
-| `ynd validate [path]` | Validate harness structure and required fields |
-| `ynd fmt [files]` | Format markdown files |
-| `ynd compress [files]` | LLM-powered prompt compression with backup/restore |
-| `ynd inspect` | Interactive codebase analysis to generate skills and agents |
-| `ynd export <source> [flags]` | Export harness as vendor-native plugins |
-| `ynd marketplace build [flags]` | Build a marketplace from harnesses and plugins |
-
-See the [full command reference](https://eyelock.github.io/ynh/#/ynd) for all flags and options.
-
-### Run Flags
-
-| Flag | Description |
-|------|-------------|
-| `-v <vendor>` | Override vendor (claude, codex, cursor) |
-| `--install` | Install symlinks for the vendor in the current project |
-| `--clean` | Remove symlinks for the vendor in the current project |
-| `--` | Separator between vendor flags and the prompt |
+**Share** — Export as vendor-native plugins with `ynd export`. Build team marketplaces with `ynd marketplace build`. Publish to registries. Bake harnesses into Docker images for CI/CD.
 
 ## Documentation
 
-Full documentation is available at **[eyelock.github.io/ynh](https://eyelock.github.io/ynh)**, including:
+Full docs at **[eyelock.github.io/ynh](https://eyelock.github.io/ynh)**:
 
-- [Getting Started](https://eyelock.github.io/ynh/#/getting-started) — create and run your first harness
-- [Harness Reference](https://eyelock.github.io/ynh/#/harnesses) — plugin manifest, metadata, includes, delegates
-- [Artifacts Guide](https://eyelock.github.io/ynh/#/artifacts) — skills, agents, rules, commands, and project instructions
-- [Vendor Support](https://eyelock.github.io/ynh/#/vendors) — Claude, Codex, Cursor capabilities and launch strategies
-- [Agent Skills Standard](https://eyelock.github.io/ynh/#/skills-standard) — cross-platform spec, discovery paths, catalog budget
-- [Marketplace & Distribution](https://eyelock.github.io/ynh/#/marketplace) — cross-vendor marketplace systems and ynh's marketplace builder
-- [Docker](https://eyelock.github.io/ynh/#/docker) — containerized harnesses and Docker image baking
-- [Tutorials](https://eyelock.github.io/ynh/#/tutorial/) — 13 progressive tutorials from first harness to profiles
+- **[Getting Started](https://eyelock.github.io/ynh/#/getting-started)** — Create and run your first harness
+- **[Harness Engineering](https://eyelock.github.io/ynh/#/harness-engineering)** — Why harness management matters
+- **[Tutorials](https://eyelock.github.io/ynh/#/tutorial/)** — 13 progressive tutorials from first harness to Docker images
+- **[Artifacts Guide](https://eyelock.github.io/ynh/#/artifacts)** — Skills, agents, rules, commands
+- **[CLI Reference](https://eyelock.github.io/ynh/#/reference)** — Full command reference for ynh and ynd
+- **[Agent Skills Standard](https://eyelock.github.io/ynh/#/skills-standard)** — Cross-platform spec, discovery paths, catalog budget
+- **[Vendor Support](https://eyelock.github.io/ynh/#/vendors)** — Claude, Codex, Cursor capabilities
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,13 +74,13 @@ Add skills, agents, rules, and commands to the harness directory. Pull from Git 
 
 ## Guides
 
+- **[Harness Engineering](harness-engineering.md)** - Why harness management matters (Fowler, OpenAI, Anthropic)
 - **[Getting Started](getting-started.md)** - Create your first harness and run it
-- **[Harness Reference](harnesses.md)** - Harness manifest, includes, delegates, profiles
+- **[Tutorials](tutorial/README.md)** - Progressive tutorials: build, refine, share & scale
 - **[Artifacts Guide](artifacts.md)** - Skills, agents, rules, commands, and project instructions
-- **[Vendor Support](vendors.md)** - Claude, Codex, Cursor - capabilities and launch strategies
 - **[Agent Skills Standard](skills-standard.md)** - Cross-platform spec, frontmatter fields, catalog budget, discovery paths
+- **[Harness Reference](harnesses.md)** - Harness manifest, includes, delegates, profiles
+- **[Vendor Support](vendors.md)** - Claude, Codex, Cursor - capabilities and launch strategies
+- **[ynd Developer Tools](ynd.md)** - CLI for scaffolding, linting, formatting, compressing, inspecting, exporting, and marketplace building
 - **[Marketplace & Distribution](marketplace.md)** - Cross-vendor marketplace systems, distribution formats, and ynh's marketplace builder
 - **[Docker](docker.md)** - Run harnesses in containers, build harness appliance images for CI/CD
-- **[Tutorials](tutorial/README.md)** - Progressive tutorials from first harness to Docker images
-- **[Manual Test Plan](tutorial/manual-test-plan.md)** - Tests covering every feature
-- **[ynd Developer Tools](ynd.md)** - CLI for scaffolding, linting, formatting, compressing, inspecting, exporting, and marketplace building

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,39 +1,47 @@
-* **Concepts**
+* **Why**
+  * [Harness Engineering](harness-engineering.md)
+
+* **Start**
   * [Overview](README.md)
   * [Getting Started](getting-started.md)
-  * [Harness Engineering](harness-engineering.md)
   * [Artifacts](artifacts.md)
   * [Agent Skills Standard](skills-standard.md)
 
-* **Configuration**
+* **Configure**
   * [Harness Manifest](harnesses.md)
   * [Hooks](hooks.md)
   * [MCP Servers](mcp.md)
   * [Profiles](profiles.md)
   * [Vendor Support](vendors.md)
 
-* **Tooling**
+* **Tools**
   * [CLI Reference](reference.md)
   * [ynd Developer Tools](ynd.md)
+
+* **Distribute**
   * [Marketplace & Distribution](marketplace.md)
   * [Docker](docker.md)
 
-* **Tutorials**
+* **Tutorials: Build Your Harness**
   * [Tutorial Overview](tutorial/README.md)
   * [1. First Harness](tutorial/01-first-harness.md)
   * [2. Vendors & Symlinks](tutorial/02-vendors-and-symlinks.md)
   * [3. Composition](tutorial/03-composition.md)
-  * [4. Delegation](tutorial/04-delegation.md)
-  * [5. Export](tutorial/05-export.md)
-  * [6. Marketplace](tutorial/06-marketplace.md)
-  * [7. Registry & Discovery](tutorial/07-registry-and-discovery.md)
-  * [8. Developer Tools](tutorial/08-developer-tools.md)
-  * [9. Docker Images](tutorial/09-docker-image.md)
-  * [10. Hooks](tutorial/10-hooks.md)
-  * [11. MCP Servers](tutorial/11-mcp-servers.md)
-  * [12. Developer Preview](tutorial/12-developer-preview.md)
-  * [13. Profiles](tutorial/13-profiles.md)
-  * [Manual Test Plan](tutorial/manual-test-plan.md)
+  * [4. Hooks](tutorial/10-hooks.md)
+  * [5. MCP Servers](tutorial/11-mcp-servers.md)
+  * [6. Profiles](tutorial/13-profiles.md)
+
+* **Tutorials: Refine**
+  * [7. Developer Tools](tutorial/08-developer-tools.md)
+  * [8. Developer Preview](tutorial/12-developer-preview.md)
+
+* **Tutorials: Share & Scale**
+  * [9. Delegation](tutorial/04-delegation.md)
+  * [10. Export](tutorial/05-export.md)
+  * [11. Marketplace](tutorial/06-marketplace.md)
+  * [12. Registry & Discovery](tutorial/07-registry-and-discovery.md)
+  * [13. Docker Images](tutorial/09-docker-image.md)
 
 * **Project**
+  * [Manual Test Plan](tutorial/manual-test-plan.md)
   * [Contributing](https://github.com/eyelock/ynh/blob/main/.github/CONTRIBUTING.md)

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -197,4 +197,4 @@ All three sources are merged into the same vendor config at runtime. If two sour
 
 ## Exporting Artifacts
 
-Artifacts can be exported from ynh's harness format into vendor-native plugin layouts using `ynd export`. This resolves all remote includes, flattens the result, and writes distributable output per vendor. See the [export command reference](ynd.md#export) and [Tutorial 5](tutorial/05-export.md) for details.
+Artifacts can be exported from ynh's harness format into vendor-native plugin layouts using `ynd export`. This resolves all remote includes, flattens the result, and writes distributable output per vendor. See the [export command reference](ynd.md#export) and [Tutorial 10](tutorial/05-export.md) for details.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+> **Prefer a guided walkthrough?** Start with [Tutorial 1: First Harness](tutorial/01-first-harness.md).
+
 ## Install
 
 ```bash
@@ -19,8 +21,6 @@ The `~/.ynh/` directory is created automatically on first use. To customize the 
 ```bash
 export YNH_HOME="$HOME/.config/ynh"
 ```
-
-See [CLI Reference](reference.md) for the full list of environment variables and CLI flags.
 
 ## Create a Harness
 
@@ -54,13 +54,17 @@ david                              # interactive session
 david "explain what this function does"   # one-shot
 ```
 
-### Install from a monorepo
-
-Use `--path` to install a harness from a subdirectory:
+## Switch Vendors
 
 ```bash
-ynh install github.com/org/assistants --path harnesses/david
-ynh install ./local-monorepo --path plugins/my-plugin
+david -v codex
+david -v cursor
+```
+
+Or set a global default in `~/.ynh/config.json`:
+
+```json
+{"default_vendor": "codex"}
 ```
 
 ## Pull Skills From Git
@@ -96,7 +100,43 @@ Reinstall to pick up changes:
 ynh install ./david
 ```
 
-## Private Repositories
+## Passing Vendor Flags
+
+All flags except `-v`, `--install`, and `--clean` are passed through to the vendor CLI. Use `--` to separate vendor flags from the prompt:
+
+```bash
+david --model opus -- "fix this bug"
+david -v codex -- "refactor auth"
+```
+
+When there are no vendor flags, the prompt can be a plain argument:
+
+```bash
+david "explain this function"
+```
+
+## Next Steps
+
+- [Harness Reference](harnesses.md) - full manifest syntax
+- [Artifacts Guide](artifacts.md) - skills, agents, rules, commands
+- [Vendor Support](vendors.md) - supported vendors and switching between them
+- [Tutorials](tutorial/README.md) - progressive walkthroughs from first harness to Docker images
+- [ynd Developer Tools](ynd.md) - authoring, exporting, and marketplace building
+
+---
+
+## Advanced Topics
+
+### Install from a Monorepo
+
+Use `--path` to install a harness from a subdirectory:
+
+```bash
+ynh install github.com/org/assistants --path harnesses/david
+ynh install ./local-monorepo --path plugins/my-plugin
+```
+
+### Private Repositories
 
 ynh uses your local `git` for all cloning. If `git clone` works on your machine, `ynh` works too - it inherits whatever authentication you already have configured.
 
@@ -136,20 +176,7 @@ The shorthand form expands to an SSH URL (`git@github.com:company/private-repo.g
 git ls-remote git@github.com:company/private-skills.git
 ```
 
-## Switch Vendors
-
-```bash
-david -v codex
-david -v cursor
-```
-
-Or set a global default in `~/.ynh/config.json`:
-
-```json
-{"default_vendor": "codex"}
-```
-
-## Restrict Remote Sources
+### Restrict Remote Sources
 
 By default, harnesses can pull skills and agents from any Git repo via `includes` or `delegates_to`. You can restrict which remote sources are allowed by adding an `allowed_remote_sources` list to `~/.ynh/config.json`:
 
@@ -204,22 +231,7 @@ david -v cursor --clean       # removes symlinks
 
 Use `ynh status` to see all symlink installations and `ynh prune` to clean up orphaned ones.
 
-## Passing Vendor Flags
-
-All flags except `-v`, `--install`, and `--clean` are passed through to the vendor CLI. Use `--` to separate vendor flags from the prompt:
-
-```bash
-david --model opus -- "fix this bug"
-david -v codex -- "refactor auth"
-```
-
-When there are no vendor flags, the prompt can be a plain argument:
-
-```bash
-david "explain this function"
-```
-
-## Discover and Install From Registries
+### Discover and Install From Registries
 
 A registry is a Git repository containing a `registry.json` that indexes available harnesses. You can add registries to discover and install harnesses by name instead of URL.
 
@@ -237,7 +249,7 @@ ynh install go-dev
 ynh install go-dev@eyelock
 ```
 
-### Registry management
+**Registry management:**
 
 ```bash
 ynh registry list              # show configured registries
@@ -245,7 +257,7 @@ ynh registry remove <url>      # remove a registry
 ynh registry update            # refresh all cached registries
 ```
 
-### Install disambiguation
+**Install disambiguation:**
 
 ynh resolves install arguments in this order:
 
@@ -260,9 +272,9 @@ ynh resolves install arguments in this order:
 
 Plain word matches: single match installs directly; multiple matches errors with disambiguation guidance; no exact match searches descriptions and suggests similar results.
 
-See [Tutorial 7: Registry & Discovery](tutorial/07-registry-and-discovery.md) for a guided walkthrough.
+See [Tutorial 12: Registry & Discovery](tutorial/07-registry-and-discovery.md) for a guided walkthrough.
 
-## Build From Source
+### Build From Source
 
 If you prefer not to use Homebrew:
 
@@ -274,12 +286,3 @@ make install
 export PATH="$HOME/.ynh/bin:$PATH"
 ynh install ./david
 ```
-
-## Next Steps
-
-- [Harness Reference](harnesses.md) - full manifest syntax
-- [Artifacts Guide](artifacts.md) - skills, agents, rules, commands
-- [Vendor Support](vendors.md) - supported vendors and switching between them
-- [Docker](docker.md) - run harnesses in containers, build harness appliance images for CI/CD
-- [ynd Developer Tools](ynd.md) - authoring, exporting, and marketplace building
-- [Tutorials](tutorial/README.md) - progressive walkthroughs from first harness to Docker images

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -179,6 +179,6 @@ When writing hook scripts for use across vendors:
 
 ## See Also
 
-- [Tutorial 10: Hooks](tutorial/10-hooks.md) — step-by-step walkthrough
+- [Tutorial 4: Hooks](tutorial/10-hooks.md) — step-by-step walkthrough
 - [Harness Engineering](harness-engineering.md) — how hooks bridge guides to sensors
 - [Vendor Support](vendors.md) — vendor capabilities and differences

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -378,5 +378,5 @@ Add the marketplace URL in Cursor's plugin settings, then install from the IDE m
 - Cursor marketplace: [cursor.com/marketplace](https://cursor.com/marketplace)
 - Cursor plugins: [cursor.com/docs/plugins](https://cursor.com/docs/plugins)
 - Codex CLI: [developers.openai.com/codex/cli](https://developers.openai.com/codex/cli)
-- ynh marketplace tutorial: [Tutorial 6: Marketplace](tutorial/06-marketplace.md)
+- ynh marketplace tutorial: [Tutorial 11: Marketplace](tutorial/06-marketplace.md)
 - ynd marketplace command: [ynd Developer Tools](ynd.md#marketplace-build)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -145,6 +145,6 @@ The [Agentic AI Foundation (AAIF)](https://www.linuxfoundation.org/press/linux-f
 
 ## See Also
 
-- [Tutorial 11: MCP Servers](tutorial/11-mcp-servers.md) — step-by-step walkthrough
+- [Tutorial 5: MCP Servers](tutorial/11-mcp-servers.md) — step-by-step walkthrough
 - [Hooks](hooks.md) — lifecycle hooks that bridge guides to sensors
 - [Vendor Support](vendors.md) — vendor capabilities and differences

--- a/docs/tutorial/03-composition.md
+++ b/docs/tutorial/03-composition.md
@@ -484,4 +484,4 @@ ynh uninstall my-dev with-anthropic with-vercel full-stack mixed local-ref pinne
 
 ## Next
 
-[Tutorial 4: Delegation](tutorial/04-delegation.md) — chain harnesses together as subagents.
+[Tutorial 4: Hooks](tutorial/10-hooks.md) — declare vendor-agnostic lifecycle hooks.

--- a/docs/tutorial/04-delegation.md
+++ b/docs/tutorial/04-delegation.md
@@ -152,4 +152,4 @@ ynh uninstall team-lead
 
 ## Next
 
-[Tutorial 5: Export](tutorial/05-export.md) — produce vendor-native distributable plugins.
+[Tutorial 10: Export](tutorial/05-export.md) — produce vendor-native distributable plugins.

--- a/docs/tutorial/05-export.md
+++ b/docs/tutorial/05-export.md
@@ -284,4 +284,4 @@ rm -rf /tmp/ynh-tutorial/no-inst-out
 
 ## Next
 
-[Tutorial 6: Marketplace](tutorial/06-marketplace.md) — generate marketplace indexes for distribution.
+[Tutorial 11: Marketplace](tutorial/06-marketplace.md) — generate marketplace indexes for distribution.

--- a/docs/tutorial/06-marketplace.md
+++ b/docs/tutorial/06-marketplace.md
@@ -247,4 +247,4 @@ rm -rf /tmp/ynh-tutorial/marketplace-*
 
 ## Next
 
-[Tutorial 7: Registry & Discovery](tutorial/07-registry-and-discovery.md) — search and install from curated indexes.
+[Tutorial 12: Registry & Discovery](tutorial/07-registry-and-discovery.md) — search and install from curated indexes.

--- a/docs/tutorial/07-registry-and-discovery.md
+++ b/docs/tutorial/07-registry-and-discovery.md
@@ -261,4 +261,4 @@ ynh uninstall tester 2>/dev/null
 
 ## Next
 
-[Tutorial 8: Developer Tools](tutorial/08-developer-tools.md) — scaffold, lint, validate, format, compress, inspect with ynd.
+[Tutorial 13: Docker Images](tutorial/09-docker-image.md) — build harness appliance images for CI/CD.

--- a/docs/tutorial/08-developer-tools.md
+++ b/docs/tutorial/08-developer-tools.md
@@ -246,4 +246,4 @@ rm -rf /tmp/ynh-tutorial
 
 ## Complete
 
-Continue to [Tutorial 9: Docker Images](tutorial/09-docker-image.md) or jump to [Tutorial 13: Profiles](tutorial/13-profiles.md) for the profile system.
+[Tutorial 8: Developer Preview](tutorial/12-developer-preview.md) — preview and diff assembled output across vendors.

--- a/docs/tutorial/10-hooks.md
+++ b/docs/tutorial/10-hooks.md
@@ -236,4 +236,4 @@ rm -rf /tmp/ynh-tutorial
 
 ## Next
 
-[Tutorial 11: MCP Servers](11-mcp-servers.md) — declare tool dependencies that vendors load automatically.
+[Tutorial 5: MCP Servers](tutorial/11-mcp-servers.md) — declare tool dependencies that vendors load automatically.

--- a/docs/tutorial/11-mcp-servers.md
+++ b/docs/tutorial/11-mcp-servers.md
@@ -213,4 +213,4 @@ rm -rf /tmp/ynh-tutorial
 
 ## Next
 
-[Tutorial 12: Developer Preview](12-developer-preview.md) — use preview and diff to iterate on harness design.
+[Tutorial 6: Profiles](tutorial/13-profiles.md) — configure environment-specific overrides with profiles.

--- a/docs/tutorial/12-developer-preview.md
+++ b/docs/tutorial/12-developer-preview.md
@@ -280,4 +280,4 @@ rm -rf /tmp/ynh-tutorial
 
 ## Next
 
-[Tutorial 13: Profiles](13-profiles.md) — configure environment-specific overrides with profiles.
+[Tutorial 9: Delegation](tutorial/04-delegation.md) — chain harnesses together as subagents.

--- a/docs/tutorial/13-profiles.md
+++ b/docs/tutorial/13-profiles.md
@@ -225,4 +225,4 @@ rm -rf /tmp/ynh-tutorial
 
 ## Next
 
-Return to the [Tutorial Overview](README.md) for a full list of tutorials.
+[Tutorial 7: Developer Tools](tutorial/08-developer-tools.md) — scaffold, lint, validate, format, compress, inspect with ynd.

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -4,21 +4,33 @@ Progressive tutorials from first steps to advanced configurations. Each tutorial
 
 ## Tutorials
 
+### Build Your Harness
+
 | # | Tutorial | What you'll learn |
 |---|----------|-------------------|
 | 1 | [First Harness](tutorial/01-first-harness.md) | Create, install, and run a harness with all artifact types |
 | 2 | [Vendors & Symlinks](tutorial/02-vendors-and-symlinks.md) | Switch between Claude/Codex/Cursor, manage symlinks |
 | 3 | [Composition](tutorial/03-composition.md) | Pull skills from Git repos with pick, path, and ref |
-| 4 | [Delegation](tutorial/04-delegation.md) | Chain harnesses together as subagents |
-| 5 | [Export](tutorial/05-export.md) | Produce vendor-native distributable plugins |
-| 6 | [Marketplace](tutorial/06-marketplace.md) | Generate marketplace indexes for team distribution |
-| 7 | [Registry & Discovery](tutorial/07-registry-and-discovery.md) | Search and install harnesses from curated registries |
-| 8 | [Developer Tools](tutorial/08-developer-tools.md) | Scaffold, lint, validate, format, compress, inspect with ynd |
-| 9 | [Docker Images](tutorial/09-docker-image.md) | Build harness appliance images for CI/CD |
-| 10 | [Hooks](tutorial/10-hooks.md) | Declare vendor-agnostic lifecycle hooks |
-| 11 | [MCP Servers](tutorial/11-mcp-servers.md) | Declare MCP server dependencies per harness |
-| 12 | [Developer Preview](tutorial/12-developer-preview.md) | Preview and diff assembled output across vendors |
-| 13 | [Profiles](tutorial/13-profiles.md) | Environment-specific overrides with profiles |
+| 4 | [Hooks](tutorial/10-hooks.md) | Declare vendor-agnostic lifecycle hooks |
+| 5 | [MCP Servers](tutorial/11-mcp-servers.md) | Declare MCP server dependencies per harness |
+| 6 | [Profiles](tutorial/13-profiles.md) | Environment-specific overrides with profiles |
+
+### Refine
+
+| # | Tutorial | What you'll learn |
+|---|----------|-------------------|
+| 7 | [Developer Tools](tutorial/08-developer-tools.md) | Scaffold, lint, validate, format, compress, inspect with ynd |
+| 8 | [Developer Preview](tutorial/12-developer-preview.md) | Preview and diff assembled output across vendors |
+
+### Share & Scale
+
+| # | Tutorial | What you'll learn |
+|---|----------|-------------------|
+| 9 | [Delegation](tutorial/04-delegation.md) | Chain harnesses together as subagents |
+| 10 | [Export](tutorial/05-export.md) | Produce vendor-native distributable plugins |
+| 11 | [Marketplace](tutorial/06-marketplace.md) | Generate marketplace indexes for team distribution |
+| 12 | [Registry & Discovery](tutorial/07-registry-and-discovery.md) | Search and install harnesses from curated registries |
+| 13 | [Docker Images](tutorial/09-docker-image.md) | Build harness appliance images for CI/CD |
 
 ## Manual Test Plan
 
@@ -72,4 +84,4 @@ You also need at least one AI coding assistant CLI installed:
 | OpenAI Codex | `codex` | `npm install -g @openai/codex` |
 | Cursor | `agent` | Bundled with [Cursor](https://cursor.com) |
 
-Claude Code is used in most tutorial examples. Codex and Cursor are needed for Tutorial 2 (Vendors & Symlinks) and Tutorial 5 (Export).
+Claude Code is used in most tutorial examples. Codex and Cursor are needed for Tutorial 2 (Vendors & Symlinks) and Tutorial 10 (Export).

--- a/docs/ynd.md
+++ b/docs/ynd.md
@@ -113,7 +113,7 @@ When no `-o` flag is given, preview prints a tree with file contents to stdout. 
 
 Preview supports the same source types as export: local directories with `harness.json` or bare `AGENTS.md` directories.
 
-See [Tutorial 12: Developer Preview](tutorial/12-developer-preview.md) for a guided walkthrough.
+See [Tutorial 8: Developer Preview](tutorial/12-developer-preview.md) for a guided walkthrough.
 
 ### diff
 
@@ -135,7 +135,7 @@ The diff output groups files into four categories:
 
 At least two vendors are required for comparison. If no vendors are specified, all registered vendors are compared.
 
-See [Tutorial 12: Developer Preview](tutorial/12-developer-preview.md) for a guided walkthrough.
+See [Tutorial 8: Developer Preview](tutorial/12-developer-preview.md) for a guided walkthrough.
 
 ### export
 
@@ -194,7 +194,7 @@ Key differences from runtime layout:
 - Codex is limited to skills only — agents, rules, commands, and delegates are excluded with warnings
 - `--merged` produces one directory with both `.claude-plugin/` and `.cursor-plugin/` manifests; Codex is excluded from merged mode
 
-See [Tutorial 5: Export](tutorial/05-export.md) for a guided walkthrough.
+See [Tutorial 10: Export](tutorial/05-export.md) for a guided walkthrough.
 
 ### marketplace build
 
@@ -247,7 +247,7 @@ dist/
 └── README.md
 ```
 
-See [Tutorial 6: Marketplace](tutorial/06-marketplace.md) for a guided walkthrough.
+See [Tutorial 11: Marketplace](tutorial/06-marketplace.md) for a guided walkthrough.
 
 ## Common Options
 


### PR DESCRIPTION
## Summary

- **GitHub README rewritten** — leads with "Your name. Your AI." pitch, 60-second quickstart, "Why harness management?" section (Fowler/OpenAI/Anthropic). Disclaimer removed. Command tables moved to docs.
- **Tutorial reading order restructured** — sidebar and tutorial README reordered as Build (1-6) → Refine (7-8) → Share & Scale (9-13). Files not renamed — sidebar controls reading order.
- **Getting-started streamlined** — core flow at top, advanced topics (allow-lists, registries, private repos) below a divider. Tutorial 1 cross-referenced as alternative.
- **Harness Engineering promoted** — first item in sidebar under "Why" section, linked from README.
- **All cross-references updated** — 10 tutorial "Next" links and 8 tutorial number references in reference docs updated to match new order.

## Motivation

The docs were technically thorough but told the wrong story in the wrong order:
1. GitHub README was a dry technical reference; the compelling pitch was hidden in the docsify docs
2. Tutorials jumped from "build your harness" to "distribute it" (tutorials 5-7) before teaching hooks, MCP, profiles, or dev tools
3. The strongest page (harness-engineering.md) was buried third in the sidebar

## What's NOT changed

- No code changes, no CLI behavior changes
- Tutorial content unchanged — only reading order and navigation links
- Tutorial filenames unchanged (no renumbering)
- Reference docs (harnesses.md, artifacts.md, vendors.md, etc.) unchanged
- Manual test plan unchanged (uses filename-based T-numbers)

## Pre-existing issues found during eval (not in this PR)

| Tutorial | Issue |
|----------|-------|
| T8.1 | Scaffold output says `instructions.md`, actual is `AGENTS.md` |
| T10.2 | Says hooks in `.claude/settings.json`, actual is `.claude/hooks/hooks.json` |
| T11.4 | Says Codex uses TOML `.codex/config.toml`, actual is JSON `.mcp.json` |

## Test plan

- [ ] Verify docsify renders correctly (`docsify serve docs/`)
- [ ] All sidebar links resolve to real files
- [ ] Follow tutorial "Next" links through all 13 tutorials — chain is complete
- [ ] GitHub README links point to correct docs pages
- [ ] Read GitHub README cold — does it hook?

🤖 Generated with [Claude Code](https://claude.com/claude-code)