### PR TITLE
docs: update tutorials for refactor output changes

### DIFF
--- a/docs/tutorial/01-first-harness.md
+++ b/docs/tutorial/01-first-harness.md
@@ -221,6 +221,8 @@ CLAUDE.md
   commands/hello.md
   rules/be-brief.md
   skills/greet/SKILL.md
+.claude-plugin/
+  plugin.json
 ```
 
 `CLAUDE.md` (at the root) was generated from `instructions.md`. Artifacts are inside `.claude/` — the layout Claude expects for `--plugin-dir`.

--- a/docs/tutorial/03-composition.md
+++ b/docs/tutorial/03-composition.md
@@ -410,7 +410,7 @@ Now try to run a harness that includes a non-eyelock source:
 
 ```bash
 with-anthropic "hello" 2>&1
-# Expected error: resolving includes: include "github.com/anthropics/skills": remote source not allowed
+# Expected error: resolving includes: include "github.com/anthropics/skills": remote source "github.com/anthropics/skills" is not in the allowed sources list
 ```
 
 The `anthropics/skills` source doesn't match `github.com/eyelock/**`, so it's rejected at run time when ynh tries to resolve the includes.
@@ -419,7 +419,7 @@ The `full-stack` harness also fails (it includes both eyelock and anthropic sour
 
 ```bash
 full-stack "hello" 2>&1
-# Expected error: resolving includes: include "github.com/anthropics/skills": remote source not allowed
+# Expected error: resolving includes: include "github.com/anthropics/skills": remote source "github.com/anthropics/skills" is not in the allowed sources list
 ```
 
 > **Note:** `ynh install` now fetches all includes at install time, so the allow-list is enforced during install as well as at run time. If an include is blocked by the allow-list, `ynh install` will fail with an error.

--- a/docs/tutorial/05-export.md
+++ b/docs/tutorial/05-export.md
@@ -67,10 +67,10 @@ ynd export /tmp/ynh-tutorial/exportable -o /tmp/ynh-tutorial/export-output
 
 Expected output:
 ```
-Exported "exportable" for claude → /tmp/ynh-tutorial/export-output/claude/
-Exported "exportable" for cursor → /tmp/ynh-tutorial/export-output/cursor/
-Exported "exportable" for codex → /tmp/ynh-tutorial/export-output/codex/
-  codex: skipping 1 agent (not supported)
+Exported for claude → /tmp/ynh-tutorial/export-output/claude (2 skills, 1 agents)
+Exported for codex → /tmp/ynh-tutorial/export-output/codex (2 skills, 0 agents)
+  warning: codex: skipping 1 agents (not supported)
+Exported for cursor → /tmp/ynh-tutorial/export-output/cursor (2 skills, 1 agents)
 ```
 
 ## T5.3: Verify Claude export
@@ -254,7 +254,7 @@ cat > /tmp/ynh-tutorial/no-instructions/harness.json << 'EOF'
 EOF
 
 ynd export /tmp/ynh-tutorial/no-instructions -o /tmp/ynh-tutorial/no-inst-out -v claude
-# Expected: succeeds with warning "No instructions.md found"
+# Expected: succeeds (no warning)
 
 ls /tmp/ynh-tutorial/no-inst-out/claude/
 # Expected: .claude-plugin/plugin.json only (generated from harness.json, no AGENTS.md)

--- a/docs/tutorial/06-marketplace.md
+++ b/docs/tutorial/06-marketplace.md
@@ -118,12 +118,15 @@ Expected (`.git/` excluded from listing — it's auto-created by the build):
 .claude-plugin/marketplace.json
 .cursor-plugin/marketplace.json
 plugins/formatter/.claude-plugin/plugin.json
+plugins/formatter/.codex-plugin/plugin.json
 plugins/formatter/.cursor-plugin/plugin.json
 plugins/formatter/skills/auto-format/SKILL.md
 plugins/reviewer/.claude-plugin/plugin.json
+plugins/reviewer/.codex-plugin/plugin.json
 plugins/reviewer/.cursor-plugin/plugin.json
 plugins/reviewer/.cursorrules
 plugins/reviewer/AGENTS.md
+plugins/reviewer/CLAUDE.md
 plugins/reviewer/skills/dev-quality/SKILL.md
 plugins/reviewer/skills/dev-review/SKILL.md
 README.md
@@ -158,15 +161,15 @@ Expected (formatted):
   "plugins": [
     {
       "name": "formatter",
-      "source": "./plugins/formatter",
       "description": "Auto-format code on save",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "source": "./plugins/formatter"
     },
     {
       "name": "reviewer",
-      "source": "./plugins/reviewer",
       "description": "Code review with dev-quality and dev-review skills",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "source": "./plugins/reviewer"
     }
   ]
 }

--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -259,7 +259,7 @@ ynh uninstall nonexistent-harness
 
 ```bash
 ynh run nonexistent-harness
-# Expected: Error: harness "nonexistent-harness" not found
+# Expected: Error: harness "nonexistent-harness": harness not found
 ```
 
 ### E7: Export unknown vendor
@@ -363,7 +363,7 @@ ynh info my-harness
 
 ```bash
 ynh info nonexistent
-# Expected: Error: harness "nonexistent" not found
+# Expected: Error: harness "nonexistent": harness not found
 ```
 
 ### E18: Info with no args


### PR DESCRIPTION
## Summary
Updates tutorial expected output to match CLI changes from the coding standards refactor PRs:
- Tutorial 01: run dir now includes `.claude-plugin/plugin.json`
- Tutorial 03: allow-list error message reworded (PR 1)
- Tutorial 05: export output format overhauled (PR 7)
- Tutorial 06: marketplace listing includes Codex manifests and CLAUDE.md (PR 7)
- Manual test plan: harness not-found error format (PR 6 + fix PR 35)

## Test plan
- [x] `make check` passes
- [x] Only updates for our changes — pre-existing mismatches left for separate cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)