### PR TITLE
docs: fix all remaining tutorial eval mismatches

### DIFF
--- a/docs/tutorial/01-first-harness.md
+++ b/docs/tutorial/01-first-harness.md
@@ -168,6 +168,12 @@ Includes:
 
 Delegates to:
   (none)
+
+Hooks:
+  (none)
+
+MCP Servers:
+  (none)
 ```
 
 Check the launcher script:
@@ -232,7 +238,9 @@ CLAUDE.md
 ```bash
 ynh uninstall my-harness
 ynh ls
-# Expected: No harnesses installed.
+# Expected:
+#   No harnesses installed.
+#   Install one with: ynh install <git-url|path>
 ```
 
 The `remove` alias also works: `ynh remove my-harness`.

--- a/docs/tutorial/02-vendors-and-symlinks.md
+++ b/docs/tutorial/02-vendors-and-symlinks.md
@@ -225,6 +225,7 @@ ynh prune
 Expected:
 ```
 Removed stale launcher: /Users/<you>/.ynh/bin/my-harness
+Removed stale run dir: /Users/<you>/.ynh/run/my-harness
 ```
 
 Verify the launcher was removed:

--- a/docs/tutorial/07-registry-and-discovery.md
+++ b/docs/tutorial/07-registry-and-discovery.md
@@ -68,7 +68,7 @@ ynh registry add /tmp/ynh-tutorial/my-registry
 
 Expected:
 ```
-Added registry "tutorial-registry" from /tmp/ynh-tutorial/my-registry
+Added registry: /tmp/ynh-tutorial/my-registry
 ```
 
 ## T7.3: List registries
@@ -79,8 +79,7 @@ ynh registry list
 
 Expected:
 ```
-NAME                URL
-tutorial-registry   /tmp/ynh-tutorial/my-registry
+  /tmp/ynh-tutorial/my-registry
 ```
 
 ## T7.4: Search
@@ -93,8 +92,8 @@ ynh search "go"
 
 Expected:
 ```
-NAME    DESCRIPTION                                    REPO                          VENDORS
-david   Full-stack development harness with Go expertise  eyelock/assistants (ynh/david)  claude, codex, cursor
+NAME   DESCRIPTION                                       REPO                                       VENDORS              REGISTRY
+david  Full-stack development harness with Go expertise  github.com/eyelock/assistants (ynh/david)  claude,codex,cursor  tutorial-registry
 ```
 
 ```bash
@@ -103,8 +102,8 @@ ynh search "planning"
 
 Expected:
 ```
-NAME      DESCRIPTION                              REPO                              VENDORS
-planner   Project planning and architecture harness  eyelock/assistants (ynh/planner)  claude
+NAME     DESCRIPTION                                REPO                                         VENDORS  REGISTRY
+planner  Project planning and architecture harness  github.com/eyelock/assistants (ynh/planner)  claude   tutorial-registry
 ```
 
 ```bash
@@ -113,13 +112,13 @@ ynh search "music"
 
 Expected:
 ```
-NAME               DESCRIPTION                                    REPO                                       VENDORS
-media-management   Music library processing and Apple Music import  eyelock/assistants (plugins/media-management)  claude
+NAME              DESCRIPTION                                      REPO                                                      VENDORS  REGISTRY
+media-management  Music library processing and Apple Music import  github.com/eyelock/assistants (plugins/media-management)  claude   tutorial-registry
 ```
 
 ```bash
 ynh search "nonexistent"
-# Expected: No results found for "nonexistent".
+# Expected: No results for "nonexistent"
 ```
 
 ## T7.5: Install — by exact name
@@ -189,8 +188,7 @@ ynh registry update
 
 Expected:
 ```
-Updating tutorial-registry...
-  Already up to date.
+  tutorial-registry (up to date, 3 entries)
 ```
 
 This fetches the latest `registry.json` from each configured registry.

--- a/docs/tutorial/08-developer-tools.md
+++ b/docs/tutorial/08-developer-tools.md
@@ -22,8 +22,8 @@ Expected: a `my-team/` directory with the full harness structure:
 ```bash
 find my-team -type f | sort
 # Expected:
+#   my-team/AGENTS.md
 #   my-team/harness.json
-#   my-team/instructions.md
 ```
 
 Empty directories are also created: `skills/`, `agents/`, `rules/`, `commands/`.
@@ -149,10 +149,12 @@ Multiple blank lines above.
 EOF
 
 ynd fmt
-# Expected: "Formatted rules/messy.md"
+# Expected:
+#   Formatted rules/messy.md
+#   Formatted 1 of 2 file(s).
 
 ynd fmt
-# Expected: "all formatted" (idempotent — no-op on second run)
+# Expected: "Checked 2 file(s) — all formatted." (idempotent — no-op on second run)
 ```
 
 ## T8.7: Compress

--- a/docs/tutorial/10-hooks.md
+++ b/docs/tutorial/10-hooks.md
@@ -69,23 +69,23 @@ ls -R /tmp/ynh-tutorial/hook-harness/
 ynd preview /tmp/ynh-tutorial/hook-harness -v claude
 ```
 
-Expected output includes `.claude/settings.json` with Claude's three-level hook structure:
+Expected output includes `.claude/hooks/hooks.json` with Claude's three-level hook structure:
 
 ```json
 {
   "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          { "type": "command", "command": "/usr/local/bin/run-linter.sh" }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
         "hooks": [
           { "type": "command", "command": "/usr/local/bin/check-commands.sh" }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "hooks": [
-          { "type": "command", "command": "/usr/local/bin/run-linter.sh" }
         ]
       }
     ],
@@ -213,7 +213,7 @@ ynd diff /tmp/ynh-tutorial/hook-harness claude cursor codex
 ```
 
 Expected output shows:
-- `.claude/settings.json` is only in Claude (hooks embedded in settings)
+- `.claude/hooks/hooks.json` is only in Claude
 - `.cursor/hooks.json` is only in Cursor
 - `.codex/hooks.json` is only in Codex
 - Shared files (like `CLAUDE.md`, `.cursorrules`, `codex.md`) may be listed as identical or different depending on instructions content

--- a/docs/tutorial/11-mcp-servers.md
+++ b/docs/tutorial/11-mcp-servers.md
@@ -44,7 +44,7 @@ EOF
 ynd preview /tmp/ynh-tutorial/mcp-harness -v claude
 ```
 
-Expected output includes `.mcp.json` at the project root:
+Expected output includes `.claude/.mcp.json`:
 
 ```json
 {
@@ -60,7 +60,7 @@ Expected output includes `.mcp.json` at the project root:
 }
 ```
 
-Claude uses `.mcp.json` with a `mcpServers` key — the server definition passes through directly.
+Claude uses `.claude/.mcp.json` with a `mcpServers` key — the server definition passes through directly.
 
 ## T11.3: Preview for Cursor
 
@@ -84,7 +84,7 @@ Expected output includes `.cursor/mcp.json`:
 }
 ```
 
-Cursor uses the same JSON structure as Claude but places the file at `.cursor/mcp.json` instead of the project root.
+Cursor uses the same JSON structure as Claude but places the file at `.cursor/mcp.json` instead of `.claude/.mcp.json`.
 
 ## T11.4: Preview for Codex
 
@@ -92,18 +92,23 @@ Cursor uses the same JSON structure as Claude but places the file at `.cursor/mc
 ynd preview /tmp/ynh-tutorial/mcp-harness -v codex
 ```
 
-Expected output includes `.codex/config.toml` with TOML format:
+Expected output includes `.mcp.json` with JSON format (same structure as Claude, at plugin root):
 
-```toml
-[mcp_servers.sqlite]
-command = "npx"
-args = ["-y", "@modelcontextprotocol/server-sqlite", "/tmp/demo.db"]
-
-[mcp_servers.sqlite.env]
-NODE_ENV = "production"
+```json
+{
+  "mcpServers": {
+    "sqlite": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sqlite", "/tmp/demo.db"],
+      "env": {
+        "NODE_ENV": "production"
+      }
+    }
+  }
+}
 ```
 
-Codex uses TOML instead of JSON, with `[mcp_servers.<name>]` table headers and a separate `[mcp_servers.<name>.env]` sub-table for environment variables.
+Codex uses the same JSON format as Claude with a `mcpServers` key, placed at the plugin root as `.mcp.json`.
 
 ## T11.5: Add an HTTP MCP server
 
@@ -140,7 +145,7 @@ Preview for Claude to see both servers:
 ynd preview /tmp/ynh-tutorial/mcp-harness -v claude
 ```
 
-Expected `.mcp.json` now includes both servers:
+Expected `.claude/.mcp.json` now includes both servers:
 
 ```json
 {
@@ -162,27 +167,32 @@ Expected `.mcp.json` now includes both servers:
 }
 ```
 
-Preview for Codex to see the TOML translation with both server types:
+Preview for Codex to see the JSON translation with both server types:
 
 ```bash
 ynd preview /tmp/ynh-tutorial/mcp-harness -v codex
 ```
 
-Expected `.codex/config.toml`:
+Expected `.mcp.json` (at plugin root):
 
-```toml
-[mcp_servers.docs-api]
-url = "https://docs.example.com/mcp"
-
-[mcp_servers.docs-api.headers]
-Authorization = "Bearer ${DOCS_API_KEY}"
-
-[mcp_servers.sqlite]
-command = "npx"
-args = ["-y", "@modelcontextprotocol/server-sqlite", "/tmp/demo.db"]
-
-[mcp_servers.sqlite.env]
-NODE_ENV = "production"
+```json
+{
+  "mcpServers": {
+    "docs-api": {
+      "url": "https://docs.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${DOCS_API_KEY}"
+      }
+    },
+    "sqlite": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sqlite", "/tmp/demo.db"],
+      "env": {
+        "NODE_ENV": "production"
+      }
+    }
+  }
+}
 ```
 
 ## T11.6: Compare MCP config across vendors
@@ -192,10 +202,10 @@ ynd diff /tmp/ynh-tutorial/mcp-harness claude cursor codex
 ```
 
 Expected output shows:
-- `.mcp.json` only in Claude (project-root MCP config)
+- `.claude/.mcp.json` only in Claude
 - `.cursor/mcp.json` only in Cursor
-- `.codex/config.toml` only in Codex
-- The same two servers appear in all three, but in structurally different formats
+- `.mcp.json` only in Codex (at plugin root)
+- The same two servers appear in all three, in the same JSON format but at different file locations
 
 ## Clean up
 
@@ -207,8 +217,8 @@ rm -rf /tmp/ynh-tutorial
 
 - MCP servers are declared in `harness.json` under `mcp_servers`
 - Servers can use stdio transport (`command` + `args`) or HTTP transport (`url`)
-- Claude and Cursor both use JSON with `mcpServers` key, but in different file locations
-- Codex uses TOML format with `[mcp_servers.<name>]` table sections
+- All three vendors use JSON with a `mcpServers` key, but in different file locations
+- Claude places MCP config at `.claude/.mcp.json`, Cursor at `.cursor/mcp.json`, and Codex at `.mcp.json` (plugin root)
 - `ynd preview` and `ynd diff` let you verify MCP config without installing
 
 ## Next

--- a/docs/tutorial/12-developer-preview.md
+++ b/docs/tutorial/12-developer-preview.md
@@ -83,15 +83,16 @@ Expected output structure:
 
 ```
 .claude/
-  .claude-plugin/
-    plugin.json
+  hooks/
+    hooks.json
   rules/
     safety.md
   skills/
     deploy/
       SKILL.md
-  settings.json
-.mcp.json
+  .mcp.json
+.claude-plugin/
+  plugin.json
 CLAUDE.md
 ```
 
@@ -99,8 +100,8 @@ Key things to verify:
 - `CLAUDE.md` contains the harness instructions
 - `.claude/skills/deploy/SKILL.md` has the skill content
 - `.claude/rules/safety.md` has the rule content
-- `.claude/settings.json` has hooks in Claude's three-level format
-- `.mcp.json` has the MCP server config
+- `.claude/hooks/hooks.json` has hooks in Claude's three-level format
+- `.claude/.mcp.json` has the MCP server config
 
 ## T12.2: Preview the same harness for Cursor
 
@@ -126,8 +127,8 @@ Expected output structure:
 
 Note the differences from Claude:
 - Instructions go to `.cursorrules` instead of `CLAUDE.md`
-- Hooks go to `.cursor/hooks.json` instead of `.claude/settings.json`
-- MCP config goes to `.cursor/mcp.json` instead of `.mcp.json`
+- Hooks go to `.cursor/hooks.json` instead of `.claude/hooks/hooks.json`
+- MCP config goes to `.cursor/mcp.json` instead of `.claude/.mcp.json`
 - Artifacts are under `.cursor/` instead of `.claude/`
 
 ## T12.3: Compare Claude vs Cursor output
@@ -141,17 +142,19 @@ Expected output:
 ```
 === claude vs cursor ===
 Only in claude:
-  .claude/settings.json
-  .mcp.json
+  .claude-plugin/plugin.json
+  .claude/.mcp.json
+  .claude/hooks/hooks.json
+  .claude/rules/safety.md
+  .claude/skills/deploy/SKILL.md
   CLAUDE.md
 Only in cursor:
+  .cursor-plugin/plugin.json
   .cursor/hooks.json
   .cursor/mcp.json
+  .cursor/rules/safety.md
+  .cursor/skills/deploy/SKILL.md
   .cursorrules
-Different content:
-  ...
-Identical:
-  ...
 ```
 
 The diff shows which files are vendor-specific and which content is shared. Artifacts like skills and rules may appear as identical content under different directory prefixes.
@@ -167,7 +170,7 @@ ynd preview /tmp/ynh-tutorial/preview-harness -v claude -o /tmp/ynh-tutorial/cla
 Inspect the hook config:
 
 ```bash
-cat /tmp/ynh-tutorial/claude-output/.claude/settings.json
+cat /tmp/ynh-tutorial/claude-output/.claude/hooks/hooks.json
 ```
 
 Expected:
@@ -222,7 +225,7 @@ Expected:
 Inspect MCP config for each vendor:
 
 ```bash
-cat /tmp/ynh-tutorial/claude-output/.mcp.json
+cat /tmp/ynh-tutorial/claude-output/.claude/.mcp.json
 ```
 
 Expected:
@@ -251,7 +254,7 @@ ynd preview /tmp/ynh-tutorial/preview-harness -v codex -o /tmp/ynh-tutorial/code
 cat /tmp/ynh-tutorial/codex-output/.mcp.json
 ```
 
-Expected (JSON, same format as Claude — at plugin root):
+Expected (JSON, same format as Claude, at plugin root):
 
 ```json
 {

--- a/docs/tutorial/13-profiles.md
+++ b/docs/tutorial/13-profiles.md
@@ -103,8 +103,8 @@ ynd preview /tmp/ynh-tutorial/profile-harness -v claude --profile ci
 ```
 
 Expected output includes:
-- `.claude/settings.json` with **only** the `ci` profile's `before_tool` hook (the base `after_tool` hook is replaced — profiles use replace semantics, not merge)
-- `.mcp.json` with the `ci-db` MCP server from the `ci` profile
+- `.claude/hooks/hooks.json` with **only** the `ci` profile's `before_tool` hook (the base `after_tool` hook is replaced — profiles use replace semantics, not merge)
+- `.claude/.mcp.json` with the `ci-db` MCP server from the `ci` profile
 
 Compare with the base (no profile):
 
@@ -112,7 +112,7 @@ Compare with the base (no profile):
 ynd preview /tmp/ynh-tutorial/profile-harness -v claude
 ```
 
-Expected: `.claude/settings.json` has only the base `after_tool` hook. No `.mcp.json` (no MCP servers in base config).
+Expected: `.claude/hooks/hooks.json` has only the base `after_tool` hook. No `.claude/.mcp.json` (no MCP servers in base config).
 
 ## T13.4: Run with --profile ci
 
@@ -153,10 +153,8 @@ ynd preview /tmp/ynh-tutorial/profile-harness -v claude --profile nonexistent
 
 Expected error:
 ```
-Error: profile "nonexistent" not found in harness.json (available: ci, local)
+Error: profile "nonexistent" not defined in harness.json
 ```
-
-The error lists available profiles to help you pick the right one.
 
 ## T13.6: Use YNH_PROFILE env var
 
@@ -197,7 +195,7 @@ ynd diff /tmp/ynh-tutorial/profile-harness claude cursor --profile ci
 ```
 
 Expected output shows the vendor-specific differences with the `ci` profile applied to both:
-- Claude: hooks in `.claude/settings.json`, MCP in `.mcp.json`
+- Claude: hooks in `.claude/hooks/hooks.json`, MCP in `.claude/.mcp.json`
 - Cursor: hooks in `.cursor/hooks.json`, MCP in `.cursor/mcp.json`
 
 Compare with no profile to see what the profile adds:

--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -160,7 +160,7 @@ Requires Docker installed and running.
 | ID | Test | Tutorial step |
 |---|---|---|
 | T10.1 | Add hooks to harness.json | [T10.1](tutorial/10-hooks.md#t101-add-hooks-to-a-harness) |
-| T10.2 | Preview for Claude — verify settings.json | [T10.2](tutorial/10-hooks.md#t102-preview-for-claude) |
+| T10.2 | Preview for Claude — verify hooks.json | [T10.2](tutorial/10-hooks.md#t102-preview-for-claude) |
 | T10.3 | Preview for Cursor — verify hooks.json | [T10.3](tutorial/10-hooks.md#t103-preview-for-cursor) |
 | T10.4 | Preview for Codex — verify hooks.json | [T10.4](tutorial/10-hooks.md#t104-preview-for-codex) |
 | T10.5 | Write a blocking hook script | [T10.5](tutorial/10-hooks.md#t105-write-a-blocking-hook-example) |
@@ -171,9 +171,9 @@ Requires Docker installed and running.
 | ID | Test | Tutorial step |
 |---|---|---|
 | T11.1 | Add stdio MCP server to harness | [T11.1](tutorial/11-mcp-servers.md#t111-add-a-stdio-mcp-server-to-a-harness) |
-| T11.2 | Preview for Claude — verify .mcp.json | [T11.2](tutorial/11-mcp-servers.md#t112-preview-for-claude) |
+| T11.2 | Preview for Claude — verify .claude/.mcp.json | [T11.2](tutorial/11-mcp-servers.md#t112-preview-for-claude) |
 | T11.3 | Preview for Cursor — verify .cursor/mcp.json | [T11.3](tutorial/11-mcp-servers.md#t113-preview-for-cursor) |
-| T11.4 | Preview for Codex — verify TOML | [T11.4](tutorial/11-mcp-servers.md#t114-preview-for-codex) |
+| T11.4 | Preview for Codex — verify JSON | [T11.4](tutorial/11-mcp-servers.md#t114-preview-for-codex) |
 | T11.5 | Add HTTP MCP server — verify URL | [T11.5](tutorial/11-mcp-servers.md#t115-add-an-http-mcp-server) |
 | T11.6 | Diff MCP config across vendors | [T11.6](tutorial/11-mcp-servers.md#t116-compare-mcp-config-across-vendors) |
 
@@ -266,14 +266,14 @@ ynh run nonexistent-harness
 
 ```bash
 ynd export /tmp/ynh-edge/repo -v fakevend
-# Expected: Error: unknown vendor "fakevend"
+# Expected: Error: unknown vendor "fakevend" (available: [claude codex cursor])
 ```
 
 ### E8: Export missing source
 
 ```bash
 ynd export
-# Expected: Error: usage: ynd export <harness-dir|git-url> [flags]
+# Expected: Error: usage: ynd export <harness-dir|git-url> [--harness dir] [flags]
 ```
 
 ### E9: Marketplace build without config
@@ -303,7 +303,10 @@ cp ~/.ynh/config.json ~/.ynh/config.json.bak
 echo '{"default_vendor":"claude"}' > ~/.ynh/config.json
 
 ynh install somename
-# Expected: Error: no registries configured. Add one with: ynh registry add <url>
+# Expected:
+#   Error: no registries configured.
+#     Add one with: ynh registry add <url>
+#     Or specify a Git URL: ynh install github.com/user/somename
 
 mv ~/.ynh/config.json.bak ~/.ynh/config.json
 ```


### PR DESCRIPTION
## Summary
Updates all 9 remaining tutorial files so that the `/evals` slash command passes cleanly across the entire suite.

### Changes by tutorial
- **01-first-harness**: `ynh info` shows Hooks/MCP sections; empty `ynh ls` shows install hint
- **02-vendors-and-symlinks**: `ynh prune` shows stale run dir removal
- **07-registry-and-discovery**: registry add/list/search/update output format updates
- **08-developer-tools**: scaffold creates `AGENTS.md`; `ynd fmt` summary line
- **10-hooks**: hooks file at `.claude/hooks/hooks.json` (not `settings.json`)
- **11-mcp-servers**: Claude MCP at `.claude/.mcp.json`; Codex uses JSON (not TOML)
- **12-developer-preview**: tree/diff/cat paths updated for hooks and MCP
- **13-profiles**: hooks/MCP paths; profile error wording
- **manual-test-plan**: info sections, ls hint, error message formats

## Test plan
- [x] `make check` passes
- [x] Each tutorial step verified against actual CLI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)