### PR TITLE
feat: add /release command, strengthen /evals as release gate

### DIFF
--- a/.claude/commands/evals.md
+++ b/.claude/commands/evals.md
@@ -1,17 +1,52 @@
-Evaluate all tutorials affected by recent changes. For each affected tutorial:
+Evaluate ALL tutorials. This is a release gate — the verdict must be PASS before any release.
 
-1. Build and install the latest binaries (`make build && make install`)
-2. Run each tutorial step that produces verifiable output
-3. Compare actual output against the expected output documented in the tutorial
-4. Record every mismatch — do not fix anything during evaluation
+## Process
 
-At the end, produce a structured report:
+1. Build and install the latest binaries: `make build && make install`
+2. For EVERY tutorial in `docs/tutorial/` (01 through 13, excluding README.md):
+   - Set up an isolated environment: `export HOME=$(mktemp -d) && export YNH_HOME=""`
+   - Use binaries at `/Users/david/.ynh/bin/ynh` and `/Users/david/.ynh/bin/ynd`
+   - Execute each step that produces verifiable output
+   - Compare actual output against the expected output documented in the tutorial
+   - Skip steps that require network access (git clone from GitHub), vendor CLIs (claude, codex), or Docker
+3. Run the manual test plan (`docs/tutorial/manual-test-plan.md`) error-case section (E1–E17)
+
+## Pass/Fail Criteria
+
+A step **FAILS** if:
+- A command produces different output than documented (wrong text, missing lines, extra lines)
+- A file path in the output doesn't match what the tutorial shows
+- An error message differs from what's documented
+- A JSON/TOML structure or field order differs from what's documented
+- A file that should exist is missing, or an unexpected file appears in a listing
+
+A step **PASSES** if:
+- Output matches the tutorial exactly (whitespace-normalized)
+- OR the tutorial uses placeholder values (e.g., `<you>`, `/tmp/...`) and the structure matches
+
+## Report Format
+
+For each tutorial, report PASS or FAIL. For failures, include:
 
 - **File**: tutorial path
-- **Step**: which T-number
+- **Step**: description
 - **Expected**: what the tutorial says
 - **Actual**: what was produced
-- **Cause**: whether the mismatch is from our changes or pre-existing
-- **Severity**: cosmetic (wording/formatting) vs structural (wrong paths/formats)
 
-Do not attempt fixes. The goal is a complete picture of what needs updating before committing.
+## Verdict
+
+At the end, produce a single verdict line:
+
+```
+EVALS: PASS (N tutorials, 0 failures)
+```
+
+or:
+
+```
+EVALS: FAIL (N tutorials, X failures)
+```
+
+If ANY step in ANY tutorial fails, the overall verdict is **FAIL**.
+
+Do not attempt fixes during evaluation. Report only.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,55 @@
+Release a new version of ynh. This pushes a semver tag which triggers goreleaser via GitHub Actions to build binaries, Docker images, and update the Homebrew tap.
+
+## Pre-flight (mandatory — do not skip any step)
+
+### 1. Evals gate
+
+Run `/evals` and confirm the verdict is `EVALS: PASS`. If evals have not been run in this conversation, or the last run produced `EVALS: FAIL`, **STOP immediately** and tell the user:
+
+> Release blocked: evals have not passed in this conversation. Run /evals first.
+
+Do not proceed with the release under any circumstances until evals pass.
+
+### 2. CI check
+
+Run `make check` to verify format, lint, test, and build all pass. If any step fails, stop and report.
+
+### 3. Clean working tree
+
+Verify ALL of the following:
+- `git status` shows a clean working tree (no uncommitted changes)
+- Current branch is `main`
+- Local main is up to date with `origin/main` (`git pull origin main`)
+
+If any condition fails, stop and tell the user what needs to be resolved.
+
+## Version bump
+
+1. Get the latest tag: `git tag --sort=-version:refname | head -1`
+2. Ask the user: **MAJOR, MINOR, or PATCH?**
+   - MAJOR: breaking changes (v1.2.3 → v2.0.0)
+   - MINOR: new features, backward-compatible (v1.2.3 → v1.3.0)
+   - PATCH: bug fixes only (v1.2.3 → v1.2.4)
+3. Compute the new version from the latest tag
+4. Confirm with the user before proceeding:
+   > Release **v0.1.0**? This will trigger goreleaser to build and publish binaries, Docker images, and update the Homebrew tap. Proceed? [y/N]
+
+Wait for explicit confirmation. Do not proceed on silence or ambiguity.
+
+## Release
+
+1. Create and push the tag:
+   ```
+   git tag v<new-version>
+   git push origin v<new-version>
+   ```
+2. Monitor the release workflow:
+   ```
+   gh run watch --exit-status
+   ```
+3. Verify the release exists:
+   ```
+   gh release view v<new-version>
+   ```
+
+Report the release URL when complete.


### PR DESCRIPTION
## Summary
- **`/evals`**: Evaluate ALL tutorials with strict pass/fail criteria and a machine-readable verdict (`EVALS: PASS` / `EVALS: FAIL`). Any mismatch in any tutorial = FAIL.
- **`/release`**: Semver tag release with mandatory pre-flight: evals gate, `make check`, clean main branch. Asks user for MAJOR/MINOR/PATCH, confirms before pushing tag.

## Test plan
- [x] Commands are markdown — no code to test
- [x] Release workflow unchanged (`.goreleaser.yml`, `.github/workflows/release.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)