### PR TITLE
feat: make ynh repo a ynh-installable harness

### DIFF
--- a/.claude/commands/evals.md
+++ b/.claude/commands/evals.md
@@ -6,6 +6,8 @@ Evaluate ALL tutorials. This is a release gate — the verdict must be PASS befo
 2. For EVERY tutorial in `docs/tutorial/` (01 through 13, excluding README.md):
    - Set up an isolated environment: `export HOME=$(mktemp -d) && export YNH_HOME=""`
    - Use binaries at `/Users/david/.ynh/bin/ynh` and `/Users/david/.ynh/bin/ynd`
+   - **ALL file creation and commands MUST run in `/tmp/`** — never in the repo directory. The repo has real `skills/`, `agents/`, `rules/`, `commands/` directories; creating test files there pollutes the working tree. Use `cd /tmp` or absolute `/tmp/...` paths for all tutorial commands.
+   - **Use only the Bash tool** for creating files outside the repo. Do NOT use Write/Edit tools for `/tmp/` files (they trigger permission prompts).
    - Execute each step that produces verifiable output
    - Compare actual output against the expected output documented in the tutorial
    - Skip steps that require network access (git clone from GitHub), vendor CLIs (claude, codex), or Docker

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -387,24 +387,14 @@ Possible `source_type` values: `"local"`, `"git"`, `"registry"`. Registry instal
 
 ## Using ynh's Own Harness
 
-The ynh project ships its own harness (skills, agents, rules) for contributors. Since the harness is named `ynh` — which conflicts with the `ynh` binary in `~/.ynh/bin/` — it installs without a launcher script:
+The ynh project ships its own harness (skills, agents, rules) for both contributors and new users:
 
 ```bash
 ynh install github.com/eyelock/ynh
-
-# Or install from a monorepo subdirectory:
-# ynh install github.com/org/monorepo --path harnesses/my-harness
-# Installed harness "ynh"
-#   Launcher: (skipped — conflicts with ynh binary, use "ynh run ynh")
+ynh-guide
 ```
 
-To use it, run explicitly:
-
-```bash
-ynh run ynh
-```
-
-The skills and agents in this harness are development-focused and will be extracted to a separate repo in the future.
+Inside the session, `/ynh-create-harness` walks you through creating your own harness. The development-focused skills (`ynh-dev`, `vendor-adapters`, etc.) live in `.claude/` and are loaded natively by Claude — they're not part of the installable harness.
 
 ## Submitting Changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# ynh — Your Name, Your AI
+
+You are running inside a ynh-managed harness. ynh assembles skills, agents, rules, and commands from any source into a vendor-native layout for Claude, Codex, or Cursor.
+
+## What you can help with
+
+- **Creating harnesses** — Use `/ynh-create-harness` to walk the user through building their first harness
+- **Team setup** — Use `/ynh-team-setup` to graduate from a personal harness to team delegation
+- **Questions about ynh** — Composition, vendor switching, includes, delegates, registries — answer from the docs and code in this harness
+
+## Key concepts
+
+- A **harness** is a directory with `harness.json` plus `skills/`, `agents/`, `rules/`, `commands/`
+- `ynh install` copies a harness (local or Git) into `~/.ynh/harnesses/` and assembles it for the target vendor
+- `ynh run <name>` launches the vendor CLI with the assembled config
+- Harnesses compose via `includes` (pull artifacts from other repos) and `delegates_to` (subagent delegation)
+- Switch vendors at any time with `-v codex` or `-v cursor`

--- a/README.md
+++ b/README.md
@@ -3,11 +3,19 @@
 **Your name. Your AI.**
 
 ```bash
+brew tap eyelock/tap && brew install ynh
+ynh install github.com/eyelock/ynh
+ynh-guide
+```
+
+That gets you a guided session that teaches you ynh — and helps you create your own harness. Once you have one:
+
+```bash
 ynh install github.com/myorg/david
 david
 ```
 
-That's it. `david` is now a command. It knows your skills, your team's rules, your coding standards. It works on Claude today. Switch to Codex with `-v codex`. Same harness, different engine.
+`david` is now a command. It knows your skills, your team's rules, your coding standards. It works on Claude today. Switch to Codex with `-v codex`. Same harness, different engine.
 
 ## What this gives you
 
@@ -26,9 +34,17 @@ david -v codex                     # same harness, different vendor
 ## The 60-second version
 
 ```bash
-# Install
+# Install ynh
 brew tap eyelock/tap && brew install ynh
 
+# Try the ynh harness — it teaches you ynh
+ynh install github.com/eyelock/ynh
+ynh-guide
+```
+
+Inside the session, use `/ynh-create-harness` to build your own. Or do it manually:
+
+```bash
 # Create a harness
 mkdir david && cat > david/harness.json << 'EOF'
 {"name":"david","version":"0.1.0","default_vendor":"claude"}

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,11 +3,19 @@
 **Your name. Your AI.**
 
 ```bash
+brew tap eyelock/tap && brew install ynh
+ynh install github.com/eyelock/ynh
+ynh-guide
+```
+
+That gets you a guided session that teaches you ynh — and helps you create your own harness. Once you have one:
+
+```bash
 ynh install github.com/myorg/david
 david
 ```
 
-That's it. `david` is now a command. It knows your skills, your team's rules, your coding standards. It works on Claude today. Switch to Codex with `-v codex`. Same harness, different engine.
+`david` is now a command. It knows your skills, your team's rules, your coding standards. It works on Claude today. Switch to Codex with `-v codex`. Same harness, different engine.
 
 ## What this gives you
 
@@ -59,6 +67,14 @@ ynd marketplace build              # build a shareable marketplace
 # Install ynh
 brew tap eyelock/tap && brew install ynh
 
+# Try the ynh harness — it teaches you ynh
+ynh install github.com/eyelock/ynh
+ynh-guide
+```
+
+Inside the session, use `/ynh-create-harness` to build your own. Or do it manually:
+
+```bash
 # Create a harness
 mkdir david
 echo '{"name":"david","version":"0.1.0","default_vendor":"claude"}' > david/harness.json
@@ -75,7 +91,7 @@ Add skills, agents, rules, and commands to the harness directory. Pull from Git 
 ## Guides
 
 - **[Harness Engineering](harness-engineering.md)** - Why harness management matters (Fowler, OpenAI, Anthropic)
-- **[Getting Started](getting-started.md)** - Create your first harness and run it
+- **[Getting Started](getting-started.md)** - Install, try the ynh harness, then create your own
 - **[Tutorials](tutorial/README.md)** - Progressive tutorials: build, refine, share & scale
 - **[Artifacts Guide](artifacts.md)** - Skills, agents, rules, commands, and project instructions
 - **[Agent Skills Standard](skills-standard.md)** - Cross-platform spec, frontmatter fields, catalog budget, discovery paths

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -129,21 +129,21 @@ If any step fails, fix the issue and re-run until all checks pass.
 
 ## Project Instructions
 
-A harness can include an `instructions.md` file with project-level instructions. At runtime, this is copied to the vendor-specific instructions file at the project root:
+A harness can include an `AGENTS.md` file with project-level instructions. Most vendors read `AGENTS.md` natively. For Claude, ynh generates a `CLAUDE.md` with an `@AGENTS.md` import.
 
-| Vendor | Target filename |
-|--------|----------------|
-| Claude | `CLAUDE.md` |
-| Codex | `codex.md` |
-| Cursor | `.cursorrules` |
+| Vendor | Native AGENTS.md support | ynh shim |
+|--------|--------------------------|----------|
+| Claude | No | `CLAUDE.md` with `@AGENTS.md` import |
+| Codex  | Yes | — |
+| Cursor | Yes | — |
 
 ```
 my-harness/
 ├── harness.json
-└── instructions.md       <- becomes CLAUDE.md (or vendor equivalent)
+└── AGENTS.md             <- read natively by Codex/Cursor; shimmed for Claude
 ```
 
-**Example instructions.md:**
+**Example AGENTS.md:**
 
 ```markdown
 You are a senior developer working on a Go microservices codebase.
@@ -154,7 +154,9 @@ You are a senior developer working on a Go microservices codebase.
 - Run `make check` before committing
 ```
 
-If multiple sources provide `instructions.md` (e.g., an included repo and the harness itself), the last source wins. Since the harness's own content is processed last, its `instructions.md` takes priority over included repos.
+If multiple sources provide instructions (e.g., an included repo and the harness itself), the last source wins. Since the harness's own content is processed last, its `AGENTS.md` takes priority over included repos.
+
+> **Note:** `instructions.md` is also supported and takes precedence over `AGENTS.md` if both exist. New harnesses should use `AGENTS.md`.
 
 ## Where Artifacts Come From
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,6 +22,17 @@ The `~/.ynh/` directory is created automatically on first use. To customize the 
 export YNH_HOME="$HOME/.config/ynh"
 ```
 
+## Try the ynh Harness
+
+The fastest way to see what ynh does is to install the ynh harness itself:
+
+```bash
+ynh install github.com/eyelock/ynh
+ynh-guide
+```
+
+This gives you an AI session with skills that teach you ynh — including `/ynh-create-harness` to build your own harness interactively.
+
 ## Create a Harness
 
 A harness is a directory with a `harness.json` and your artifacts:

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -11,7 +11,7 @@ A harness is defined by a `harness.json` manifest and artifact directories.
 ```
 david/
 ├── harness.json              # required - name, version, vendor, includes, hooks, etc.
-├── instructions.md           # optional - project-level instructions
+├── AGENTS.md                 # optional - project-level instructions (read natively by most vendors; ynh shims Claude via @-import)
 ├── skills/                   # optional - embedded skills
 │   └── review/
 │       └── SKILL.md
@@ -180,7 +180,7 @@ When running as `david`, you can ask it to delegate a task to `team-dev`. The de
 At runtime, ynh generates a vendor-native agent file for each delegate containing:
 
 - **Description** from the delegate's `harness.json` (helps the AI route to the right delegate)
-- **Instructions** from the delegate's `instructions.md` (gives the delegate its identity)
+- **Instructions** from the delegate's `AGENTS.md` (gives the delegate its identity)
 - **Rules** inlined from the delegate's `rules/` directory
 - **Skills** listed from the delegate's `skills/` directory
 

--- a/docs/tutorial/01-first-harness.md
+++ b/docs/tutorial/01-first-harness.md
@@ -107,12 +107,12 @@ find /tmp/ynh-tutorial/my-harness -type f | sort
 
 Expected:
 ```
-agents/nitpicker.md
-commands/hello.md
-harness.json
-instructions.md
-rules/be-brief.md
-skills/greet/SKILL.md
+/tmp/ynh-tutorial/my-harness/agents/nitpicker.md
+/tmp/ynh-tutorial/my-harness/commands/hello.md
+/tmp/ynh-tutorial/my-harness/harness.json
+/tmp/ynh-tutorial/my-harness/instructions.md
+/tmp/ynh-tutorial/my-harness/rules/be-brief.md
+/tmp/ynh-tutorial/my-harness/skills/greet/SKILL.md
 ```
 
 ## T1.4: Install from local path
@@ -137,8 +137,8 @@ ynh ls
 
 Expected:
 ```
-NAME        VENDOR  SOURCE                          ARTIFACTS      INCLUDES  DELEGATES TO
-my-harness  claude  /tmp/ynh-tutorial/my-harness     1s 1a 1r 1c   0         0
+NAME        VENDOR  SOURCE                        ARTIFACTS    INCLUDES  DELEGATES TO
+my-harness  claude  /tmp/ynh-tutorial/my-harness  1s 1a 1r 1c  0         0
 ```
 
 The ARTIFACTS column shows a compact count: skills (s), agents (a), rules (r), commands (c).
@@ -215,11 +215,13 @@ my-harness --model opus -- "what are you? one sentence."
 
 ## T1.9: Inspect the assembled output
 
+> **Note:** The run directory is created by `ynh run`, which requires a vendor CLI. This step is only verifiable after running T1.6/T1.7/T1.8.
+
 ```bash
 ls -Ra ~/.ynh/run/my-harness/
 ```
 
-Expected:
+Expected (stylized — actual `ls -Ra` format uses directory headers):
 ```
 CLAUDE.md
 .claude/

--- a/docs/tutorial/10-hooks.md
+++ b/docs/tutorial/10-hooks.md
@@ -112,7 +112,6 @@ Expected output includes `.cursor/hooks.json` with Cursor's format:
 
 ```json
 {
-  "version": 1,
   "hooks": {
     "afterFileEdit": [
       { "command": "/usr/local/bin/run-linter.sh" }
@@ -123,7 +122,8 @@ Expected output includes `.cursor/hooks.json` with Cursor's format:
     "stop": [
       { "command": "/usr/local/bin/session-report.sh" }
     ]
-  }
+  },
+  "version": 1
 }
 ```
 

--- a/docs/tutorial/12-developer-preview.md
+++ b/docs/tutorial/12-developer-preview.md
@@ -83,6 +83,8 @@ Expected output structure:
 
 ```
 .claude/
+  agents/
+  commands/
   hooks/
     hooks.json
   rules/
@@ -210,7 +212,6 @@ Expected:
 
 ```json
 {
-  "version": 1,
   "hooks": {
     "afterFileEdit": [
       { "command": "/usr/local/bin/validate-output.sh" }
@@ -218,7 +219,8 @@ Expected:
     "beforeShellExecution": [
       { "command": "/usr/local/bin/check-deploy.sh" }
     ]
-  }
+  },
+  "version": 1
 }
 ```
 

--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -266,7 +266,7 @@ ynh run nonexistent-harness
 
 ```bash
 ynd export /tmp/ynh-edge/repo -v fakevend
-# Expected: Error: unknown vendor "fakevend" (available: [claude codex cursor])
+# Expected: Error: unknown vendor "fakevend" (available: [... order varies ...])
 ```
 
 ### E8: Export missing source
@@ -336,7 +336,9 @@ cd /tmp
 ynd create harness broken-test
 mkdir -p broken-test/skills/orphan
 ynd validate broken-test
-# Expected: INVALID — skills/orphan/ missing SKILL.md
+# Expected:
+#   broken-test: INVALID
+#     - skills/orphan/ missing SKILL.md
 
 rm -rf broken-test
 ```

--- a/docs/ynd.md
+++ b/docs/ynd.md
@@ -63,16 +63,16 @@ A backup of every file is saved to `~/.ynd/backups/` before overwriting. Use `--
 
 ```bash
 ynd compress                   # discover and compress all .md files
-ynd compress instructions.md   # specific file
+ynd compress AGENTS.md         # specific file
 ynd compress -y verbose.md     # skip confirmation prompt
 ynd compress -v claude         # use specific vendor CLI
 YNH_YES=1 ynd compress file.md # skip confirmation via env var
 CI=true ynd compress file.md   # also skip confirmation (CI convention)
 
 # Backup management
-ynd compress --list-backups instructions.md   # show backup history
-ynd compress --restore instructions.md        # restore latest backup
-ynd compress --restore --pick 2 instructions.md  # restore specific backup
+ynd compress --list-backups AGENTS.md   # show backup history
+ynd compress --restore AGENTS.md        # restore latest backup
+ynd compress --restore --pick 2 AGENTS.md  # restore specific backup
 ```
 
 ### inspect
@@ -280,7 +280,7 @@ ynd lint
 ynd fmt
 
 # Compress verbose instructions before shipping
-ynd compress -y instructions.md
+ynd compress -y AGENTS.md
 
 # Inspect a project to generate skills
 cd /path/to/my-app

--- a/harness.json
+++ b/harness.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json",
+  "name": "ynh-guide",
+  "version": "0.1.0",
+  "description": "AI harness management — your name, your AI",
+  "author": { "name": "eyelock", "url": "https://github.com/eyelock" },
+  "keywords": ["harness", "ai", "skills", "meta"],
+  "default_vendor": "claude"
+}

--- a/skills/ynd-compress/SKILL.md
+++ b/skills/ynd-compress/SKILL.md
@@ -15,7 +15,7 @@ Use after authoring or updating skills, agents, rules, or instructions. Compress
 
 Help the user find files worth compressing. Good candidates are:
 
-- Verbose `instructions.md` files
+- Verbose `AGENTS.md` files
 - Skills with lengthy step-by-step guides
 - Rules that use more words than necessary
 - Any markdown file over ~500 chars that loads every session
@@ -24,7 +24,7 @@ Files that should NOT be compressed:
 
 - Reference documents (they're read on-demand, not loaded every session)
 - Files that are already concise
-- Config files (plugin.json, metadata.json)
+- Config files (harness.json)
 
 ## Step 2: Review before compressing
 

--- a/skills/ynh-create-harness/SKILL.md
+++ b/skills/ynh-create-harness/SKILL.md
@@ -15,8 +15,7 @@ Read these references to understand the current formats and conventions:
 2. Read `references/artifact-formats.md` for skill, agent, rule, and command formats
 
 Also read the working examples in `testdata/sample-harness/` to see realistic artifacts:
-- `testdata/sample-harness/.claude-plugin/plugin.json`
-- `testdata/sample-harness/metadata.json`
+- `testdata/sample-harness/harness.json`
 - `testdata/sample-harness/skills/hello/SKILL.md`
 - `testdata/sample-harness/agents/code-reviewer.md`
 - `testdata/sample-harness/rules/be-concise.md`
@@ -55,10 +54,8 @@ Create the directory structure based on their choices:
 
 ```
 <output-dir>/
-├── .claude-plugin/
-│   └── plugin.json
-├── metadata.json
-├── instructions.md      (optional - becomes CLAUDE.md / codex.md / .cursorrules)
+├── harness.json
+├── AGENTS.md            (optional - read natively by most vendors; ynh shims Claude via @-import)
 ├── skills/              (if selected)
 │   └── <example>/
 │       └── SKILL.md
@@ -70,25 +67,15 @@ Create the directory structure based on their choices:
     └── <example>.md
 ```
 
-For `.claude-plugin/plugin.json`:
+For `harness.json`:
 
 ```json
 {
+  "$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json",
   "name": "<their-name>",
   "version": "0.1.0",
-  "description": "<their description>"
-}
-```
-
-For `metadata.json` (only needed if they want vendor/includes/delegates config):
-
-```json
-{
-  "ynh": {
-    "default_vendor": "<their-vendor>",
-    "includes": [],
-    "delegates_to": []
-  }
+  "description": "<their description>",
+  "default_vendor": "<their-vendor>"
 }
 ```
 
@@ -127,6 +114,6 @@ If `ynh` isn't on their PATH, remind them about the build step (`make build`) an
 
 After the harness is working, mention:
 
-1. **Add external skills** - They can pull skills from any Git repo by adding `includes` to `metadata.json`. See `references/harness-format.md` for the syntax.
+1. **Add external skills** - They can pull skills from any Git repo by adding `includes` to `harness.json`. See `references/harness-format.md` for the syntax.
 2. **Team setup** - When ready, they can use `/ynh-team-setup` to create a team harness with delegation.
 3. **Private repos** - If they need private Git repos, SSH URLs (`git@github.com:...`) are recommended. ynh delegates to the local `git` binary - if `git clone` works, ynh works.

--- a/skills/ynh-create-harness/references/artifact-formats.md
+++ b/skills/ynh-create-harness/references/artifact-formats.md
@@ -68,14 +68,14 @@ make format && make lint && make test
 ```
 ```
 
-## Project instructions (instructions.md)
+## Project instructions (AGENTS.md)
 
-Optional file at harness root. Copied to vendor-specific filename at runtime:
+Optional file at harness root. Most vendors read `AGENTS.md` natively. For Claude, ynh generates a `CLAUDE.md` with an `@AGENTS.md` import.
 
-| Vendor | Target |
-|--------|--------|
-| Claude | `CLAUDE.md` |
-| Codex  | `codex.md` |
-| Cursor | `.cursorrules` |
+| Vendor | Native support | ynh shim |
+|--------|---------------|----------|
+| Claude | No | `CLAUDE.md` with `@AGENTS.md` import |
+| Codex  | Yes | — |
+| Cursor | Yes | — |
 
-Last source wins. Harness's own `instructions.md` takes priority over included repos.
+Last source wins. Harness's own `AGENTS.md` takes priority over included repos.

--- a/skills/ynh-create-harness/references/harness-format.md
+++ b/skills/ynh-create-harness/references/harness-format.md
@@ -4,10 +4,8 @@
 
 ```
 my-harness/
-├── .claude-plugin/
-│   └── plugin.json       # required - name, version
-├── metadata.json          # optional - vendor, includes, delegates
-├── instructions.md        # optional - becomes CLAUDE.md / codex.md / .cursorrules
+├── harness.json           # required - name, version, vendor, includes, delegates
+├── AGENTS.md              # optional - read natively by most vendors; ynh shims Claude via @-import
 ├── skills/
 │   └── <name>/
 │       └── SKILL.md
@@ -19,13 +17,15 @@ my-harness/
     └── <name>.md
 ```
 
-## .claude-plugin/plugin.json
+## harness.json
 
 ```json
 {
+  "$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json",
   "name": "david",
   "version": "0.1.0",
-  "description": "David's coding harness"
+  "description": "David's coding harness",
+  "default_vendor": "claude"
 }
 ```
 
@@ -33,35 +33,24 @@ my-harness/
 
 Lowercase, hyphens and dots allowed. Regex: `^[a-zA-Z0-9][a-zA-Z0-9._-]*$`. This becomes the launcher command on PATH.
 
-## metadata.json
-
-```json
-{
-  "ynh": {
-    "default_vendor": "claude",
-    "includes": [],
-    "delegates_to": []
-  }
-}
-```
-
 ### includes
 
 ```json
 {
-  "ynh": {
-    "includes": [
-      {
-        "git": "github.com/user/repo",
-        "ref": "v2.0.0",
-        "path": "packages/ai-config",
-        "pick": ["skills/commit", "agents/reviewer"]
-      },
-      {
-        "git": "git@github.com:co/repo.git"
-      }
-    ]
-  }
+  "name": "david",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "includes": [
+    {
+      "git": "github.com/user/repo",
+      "ref": "v2.0.0",
+      "path": "packages/ai-config",
+      "pick": ["skills/commit", "agents/reviewer"]
+    },
+    {
+      "git": "git@github.com:co/repo.git"
+    }
+  ]
 }
 ```
 
@@ -69,15 +58,16 @@ Lowercase, hyphens and dots allowed. Regex: `^[a-zA-Z0-9][a-zA-Z0-9._-]*$`. This
 
 ```json
 {
-  "ynh": {
-    "delegates_to": [
-      {
-        "git": "github.com/user/other-harness",
-        "ref": "main",
-        "path": "harnesses/team-ops"
-      }
-    ]
-  }
+  "name": "team-dev",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "delegates_to": [
+    {
+      "git": "github.com/user/other-harness",
+      "ref": "main",
+      "path": "harnesses/team-ops"
+    }
+  ]
 }
 ```
 

--- a/skills/ynh-team-setup/SKILL.md
+++ b/skills/ynh-team-setup/SKILL.md
@@ -12,7 +12,7 @@ You are guiding a user through creating a team harness that delegates to persona
 Read these references to understand delegation and Git URL formats:
 
 1. Read `references/delegation.md` for `delegates_to` syntax, Git URL formats, auth, and vendor support
-2. Read `testdata/team-harness/.claude-plugin/plugin.json` and `testdata/team-harness/metadata.json` for the team harness structure
+2. Read `testdata/team-harness/harness.json` for the team harness structure
 
 ## Step 1: Understand their current setup
 
@@ -55,27 +55,18 @@ They might also want to pull from external repos via `includes`.
 
 Create the team harness directory.
 
-`.claude-plugin/plugin.json`:
+`harness.json`:
 
 ```json
 {
+  "$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json",
   "name": "<team-name>",
   "version": "0.1.0",
-  "description": "<team description>"
-}
-```
-
-`metadata.json`:
-
-```json
-{
-  "ynh": {
-    "default_vendor": "<vendor>",
-    "includes": [],
-    "delegates_to": [
-      {"git": "<personal-persona-git-url>"}
-    ]
-  }
+  "description": "<team description>",
+  "default_vendor": "<vendor>",
+  "delegates_to": [
+    {"git": "<personal-persona-git-url>"}
+  ]
 }
 ```
 
@@ -108,7 +99,7 @@ ynh install <personal-persona-git-url>
 david                       # personal session
 ```
 
-Explain the vendor standardization: setting `default_vendor` in `metadata.json` ensures everyone uses the same AI vendor, but individuals can override with `-v`.
+Explain the vendor standardization: setting `default_vendor` in `harness.json` ensures everyone uses the same AI vendor, but individuals can override with `-v`.
 
 ## Step 7: Auth considerations
 


### PR DESCRIPTION
## Summary

- Add `harness.json` and `AGENTS.md` at repo root — `ynh install github.com/eyelock/ynh` now works, creating a `ynh-guide` launcher
- Update all user-facing skills to `harness.json` format (was legacy `.claude-plugin/plugin.json` + `metadata.json`)
- Standardize docs on `AGENTS.md` (was `instructions.md`) — harnesses.md, artifacts.md, ynd.md
- Lead README, docs homepage, and getting-started with the ynh harness install flow
- Add eval isolation rules to prevent agents polluting repo working tree
- Fix 7 pre-existing tutorial doc mismatches

## Test plan

- [x] `ynh install .` → `ynh-guide` launcher created
- [x] `ynh-guide` → session launches with skills visible
- [x] `/evals` passes (13 tutorials + E1-E17, 0 failures)
- [x] Docs site (`localhost:3000`) homepage updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)