### PR TITLE
refactor: sentinel errors for harness and vendor lookups

### DIFF
--- a/cmd/ynh/image_test.go
+++ b/cmd/ynh/image_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/eyelock/ynh/internal/harness"
 )
 
 func TestParseImageArgs(t *testing.T) {
@@ -246,8 +249,8 @@ func TestCmdImage_HarnessNotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing harness")
 	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("expected 'not found' error, got: %v", err)
+	if !errors.Is(err, harness.ErrNotFound) {
+		t.Errorf("expected harness.ErrNotFound, got: %v", err)
 	}
 }
 

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -468,7 +469,7 @@ func TestCmdInfo_NotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nonexistent harness")
 	}
-	if !strings.Contains(err.Error(), "not found") {
+	if !errors.Is(err, harness.ErrNotFound) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -544,7 +545,7 @@ func TestCmdUpdate_NotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nonexistent harness")
 	}
-	if !strings.Contains(err.Error(), "not found") {
+	if !errors.Is(err, harness.ErrNotFound) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -1,6 +1,7 @@
 package harness
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -67,6 +68,9 @@ func DetectFormat(dir string) string {
 	return ""
 }
 
+// ErrNotFound is returned when a harness is not installed.
+var ErrNotFound = errors.New("harness not found")
+
 func Load(name string) (*Harness, error) {
 	installDir := InstalledDir(name)
 	switch DetectFormat(installDir) {
@@ -75,7 +79,7 @@ func Load(name string) (*Harness, error) {
 	case "legacy":
 		return nil, fmt.Errorf("harness %q: legacy format detected. Consolidate .claude-plugin/plugin.json and metadata.json into harness.json", name)
 	default:
-		return nil, fmt.Errorf("harness %q: no harness.json found", name)
+		return nil, fmt.Errorf("harness %q: %w", name, ErrNotFound)
 	}
 }
 

--- a/internal/vendor/adapter.go
+++ b/internal/vendor/adapter.go
@@ -1,11 +1,15 @@
 package vendor
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
 	"github.com/eyelock/ynh/internal/plugin"
 )
+
+// ErrUnknownVendor is returned when a vendor name is not registered.
+var ErrUnknownVendor = errors.New("unknown vendor")
 
 // SymlinkEntry records a single symlink created during Install.
 type SymlinkEntry struct {
@@ -91,7 +95,7 @@ func Get(name string) (Adapter, error) {
 		for k := range registry {
 			available = append(available, k)
 		}
-		return nil, fmt.Errorf("unknown vendor %q (available: %v)", name, available)
+		return nil, fmt.Errorf("%w %q (available: %v)", ErrUnknownVendor, name, available)
 	}
 	return a, nil
 }

--- a/internal/vendor/adapter_test.go
+++ b/internal/vendor/adapter_test.go
@@ -1,6 +1,7 @@
 package vendor
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -80,6 +81,9 @@ func TestGetUnknownVendor(t *testing.T) {
 	_, err := Get("nonexistent")
 	if err == nil {
 		t.Fatal("expected error for unknown vendor")
+	}
+	if !errors.Is(err, ErrUnknownVendor) {
+		t.Errorf("expected ErrUnknownVendor, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Define `harness.ErrNotFound` and `vendor.ErrUnknownVendor` sentinel errors
- Use `%w` wrapping so callers can use `errors.Is()` instead of string matching
- Update test assertions to use `errors.Is()`

## Test plan
- [x] `make check` passes (format, lint, test, build)
- [x] Sentinel errors propagate correctly through wrapping chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)