### PR TITLE
refactor: error handling cleanup

### DIFF
--- a/cmd/ynd/compress.go
+++ b/cmd/ynd/compress.go
@@ -21,10 +21,15 @@ func cmdCompress(args []string) error {
 		if len(opts.files) == 0 {
 			return fmt.Errorf("--list-backups requires a file argument")
 		}
+		var errs []string
 		for _, f := range opts.files {
 			if err := listBackups(f); err != nil {
 				fmt.Fprintf(os.Stderr, "%s: %v\n", f, err)
+				errs = append(errs, f)
 			}
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("failed to list backups for %d file(s)", len(errs))
 		}
 		return nil
 	}
@@ -34,10 +39,15 @@ func cmdCompress(args []string) error {
 		if len(opts.files) == 0 {
 			return fmt.Errorf("--restore requires a file argument")
 		}
+		var errs []string
 		for _, f := range opts.files {
 			if err := restoreBackup(f, opts.pick); err != nil {
 				fmt.Fprintf(os.Stderr, "%s: %v\n", f, err)
+				errs = append(errs, f)
 			}
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("failed to restore %d file(s)", len(errs))
 		}
 		return nil
 	}

--- a/cmd/ynd/create.go
+++ b/cmd/ynd/create.go
@@ -143,7 +143,10 @@ func createHarness(name string) error {
 		Description:   "",
 		DefaultVendor: resolveVendorDefault(""),
 	}
-	data, _ := json.MarshalIndent(scaffold, "", "  ")
+	data, err := json.MarshalIndent(scaffold, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling harness.json: %w", err)
+	}
 	if err := os.WriteFile(filepath.Join(name, "harness.json"), append(data, '\n'), 0o644); err != nil {
 		return err
 	}

--- a/cmd/ynd/diff.go
+++ b/cmd/ynd/diff.go
@@ -117,8 +117,14 @@ func cmdDiff(args []string) error {
 
 			fmt.Printf("=== %s vs %s ===\n", a.name, b.name)
 
-			filesA := listFiles(a.dir)
-			filesB := listFiles(b.dir)
+			filesA, err := listFiles(a.dir)
+			if err != nil {
+				return fmt.Errorf("listing files for %s: %w", a.name, err)
+			}
+			filesB, err := listFiles(b.dir)
+			if err != nil {
+				return fmt.Errorf("listing files for %s: %w", b.name, err)
+			}
 
 			setA := make(map[string]bool, len(filesA))
 			for _, f := range filesA {
@@ -200,22 +206,25 @@ func cmdDiff(args []string) error {
 }
 
 // listFiles returns all file paths relative to root, sorted.
-func listFiles(root string) []string {
+func listFiles(root string) ([]string, error) {
 	var files []string
-	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return nil
+			return err
 		}
 		if info.IsDir() {
 			return nil
 		}
 		rel, relErr := filepath.Rel(root, path)
 		if relErr != nil {
-			return nil
+			return relErr
 		}
 		files = append(files, rel)
 		return nil
 	})
+	if err != nil {
+		return nil, fmt.Errorf("walking %s: %w", root, err)
+	}
 	sort.Strings(files)
-	return files
+	return files, nil
 }

--- a/cmd/ynd/llm.go
+++ b/cmd/ynd/llm.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -51,8 +52,8 @@ func queryLLMImpl(vendor, prompt string) (string, error) {
 
 	output, err := cmd.Output()
 	if err != nil {
-		// Check for stderr in the exit error
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			msg := strings.TrimSpace(string(exitErr.Stderr))
 			if msg != "" {
 				return "", fmt.Errorf("%s: %w", msg, err)
@@ -63,7 +64,7 @@ func queryLLMImpl(vendor, prompt string) (string, error) {
 
 	result := strings.TrimSpace(string(output))
 	if result == "" {
-		return "", fmt.Errorf("LLM returned empty response")
+		return "", fmt.Errorf("llm returned empty response")
 	}
 
 	return result, nil

--- a/cmd/ynh/install_resolve.go
+++ b/cmd/ynh/install_resolve.go
@@ -61,7 +61,7 @@ func lookupFromRegistry(name, regName string, cfg *config.Config) (resolvedSourc
 
 	regs, err := registry.FetchAll(cfg.Registries)
 	if err != nil {
-		return resolvedSource{}, err
+		return resolvedSource{}, fmt.Errorf("fetching registries: %w", err)
 	}
 
 	results := registry.LookupExact(regs, name, regName)
@@ -88,7 +88,7 @@ func searchFromRegistry(name string, cfg *config.Config) (resolvedSource, error)
 
 	regs, err := registry.FetchAll(cfg.Registries)
 	if err != nil {
-		return resolvedSource{}, err
+		return resolvedSource{}, fmt.Errorf("fetching registries: %w", err)
 	}
 
 	results := registry.LookupExact(regs, name, "")

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -198,7 +198,7 @@ func cmdInstall(args []string) error {
 	if isLocalPath(source) {
 		absPath, err := filepath.Abs(source)
 		if err != nil {
-			return err
+			return fmt.Errorf("resolving absolute path for %s: %w", source, err)
 		}
 		srcDir = absPath
 	} else {
@@ -240,11 +240,11 @@ func cmdInstall(args []string) error {
 		return fmt.Errorf("cleaning install dir: %w", err)
 	}
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
-		return err
+		return fmt.Errorf("creating install directory: %w", err)
 	}
 
 	if err := copyTree(srcDir, installDir); err != nil {
-		return err
+		return fmt.Errorf("copying harness to install directory: %w", err)
 	}
 
 	// Inject install provenance into the copied harness.json
@@ -420,7 +420,7 @@ func cmdRun(args []string) error {
 	}
 
 	if err := config.EnsureDirs(); err != nil {
-		return err
+		return fmt.Errorf("ensuring directories: %w", err)
 	}
 
 	name := args[0]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -33,7 +34,10 @@ func HomeDir() string {
 	if env := os.Getenv("YNH_HOME"); env != "" {
 		return env
 	}
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
 	return filepath.Join(home, DefaultDirName)
 }
 
@@ -68,7 +72,7 @@ func EnsureDirs() error {
 	}
 	for _, dir := range dirs {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return err
+			return fmt.Errorf("creating directory %s: %w", dir, err)
 		}
 	}
 	return nil
@@ -84,11 +88,11 @@ func Load() (*Config, error) {
 		if os.IsNotExist(err) {
 			return cfg, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("reading config: %w", err)
 	}
 
 	if err := json.Unmarshal(data, cfg); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 
 	return cfg, nil
@@ -96,13 +100,16 @@ func Load() (*Config, error) {
 
 func (c *Config) Save() error {
 	if err := os.MkdirAll(HomeDir(), 0o755); err != nil {
-		return err
+		return fmt.Errorf("creating config directory: %w", err)
 	}
 
 	data, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
-		return err
+		return fmt.Errorf("marshalling config: %w", err)
 	}
 
-	return os.WriteFile(ConfigPath(), data, 0o644)
+	if err := os.WriteFile(ConfigPath(), data, 0o644); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	return nil
 }

--- a/internal/config/sourcecheck.go
+++ b/internal/config/sourcecheck.go
@@ -22,7 +22,7 @@ func (c *Config) CheckRemoteSource(gitURL string) error {
 		}
 	}
 
-	return fmt.Errorf("remote source %q is not in the allowed sources list\n  configure allowed_remote_sources in %s", gitURL, ConfigPath())
+	return fmt.Errorf("remote source %q is not in the allowed sources list", gitURL)
 }
 
 // normalizeForMatch strips a Git URL down to a canonical host/path form for matching.

--- a/internal/symlink/log.go
+++ b/internal/symlink/log.go
@@ -2,6 +2,7 @@ package symlink
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -39,12 +40,12 @@ func LoadLog() (*Log, error) {
 		if os.IsNotExist(err) {
 			return &Log{}, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("reading symlink log: %w", err)
 	}
 
 	var log Log
 	if err := json.Unmarshal(data, &log); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing symlink log: %w", err)
 	}
 	return &log, nil
 }
@@ -52,14 +53,18 @@ func LoadLog() (*Log, error) {
 // Save writes the transaction log to disk.
 func (l *Log) Save() error {
 	if err := os.MkdirAll(filepath.Dir(LogPath()), 0o755); err != nil {
-		return err
+		return fmt.Errorf("creating symlink log directory: %w", err)
 	}
 
 	data, err := json.MarshalIndent(l, "", "  ")
 	if err != nil {
-		return err
+		return fmt.Errorf("marshalling symlink log: %w", err)
 	}
-	return os.WriteFile(LogPath(), data, 0o644)
+
+	if err := os.WriteFile(LogPath(), data, 0o644); err != nil {
+		return fmt.Errorf("writing symlink log: %w", err)
+	}
+	return nil
 }
 
 // Record adds or updates an installation entry in the log.


### PR DESCRIPTION
## Summary
- Wrap bare `return err` with contextual messages across config, symlink, install, and run paths
- Replace `err.(*exec.ExitError)` type assertion with `errors.As()` in LLM handler
- Lowercase error string, remove embedded newline from source check error
- Handle `os.UserHomeDir()` error with fallback in `config.HomeDir()`
- Track and return summary errors in compress list/restore flows
- Check `filepath.Walk` and `json.MarshalIndent` errors instead of discarding

## Test plan
- [x] `make check` passes (format, lint, test, build)
- [x] All existing tests pass — no API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)