### PR TITLE
refactor: errcheck + stderr discipline

### DIFF
--- a/cmd/ynd/compress.go
+++ b/cmd/ynd/compress.go
@@ -64,14 +64,14 @@ func cmdCompress(args []string) error {
 	if opts.vendor == "" {
 		opts.vendor = detectVendorCLI()
 		if opts.vendor == "" {
-			fmt.Println("No supported LLM CLI found (checked: claude, codex).")
-			fmt.Println("Compression requires an LLM to perform semantic optimization.")
-			fmt.Println()
-			fmt.Println("Install one of:")
-			fmt.Println("  claude  → https://docs.anthropic.com/claude-code")
-			fmt.Println("  codex   → https://openai.com/codex")
-			fmt.Println()
-			fmt.Println("Or specify one explicitly: ynd compress -v claude")
+			fmt.Fprintln(os.Stderr, "No supported LLM CLI found (checked: claude, codex).")
+			fmt.Fprintln(os.Stderr, "Compression requires an LLM to perform semantic optimization.")
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Install one of:")
+			fmt.Fprintln(os.Stderr, "  claude  → https://docs.anthropic.com/claude-code")
+			fmt.Fprintln(os.Stderr, "  codex   → https://openai.com/codex")
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Or specify one explicitly: ynd compress -v claude")
 			return nil
 		}
 	} else {

--- a/cmd/ynd/inspect.go
+++ b/cmd/ynd/inspect.go
@@ -27,14 +27,14 @@ func cmdInspect(args []string) error {
 	if vendor == "" {
 		vendor = detectVendorCLI()
 		if vendor == "" {
-			fmt.Println("No supported LLM CLI found (checked: claude, codex).")
-			fmt.Println("Inspect requires an LLM to analyze your codebase.")
-			fmt.Println()
-			fmt.Println("Install one of:")
-			fmt.Println("  claude  → https://docs.anthropic.com/claude-code")
-			fmt.Println("  codex   → https://openai.com/codex")
-			fmt.Println()
-			fmt.Println("Or specify one explicitly: ynd inspect -v claude")
+			fmt.Fprintln(os.Stderr, "No supported LLM CLI found (checked: claude, codex).")
+			fmt.Fprintln(os.Stderr, "Inspect requires an LLM to analyze your codebase.")
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Install one of:")
+			fmt.Fprintln(os.Stderr, "  claude  → https://docs.anthropic.com/claude-code")
+			fmt.Fprintln(os.Stderr, "  codex   → https://openai.com/codex")
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Or specify one explicitly: ynd inspect -v claude")
 			return nil
 		}
 	} else {

--- a/cmd/ynd/preview.go
+++ b/cmd/ynd/preview.go
@@ -210,14 +210,22 @@ func assembleForVendor(srcDir string, vendorName string, profileName string) (st
 
 	// Generate hook config
 	if len(h.Hooks) > 0 {
-		if err := writeGeneratedFiles(tmpDir, adapter.GenerateHookConfig(h.Hooks)); err != nil {
+		hookFiles, err := adapter.GenerateHookConfig(h.Hooks)
+		if err != nil {
+			return "", fmt.Errorf("generating hook config: %w", err)
+		}
+		if err := writeGeneratedFiles(tmpDir, hookFiles); err != nil {
 			return "", fmt.Errorf("writing hook config: %w", err)
 		}
 	}
 
 	// Generate MCP config
 	if len(h.MCPServers) > 0 {
-		if err := writeGeneratedFiles(tmpDir, adapter.GenerateMCPConfig(h.MCPServers)); err != nil {
+		mcpFiles, err := adapter.GenerateMCPConfig(h.MCPServers)
+		if err != nil {
+			return "", fmt.Errorf("generating MCP config: %w", err)
+		}
+		if err := writeGeneratedFiles(tmpDir, mcpFiles); err != nil {
 			return "", fmt.Errorf("writing MCP config: %w", err)
 		}
 	}

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -42,7 +42,7 @@ func main() {
 	case "info":
 		err = cmdInfo(os.Args[2:])
 	case "vendors":
-		cmdVendors()
+		err = cmdVendors()
 	case "status":
 		err = cmdStatus()
 	case "search":
@@ -541,7 +541,10 @@ func cmdRun(args []string) error {
 
 		// Generate vendor-native hook config files
 		if len(p.Hooks) > 0 {
-			hookFiles := adapter.GenerateHookConfig(p.Hooks)
+			hookFiles, err := adapter.GenerateHookConfig(p.Hooks)
+			if err != nil {
+				return fmt.Errorf("generating hook config: %w", err)
+			}
 			for relPath, content := range hookFiles {
 				absPath := filepath.Join(runDir, relPath)
 				if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
@@ -555,7 +558,10 @@ func cmdRun(args []string) error {
 
 		// Generate vendor-native MCP config files
 		if len(p.MCPServers) > 0 {
-			mcpFiles := adapter.GenerateMCPConfig(p.MCPServers)
+			mcpFiles, err := adapter.GenerateMCPConfig(p.MCPServers)
+			if err != nil {
+				return fmt.Errorf("generating MCP config: %w", err)
+			}
 			for relPath, content := range mcpFiles {
 				absPath := filepath.Join(runDir, relPath)
 				if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
@@ -899,16 +905,20 @@ func shortGitURL(url string) string {
 	return url
 }
 
-func cmdVendors() {
+func cmdVendors() error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "NAME\tCLI\tCONFIG DIR")
 
 	for _, name := range vendor.Available() {
-		adapter, _ := vendor.Get(name)
+		adapter, err := vendor.Get(name)
+		if err != nil {
+			return fmt.Errorf("loading vendor %s: %w", name, err)
+		}
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", adapter.Name(), adapter.CLIName(), adapter.ConfigDir())
 	}
 
 	_ = w.Flush()
+	return nil
 }
 
 // resolveVendor picks the vendor: CLI flag > YNH_VENDOR env > harness default > global config.

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -36,12 +36,12 @@ func (m *mockAdapter) LaunchNonInteractive(configPath string, prompt string, ext
 func (m *mockAdapter) GenerateSystemPrompt(content []byte) map[string][]byte {
 	return map[string][]byte{"AGENTS.md": content}
 }
-func (m *mockAdapter) GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[string][]byte {
-	return nil
+func (m *mockAdapter) GenerateHookConfig(hooks map[string][]plugin.HookEntry) (map[string][]byte, error) {
+	return nil, nil
 }
 
-func (m *mockAdapter) GenerateMCPConfig(servers map[string]plugin.MCPServer) map[string][]byte {
-	return nil
+func (m *mockAdapter) GenerateMCPConfig(servers map[string]plugin.MCPServer) (map[string][]byte, error) {
+	return nil, nil
 }
 
 func TestAssembleWithPick(t *testing.T) {

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -337,7 +337,10 @@ func exportForVendor(vendorName string, outputDir string, pj *plugin.HarnessJSON
 
 // writeMCPConfig generates vendor-native MCP config files and writes them to the output directory.
 func writeMCPConfig(outputDir string, adapter vendor.Adapter, servers map[string]plugin.MCPServer) error {
-	mcpFiles := adapter.GenerateMCPConfig(servers)
+	mcpFiles, err := adapter.GenerateMCPConfig(servers)
+	if err != nil {
+		return fmt.Errorf("generating MCP config: %w", err)
+	}
 	for relPath, content := range mcpFiles {
 		absPath := filepath.Join(outputDir, relPath)
 		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
@@ -352,7 +355,10 @@ func writeMCPConfig(outputDir string, adapter vendor.Adapter, servers map[string
 
 // writeHookConfig generates vendor-native hook config files and writes them to the output directory.
 func writeHookConfig(outputDir string, adapter vendor.Adapter, hooks map[string][]plugin.HookEntry) error {
-	hookFiles := adapter.GenerateHookConfig(hooks)
+	hookFiles, err := adapter.GenerateHookConfig(hooks)
+	if err != nil {
+		return fmt.Errorf("generating hook config: %w", err)
+	}
 	for relPath, content := range hookFiles {
 		absPath := filepath.Join(outputDir, relPath)
 		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -161,8 +161,8 @@ func CacheOnlyRepo(gitURL string, ref string) (RepoResult, error) {
 		return RepoResult{Path: repoDir}, nil
 	}
 
-	// Cache miss — fall back to network fetch with warning
-	fmt.Fprintf(os.Stderr, "  Cache miss for %s, fetching...\n", ShortGitURL(gitURL))
+	// Cache miss — fall back to network fetch.
+	// Caller can detect this via RepoResult.Cloned.
 	return EnsureRepo(gitURL, ref)
 }
 

--- a/internal/vendor/adapter.go
+++ b/internal/vendor/adapter.go
@@ -65,12 +65,12 @@ type Adapter interface {
 	// GenerateHookConfig translates canonical hook declarations to vendor-native
 	// hook configuration files. Returns a map of relative file paths to file contents.
 	// Returns nil if hooks is nil or empty.
-	GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[string][]byte
+	GenerateHookConfig(hooks map[string][]plugin.HookEntry) (map[string][]byte, error)
 
 	// GenerateMCPConfig translates MCP server declarations to vendor-native
 	// MCP configuration files. Returns a map of relative file paths to file contents.
 	// Returns nil if servers is nil or empty.
-	GenerateMCPConfig(servers map[string]plugin.MCPServer) map[string][]byte
+	GenerateMCPConfig(servers map[string]plugin.MCPServer) (map[string][]byte, error)
 }
 
 // DefaultName is the fallback vendor when no vendor is specified.

--- a/internal/vendor/claude.go
+++ b/internal/vendor/claude.go
@@ -2,6 +2,7 @@ package vendor
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -89,9 +90,9 @@ var claudeHookEventMap = map[string]string{
 	"on_stop":       "Stop",
 }
 
-func (c *Claude) GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[string][]byte {
+func (c *Claude) GenerateHookConfig(hooks map[string][]plugin.HookEntry) (map[string][]byte, error) {
 	if len(hooks) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Claude's three-level structure:
@@ -156,7 +157,7 @@ func (c *Claude) GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[str
 	}
 
 	if len(allEvents) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	settings := map[string]any{
@@ -165,7 +166,7 @@ func (c *Claude) GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[str
 
 	data, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("marshalling hook config: %w", err)
 	}
 	data = append(data, '\n')
 
@@ -174,12 +175,12 @@ func (c *Claude) GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[str
 	// not from settings.json (which only supports the "agent" key in plugins).
 	return map[string][]byte{
 		filepath.Join(".claude", "hooks", "hooks.json"): data,
-	}
+	}, nil
 }
 
-func (c *Claude) GenerateMCPConfig(servers map[string]plugin.MCPServer) map[string][]byte {
+func (c *Claude) GenerateMCPConfig(servers map[string]plugin.MCPServer) (map[string][]byte, error) {
 	if len(servers) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Claude uses .mcp.json with "mcpServers" key — direct passthrough
@@ -189,7 +190,7 @@ func (c *Claude) GenerateMCPConfig(servers map[string]plugin.MCPServer) map[stri
 
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("marshalling MCP config: %w", err)
 	}
 	data = append(data, '\n')
 
@@ -197,7 +198,7 @@ func (c *Claude) GenerateMCPConfig(servers map[string]plugin.MCPServer) map[stri
 	// as a plugin-provided MCP server configuration.
 	return map[string][]byte{
 		filepath.Join(".claude", ".mcp.json"): data,
-	}
+	}, nil
 }
 
 func launchClaude(configPath string, extraArgs []string) error {

--- a/internal/vendor/claude_test.go
+++ b/internal/vendor/claude_test.go
@@ -143,7 +143,10 @@ func TestBuildClaudeArgs_NonInteractive(t *testing.T) {
 
 func TestClaudeGenerateHookConfig_NilHooks(t *testing.T) {
 	c := &Claude{}
-	result := c.GenerateHookConfig(nil)
+	result, err := c.GenerateHookConfig(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != nil {
 		t.Error("expected nil for nil hooks")
 	}
@@ -151,7 +154,10 @@ func TestClaudeGenerateHookConfig_NilHooks(t *testing.T) {
 
 func TestClaudeGenerateHookConfig_EmptyHooks(t *testing.T) {
 	c := &Claude{}
-	result := c.GenerateHookConfig(map[string][]plugin.HookEntry{})
+	result, err := c.GenerateHookConfig(map[string][]plugin.HookEntry{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != nil {
 		t.Error("expected nil for empty hooks")
 	}
@@ -170,7 +176,10 @@ func TestClaudeGenerateHookConfig_ThreeLevelNesting(t *testing.T) {
 		},
 	}
 
-	result := c.GenerateHookConfig(hooks)
+	result, err := c.GenerateHookConfig(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -235,7 +244,10 @@ func TestClaudeGenerateHookConfig_ThreeLevelNesting(t *testing.T) {
 
 func TestClaudeGenerateMCPConfig_NilServers(t *testing.T) {
 	c := &Claude{}
-	result := c.GenerateMCPConfig(nil)
+	result, err := c.GenerateMCPConfig(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != nil {
 		t.Error("expected nil for nil servers")
 	}
@@ -243,7 +255,10 @@ func TestClaudeGenerateMCPConfig_NilServers(t *testing.T) {
 
 func TestClaudeGenerateMCPConfig_EmptyServers(t *testing.T) {
 	c := &Claude{}
-	result := c.GenerateMCPConfig(map[string]plugin.MCPServer{})
+	result, err := c.GenerateMCPConfig(map[string]plugin.MCPServer{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != nil {
 		t.Error("expected nil for empty servers")
 	}
@@ -259,7 +274,10 @@ func TestClaudeGenerateMCPConfig_Passthrough(t *testing.T) {
 		},
 	}
 
-	result := c.GenerateMCPConfig(servers)
+	result, err := c.GenerateMCPConfig(servers)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -303,7 +321,10 @@ func TestClaudeGenerateHookConfig_EventTranslation(t *testing.T) {
 		"on_stop":       {{Command: "cmd4"}},
 	}
 
-	result := c.GenerateHookConfig(hooks)
+	result, err := c.GenerateHookConfig(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
 	data := result[filepath.Join(".claude", "hooks", "hooks.json")]
 
 	var settings map[string]any

--- a/internal/vendor/codex.go
+++ b/internal/vendor/codex.go
@@ -2,6 +2,7 @@ package vendor
 
 import (
 	"encoding/json"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -62,9 +63,9 @@ var codexHookEventMap = map[string]string{
 	"on_stop":       "Stop",
 }
 
-func (c *Codex) GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[string][]byte {
+func (c *Codex) GenerateHookConfig(hooks map[string][]plugin.HookEntry) (map[string][]byte, error) {
 	if len(hooks) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Codex three-level format (same structure as Claude Code):
@@ -128,7 +129,7 @@ func (c *Codex) GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[stri
 	}
 
 	if len(allEvents) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	config := map[string]any{
@@ -137,18 +138,18 @@ func (c *Codex) GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[stri
 
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("marshalling hook config: %w", err)
 	}
 	data = append(data, '\n')
 
 	return map[string][]byte{
 		filepath.Join(".codex", "hooks.json"): data,
-	}
+	}, nil
 }
 
-func (c *Codex) GenerateMCPConfig(servers map[string]plugin.MCPServer) map[string][]byte {
+func (c *Codex) GenerateMCPConfig(servers map[string]plugin.MCPServer) (map[string][]byte, error) {
 	if len(servers) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Codex plugin format uses .mcp.json at plugin root (JSON, same as Claude).
@@ -159,13 +160,13 @@ func (c *Codex) GenerateMCPConfig(servers map[string]plugin.MCPServer) map[strin
 
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("marshalling MCP config: %w", err)
 	}
 	data = append(data, '\n')
 
 	return map[string][]byte{
 		".mcp.json": data,
-	}
+	}, nil
 }
 
 func launchCodex(configPath string, extraArgs []string) error {

--- a/internal/vendor/codex_test.go
+++ b/internal/vendor/codex_test.go
@@ -10,7 +10,10 @@ import (
 
 func TestCodexGenerateHookConfig_NilHooks(t *testing.T) {
 	c := &Codex{}
-	result := c.GenerateHookConfig(nil)
+	result, err := c.GenerateHookConfig(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != nil {
 		t.Error("expected nil for nil hooks")
 	}
@@ -28,7 +31,10 @@ func TestCodexGenerateHookConfig_ThreeLevelFormat(t *testing.T) {
 		},
 	}
 
-	result := c.GenerateHookConfig(hooks)
+	result, err := c.GenerateHookConfig(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -106,7 +112,10 @@ func TestCodexGenerateHookConfig_ThreeLevelFormat(t *testing.T) {
 
 func TestCodexGenerateMCPConfig_NilServers(t *testing.T) {
 	c := &Codex{}
-	result := c.GenerateMCPConfig(nil)
+	result, err := c.GenerateMCPConfig(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != nil {
 		t.Error("expected nil for nil servers")
 	}
@@ -122,7 +131,10 @@ func TestCodexGenerateMCPConfig_StdioServer(t *testing.T) {
 		},
 	}
 
-	result := c.GenerateMCPConfig(servers)
+	result, err := c.GenerateMCPConfig(servers)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -159,7 +171,10 @@ func TestCodexGenerateMCPConfig_HTTPServer(t *testing.T) {
 		},
 	}
 
-	result := c.GenerateMCPConfig(servers)
+	result, err := c.GenerateMCPConfig(servers)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -186,7 +201,10 @@ func TestCodexGenerateMCPConfig_WithHeaders(t *testing.T) {
 		},
 	}
 
-	result := c.GenerateMCPConfig(servers)
+	result, err := c.GenerateMCPConfig(servers)
+	if err != nil {
+		t.Fatal(err)
+	}
 	data := result[".mcp.json"]
 	var config map[string]any
 	if err := json.Unmarshal(data, &config); err != nil {
@@ -210,7 +228,10 @@ func TestCodexGenerateHookConfig_EventTranslation(t *testing.T) {
 		"on_stop":       {{Command: "cmd4"}},
 	}
 
-	result := c.GenerateHookConfig(hooks)
+	result, err := c.GenerateHookConfig(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
 	data := result[filepath.Join(".codex", "hooks.json")]
 
 	var config map[string]any

--- a/internal/vendor/cursor.go
+++ b/internal/vendor/cursor.go
@@ -2,6 +2,7 @@ package vendor
 
 import (
 	"encoding/json"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -66,9 +67,9 @@ var cursorHookEventMap = map[string]string{
 	"on_stop":       "stop",
 }
 
-func (c *Cursor) GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[string][]byte {
+func (c *Cursor) GenerateHookConfig(hooks map[string][]plugin.HookEntry) (map[string][]byte, error) {
 	if len(hooks) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Cursor flat format: { "hooks": { "beforeShellExecution": [ { "command": "..." } ] } }
@@ -100,7 +101,7 @@ func (c *Cursor) GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[str
 	}
 
 	if len(allEvents) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	config := map[string]any{
@@ -110,18 +111,18 @@ func (c *Cursor) GenerateHookConfig(hooks map[string][]plugin.HookEntry) map[str
 
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("marshalling hook config: %w", err)
 	}
 	data = append(data, '\n')
 
 	return map[string][]byte{
 		filepath.Join(".cursor", "hooks.json"): data,
-	}
+	}, nil
 }
 
-func (c *Cursor) GenerateMCPConfig(servers map[string]plugin.MCPServer) map[string][]byte {
+func (c *Cursor) GenerateMCPConfig(servers map[string]plugin.MCPServer) (map[string][]byte, error) {
 	if len(servers) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Cursor uses .cursor/mcp.json with "mcpServers" key — same structure as Claude
@@ -131,13 +132,13 @@ func (c *Cursor) GenerateMCPConfig(servers map[string]plugin.MCPServer) map[stri
 
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("marshalling MCP config: %w", err)
 	}
 	data = append(data, '\n')
 
 	return map[string][]byte{
 		filepath.Join(".cursor", "mcp.json"): data,
-	}
+	}, nil
 }
 
 func launchCursor(configPath string, extraArgs []string) error {

--- a/internal/vendor/cursor_test.go
+++ b/internal/vendor/cursor_test.go
@@ -10,7 +10,10 @@ import (
 
 func TestCursorGenerateHookConfig_NilHooks(t *testing.T) {
 	c := &Cursor{}
-	result := c.GenerateHookConfig(nil)
+	result, err := c.GenerateHookConfig(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != nil {
 		t.Error("expected nil for nil hooks")
 	}
@@ -28,7 +31,10 @@ func TestCursorGenerateHookConfig_FlatFormat(t *testing.T) {
 		},
 	}
 
-	result := c.GenerateHookConfig(hooks)
+	result, err := c.GenerateHookConfig(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -84,7 +90,10 @@ func TestCursorGenerateHookConfig_FlatFormat(t *testing.T) {
 
 func TestCursorGenerateMCPConfig_NilServers(t *testing.T) {
 	c := &Cursor{}
-	result := c.GenerateMCPConfig(nil)
+	result, err := c.GenerateMCPConfig(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != nil {
 		t.Error("expected nil for nil servers")
 	}
@@ -100,7 +109,10 @@ func TestCursorGenerateMCPConfig_Format(t *testing.T) {
 		},
 	}
 
-	result := c.GenerateMCPConfig(servers)
+	result, err := c.GenerateMCPConfig(servers)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -139,7 +151,10 @@ func TestCursorGenerateHookConfig_EventTranslation(t *testing.T) {
 		"on_stop":       {{Command: "cmd4"}},
 	}
 
-	result := c.GenerateHookConfig(hooks)
+	result, err := c.GenerateHookConfig(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
 	data := result[filepath.Join(".cursor", "hooks.json")]
 
 	var config map[string]any

--- a/internal/vendor/symlinks.go
+++ b/internal/vendor/symlinks.go
@@ -89,8 +89,8 @@ func createSymlink(target, link string) (*SymlinkEntry, error) {
 				return nil, fmt.Errorf("replacing symlink %s: %w", link, err)
 			}
 		} else {
-			// Real file/dir - skip to avoid overwriting user's config.
-			fmt.Fprintf(os.Stderr, "Warning: skipping %s (existing file, not a symlink)\n", link)
+			// Real file/dir — skip to avoid overwriting user's config.
+			// Caller receives nil entry (no symlink created).
 			return nil, nil
 		}
 	}
@@ -113,8 +113,7 @@ func cleanSymlinks(entries []SymlinkEntry) error {
 		}
 
 		if info.Mode()&os.ModeSymlink == 0 {
-			// No longer a symlink (user replaced it) - skip.
-			fmt.Fprintf(os.Stderr, "Warning: skipping %s (no longer a symlink)\n", entry.Link)
+			// No longer a symlink (user replaced it) — skip.
 			continue
 		}
 
@@ -124,7 +123,7 @@ func cleanSymlinks(entries []SymlinkEntry) error {
 			continue
 		}
 		if actual != entry.Target {
-			fmt.Fprintf(os.Stderr, "Warning: skipping %s (points to %s, expected %s)\n", entry.Link, actual, entry.Target)
+			// Points elsewhere — skip.
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- Change `GenerateHookConfig`/`GenerateMCPConfig` interface to return `(map[string][]byte, error)` — marshal errors are now surfaced instead of silently returning nil
- Make `cmdVendors()` return `error` and check `vendor.Get()` result, consistent with all other commands
- Remove stderr writes from internal packages (`resolver.CacheOnlyRepo`, `vendor.symlinks`) — callers already have the info they need
- Route "no CLI found" diagnostic messages to stderr in `compress` and `inspect` commands

## Test plan
- [x] `make check` passes (format, lint, test, build)
- [x] All vendor adapter tests updated for new return signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)