### PR TITLE
fix: remove redundant error wrapping around harness.Load

### DIFF
--- a/cmd/ynh/image.go
+++ b/cmd/ynh/image.go
@@ -192,7 +192,7 @@ func cmdImageTo(args []string, stdout, stderr io.Writer) error {
 		// Load from installed harnesses
 		p, err = harness.Load(ia.name)
 		if err != nil {
-			return fmt.Errorf("harness %q not found: %w", ia.name, err)
+			return err
 		}
 		harnessSrcDir = harness.InstalledDir(ia.name)
 	}

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -356,7 +356,7 @@ func cmdUpdate(args []string) error {
 
 	p, err := harness.Load(name)
 	if err != nil {
-		return fmt.Errorf("harness %q not found: %w", name, err)
+		return err
 	}
 
 	if len(p.Includes) == 0 && len(p.DelegatesTo) == 0 {
@@ -428,7 +428,7 @@ func cmdRun(args []string) error {
 	// Load harness
 	p, err := harness.Load(name)
 	if err != nil {
-		return fmt.Errorf("harness %q not found: %w", name, err)
+		return err
 	}
 
 	// Resolve profile: --profile flag > YNH_PROFILE env var > no profile
@@ -689,7 +689,7 @@ func cmdInfo(args []string) error {
 	name := args[0]
 	p, err := harness.Load(name)
 	if err != nil {
-		return fmt.Errorf("harness %q not found: %w", name, err)
+		return err
 	}
 
 	vendorName := p.DefaultVendor


### PR DESCRIPTION
## Summary
- Remove redundant `fmt.Errorf("harness %q not found: %w", name, err)` wrapping at 4 call sites
- `harness.Load` already includes the harness name via `ErrNotFound` sentinel
- Before: `harness "x" not found: harness "x": harness not found`
- After: `harness "x": harness not found`

## Test plan
- [x] `make check` passes
- [x] `errors.Is(err, harness.ErrNotFound)` still works through the wrapping chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)