### PR TITLE
docs: add verify-before-push policy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -57,6 +57,19 @@ Follows the [Agent Skills](https://agentskills.io) open standard. See `docs/skil
 | `docs/skills-standard.md` | Agent Skills spec, cross-platform compat, known issues |
 | `docs/ynd.md` | ynd command reference |
 
+## Verify Before Push
+
+**NEVER push to remote without full local verification first.** The workflow is always:
+
+1. Make the fix
+2. Run the full verification locally (`make check`, `/evals`, whatever caught the issue)
+3. Confirm the fix actually resolves the problem — don't assume
+4. Only then: commit, push, create PR
+
+This applies to everything — code, docs, tutorials. Pushing a fix that hasn't been locally verified is not acceptable. Multiple follow-up fix PRs for the same issue is unprofessional.
+
+**Never push directly to main.** Always use a PR branch.
+
 ## Code Conventions
 
 - Go 1.25+, standard library only (zero external dependencies)

--- a/.claude/commands/evals.md
+++ b/.claude/commands/evals.md
@@ -50,3 +50,5 @@ EVALS: FAIL (N tutorials, X failures)
 If ANY step in ANY tutorial fails, the overall verdict is **FAIL**.
 
 Do not attempt fixes during evaluation. Report only.
+
+If the verdict is FAIL and you are asked to fix the failures: make the fixes locally, then re-run this entire eval process locally to confirm PASS **before** pushing anything to remote. Never push tutorial fixes without verifying them first.


### PR DESCRIPTION
## Summary
- Add "Verify Before Push" section to CLAUDE.md — enforces local verification before any remote push
- Update /evals command to reinforce that fixes must pass locally before pushing

Evals verified locally: PASS (13 tutorials + edge cases, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)