### PR TITLE
refactor: test hygiene improvements

### DIFF
--- a/cmd/ynd/export_test.go
+++ b/cmd/ynd/export_test.go
@@ -92,12 +92,8 @@ func TestCmdExportDefaultOutput(t *testing.T) {
 	}
 
 	// Run in a temp directory so the default ./dist/ doesn't pollute
-	origDir, _ := os.Getwd()
 	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Chdir(origDir) }()
+	t.Chdir(tmpDir)
 
 	err = cmdExport([]string{srcDir, "-v", "claude"})
 	if err != nil {

--- a/cmd/ynh/helpers_test.go
+++ b/cmd/ynh/helpers_test.go
@@ -6,28 +6,26 @@ import (
 	"testing"
 )
 
-func TestIsLocalPath_AbsolutePath(t *testing.T) {
-	if !isLocalPath("/tmp/some-path") {
-		t.Error("expected /tmp/some-path to be local")
-	}
-}
-
-func TestIsLocalPath_RelativePath(t *testing.T) {
-	if !isLocalPath("./some-path") {
-		t.Error("expected ./some-path to be local")
-	}
-}
-
-func TestIsLocalPath_ExistingDir(t *testing.T) {
+func TestIsLocalPath(t *testing.T) {
 	dir := t.TempDir()
-	if !isLocalPath(dir) {
-		t.Errorf("expected existing dir %q to be local", dir)
-	}
-}
 
-func TestIsLocalPath_GitURL(t *testing.T) {
-	if isLocalPath("github.com/user/repo") {
-		t.Error("expected github.com URL to not be local")
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"absolute path", "/tmp/some-path", true},
+		{"relative path", "./some-path", true},
+		{"existing dir", dir, true},
+		{"git URL", "github.com/user/repo", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isLocalPath(tt.input); got != tt.want {
+				t.Errorf("isLocalPath(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/ynh/image.go
+++ b/cmd/ynh/image.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -119,6 +120,11 @@ func generateDockerfile(data imageTemplateData) (string, error) {
 
 // cmdImage builds a Docker image with a harness baked in.
 func cmdImage(args []string) error {
+	return cmdImageTo(args, os.Stdout, os.Stderr)
+}
+
+// cmdImageTo is the testable core of cmdImage, writing output to the given writers.
+func cmdImageTo(args []string, stdout, stderr io.Writer) error {
 	ia, err := parseImageArgs(args)
 	if err != nil {
 		return err
@@ -265,7 +271,7 @@ func cmdImage(args []string) error {
 	}
 
 	if ia.dryRun {
-		fmt.Print(dockerfile)
+		_, _ = fmt.Fprint(stdout, dockerfile)
 		return nil
 	}
 
@@ -280,15 +286,15 @@ func cmdImage(args []string) error {
 	}
 
 	// Build image
-	fmt.Fprintf(os.Stderr, "Building harness image %s...\n", ia.tag)
+	_, _ = fmt.Fprintf(stderr, "Building harness image %s...\n", ia.tag)
 	cmd := exec.Command("docker", "build", "-t", ia.tag, tmpDir)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker build failed: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "\nHarness image built: %s\n", ia.tag)
-	fmt.Fprintf(os.Stderr, "Run: docker run --rm -v $(pwd):/workspace -e ANTHROPIC_API_KEY %s -- \"your prompt\"\n", ia.tag)
+	_, _ = fmt.Fprintf(stderr, "\nHarness image built: %s\n", ia.tag)
+	_, _ = fmt.Fprintf(stderr, "Run: docker run --rm -v $(pwd):/workspace -e ANTHROPIC_API_KEY %s -- \"your prompt\"\n", ia.tag)
 	return nil
 }

--- a/cmd/ynh/image_test.go
+++ b/cmd/ynh/image_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -211,24 +213,13 @@ func TestCmdImage_DryRun(t *testing.T) {
 	// Create a minimal installed harness
 	installTestHarness(t, "drytest")
 
-	// Capture stdout
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := cmdImage([]string{"drytest", "--dry-run"})
-
-	_ = w.Close()
-	os.Stdout = old
-
+	var stdout bytes.Buffer
+	err := cmdImageTo([]string{"drytest", "--dry-run"}, &stdout, io.Discard)
 	if err != nil {
-		t.Fatalf("cmdImage --dry-run failed: %v", err)
+		t.Fatalf("cmdImageTo --dry-run failed: %v", err)
 	}
 
-	buf := make([]byte, 4096)
-	n, _ := r.Read(buf)
-	output := string(buf[:n])
-
+	output := stdout.String()
 	if !strings.Contains(output, "FROM ghcr.io/eyelock/ynh:latest") {
 		t.Errorf("dry-run should print Dockerfile with FROM line\n\nGot:\n%s", output)
 	}
@@ -286,18 +277,9 @@ func TestImageAssembly_AllVendors(t *testing.T) {
 	// Create a minimal installed harness
 	installTestHarness(t, "assemblytest")
 
-	// Capture stdout (dry-run prints to stdout)
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := cmdImage([]string{"assemblytest", "--dry-run"})
-
-	_ = w.Close()
-	os.Stdout = old
-
+	err := cmdImageTo([]string{"assemblytest", "--dry-run"}, io.Discard, io.Discard)
 	if err != nil {
-		t.Fatalf("cmdImage failed: %v", err)
+		t.Fatalf("cmdImageTo failed: %v", err)
 	}
 
 	// The temp dir is cleaned up by cmdImage, but we can verify via dry-run

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -133,102 +133,45 @@ func TestParseRunArgs(t *testing.T) {
 	}
 }
 
-func TestResolveVendor_FlagTakesPriority(t *testing.T) {
-	p := &harness.Harness{
-		Name:          "test",
-		DefaultVendor: "codex",
+func TestResolveVendor(t *testing.T) {
+	tests := []struct {
+		name          string
+		flag          string
+		envVar        string
+		harnessVendor string
+		want          string
+	}{
+		{"flag takes priority", "claude", "", "codex", "claude"},
+		{"harness default", "", "", "codex", "codex"},
+		{"global config fallback", "", "", "", "claude"},
+		{"env var", "", "codex", "claude", "codex"},
+		{"flag beats env var", "claude", "codex", "cursor", "claude"},
+		{"empty env var falls through", "", "", "codex", "codex"},
 	}
 
-	got, err := resolveVendor("claude", p)
-	if err != nil {
-		t.Fatalf("resolveVendor failed: %v", err)
-	}
-	if got != "claude" {
-		t.Errorf("got %q, want %q", got, "claude")
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("HOME", dir)
+			if tt.envVar != "" {
+				t.Setenv("YNH_VENDOR", tt.envVar)
+			} else {
+				t.Setenv("YNH_VENDOR", "")
+			}
 
-func TestResolveVendor_HarnessDefault(t *testing.T) {
-	p := &harness.Harness{
-		Name:          "test",
-		DefaultVendor: "codex",
-	}
+			p := &harness.Harness{
+				Name:          "test",
+				DefaultVendor: tt.harnessVendor,
+			}
 
-	got, err := resolveVendor("", p)
-	if err != nil {
-		t.Fatalf("resolveVendor failed: %v", err)
-	}
-	if got != "codex" {
-		t.Errorf("got %q, want %q", got, "codex")
-	}
-}
-
-func TestResolveVendor_GlobalConfig(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-
-	p := &harness.Harness{
-		Name: "test",
-	}
-
-	got, err := resolveVendor("", p)
-	if err != nil {
-		t.Fatalf("resolveVendor failed: %v", err)
-	}
-	// Default global config is "claude"
-	if got != "claude" {
-		t.Errorf("got %q, want %q", got, "claude")
-	}
-}
-
-func TestResolveVendor_EnvVar(t *testing.T) {
-	t.Setenv("YNH_VENDOR", "codex")
-
-	p := &harness.Harness{
-		Name:          "test",
-		DefaultVendor: "claude",
-	}
-
-	got, err := resolveVendor("", p)
-	if err != nil {
-		t.Fatalf("resolveVendor failed: %v", err)
-	}
-	if got != "codex" {
-		t.Errorf("got %q, want %q", got, "codex")
-	}
-}
-
-func TestResolveVendor_FlagBeatsEnvVar(t *testing.T) {
-	t.Setenv("YNH_VENDOR", "codex")
-
-	p := &harness.Harness{
-		Name:          "test",
-		DefaultVendor: "cursor",
-	}
-
-	got, err := resolveVendor("claude", p)
-	if err != nil {
-		t.Fatalf("resolveVendor failed: %v", err)
-	}
-	if got != "claude" {
-		t.Errorf("got %q, want %q", got, "claude")
-	}
-}
-
-func TestResolveVendor_EnvVarFallthrough(t *testing.T) {
-	t.Setenv("YNH_VENDOR", "")
-
-	p := &harness.Harness{
-		Name:          "test",
-		DefaultVendor: "codex",
-	}
-
-	got, err := resolveVendor("", p)
-	if err != nil {
-		t.Fatalf("resolveVendor failed: %v", err)
-	}
-	if got != "codex" {
-		t.Errorf("got %q, want %q", got, "codex")
+			got, err := resolveVendor(tt.flag, p)
+			if err != nil {
+				t.Fatalf("resolveVendor failed: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/eyelock/ynh/internal/plugin"
@@ -76,7 +77,7 @@ func TestLoad_LegacyFormat(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for legacy format")
 	}
-	if got := err.Error(); !contains(got, "legacy format detected") {
+	if got := err.Error(); !strings.Contains(got, "legacy format detected") {
 		t.Errorf("error = %q, want legacy format hint", got)
 	}
 }
@@ -415,7 +416,7 @@ func TestResolveProfile_MissingProfile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing profile")
 	}
-	if !containsStr(err.Error(), `profile "nonexistent" not defined`) {
+	if !strings.Contains(err.Error(), `profile "nonexistent" not defined`) {
 		t.Errorf("error = %q", err)
 	}
 }
@@ -552,17 +553,4 @@ func writeTestHarnessMinimal(t *testing.T, dir, name string) {
 	if err := os.WriteFile(filepath.Join(dir, "harness.json"), []byte(hj), 0o644); err != nil {
 		t.Fatal(err)
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
-}
-
-func containsStr(s, substr string) bool {
-	for i := 0; i+len(substr) <= len(s); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary
- Consolidate `TestResolveVendor_*` (6 tests) and `TestIsLocalPath_*` (4 tests) into table-driven tests
- Replace `os.Chdir`/defer with `t.Chdir()` (Go 1.24+)
- Remove custom `contains`/`containsStr` helpers, use `strings.Contains`
- Inject `io.Writer` into `cmdImageTo` for testable docker output, remove `os.Stdout` monkey-patching

## Test plan
- [x] `make check` passes (format, lint, test, build)
- [x] Zero production code changes except `io.Writer` injection in `image.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)