### PR TITLE
feat: change profile semantics from replace to merge

### DIFF
--- a/.claude/agents/ynh-contributor.md
+++ b/.claude/agents/ynh-contributor.md
@@ -11,7 +11,7 @@ You help developers contribute to the ynh codebase. Always read `.github/CONTRIB
 The core flow:
 
 ```
-.claude-plugin/plugin.json + metadata.json → resolve Git includes → assemble vendor config → launch vendor CLI
+harness.json → resolve Git includes → assemble vendor config → launch vendor CLI
 ```
 
 Five packages: `internal/harness/`, `internal/plugin/`, `internal/resolver/`, `internal/assembler/`, `internal/vendor/`.

--- a/.claude/rules/pre-remote.md
+++ b/.claude/rules/pre-remote.md
@@ -1,0 +1,33 @@
+Before ANY remote operation (`git push`, `gh pr create`, `gh pr merge`), ALL of the following gates must pass. No exceptions. If blocked, stop and ask the user for help.
+
+## Gate 1: make check
+
+Run `make check`. It must pass with zero issues. If it fails, fix the issue and re-run until green.
+
+## Gate 2: Evals (behavioral changes only)
+
+If the changeset touches ANY of these, run `/evals` and it must PASS:
+- `cmd/ynh/` or `cmd/ynd/` (CLI behavior)
+- `internal/` (core logic)
+- `docs/tutorial/` (tutorial content that evals verify)
+
+Skip evals only for pure documentation changes that don't touch tutorials (e.g., CONTRIBUTING.md, README.md, profiles.md).
+
+## Gate 3: Manual spot-check (output-affecting changes)
+
+If the changeset affects assembled output (`internal/assembler/`, `internal/harness/`, `internal/vendor/`, `internal/exporter/`), do a manual spot-check:
+- Build fresh binaries: `make build`
+- Create a test harness in `/tmp/` that exercises the changed behavior
+- Run `ynd preview` or equivalent and verify the output looks correct
+- Clean up the test harness
+
+## Gate 4: CI after push
+
+After pushing and creating a PR, run `gh pr checks <number> --watch` and wait for CI to pass before merging. If CI is still running, tell the user and wait. Never merge without green CI.
+
+## What to do when blocked
+
+If any gate fails and you cannot resolve it, stop and tell the user:
+- Which gate failed
+- What the error or unexpected output was
+- What you've tried so far

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -15,10 +15,12 @@ Profiles live under the `profiles` key in `harness.json`. Each profile name maps
   "name": "my-harness",
   "version": "0.1.0",
   "hooks": {
-    "before_tool": [{"command": "echo default"}]
+    "before_tool": [{"command": "echo default"}],
+    "after_tool": [{"command": "echo log"}]
   },
   "mcp_servers": {
-    "github": {"command": "gh-mcp", "args": ["serve"]}
+    "github": {"command": "gh-mcp", "args": ["serve"]},
+    "postgres": {"command": "pg-mcp"}
   },
   "profiles": {
     "ci": {
@@ -26,13 +28,11 @@ Profiles live under the `profiles` key in `harness.json`. Each profile name maps
         "before_tool": [{"command": "./scripts/strict-lint.sh", "matcher": "Write"}]
       },
       "mcp_servers": {
-        "github": {"command": "gh-mcp", "args": ["serve"]}
+        "postgres": null,
+        "ci-metrics": {"command": "metrics-mcp"}
       }
     },
     "security-audit": {
-      "hooks": {
-        "before_tool": [{"command": "./scripts/audit-log.sh"}]
-      },
       "mcp_servers": {
         "sast": {"command": "semgrep-mcp", "args": ["serve"]}
       }
@@ -41,13 +41,23 @@ Profiles live under the `profiles` key in `harness.json`. Each profile name maps
 }
 ```
 
-The top-level `hooks` and `mcp_servers` are the defaults — used when no profile is selected. The `ci` and `security-audit` profiles each declare their own hooks and MCP servers.
+The top-level `hooks` and `mcp_servers` are the defaults — used when no profile is selected.
 
-## Replace Semantics
+## Merge Semantics
 
-When a profile is selected, its `hooks` and `mcp_servers` **fully replace** the top-level values. There is no merge and no inheritance. If the `ci` profile defines `hooks` but omits `mcp_servers`, the assembled output will contain only the profile's hooks and no MCP servers.
+Profiles declare only what they change. Absent fields inherit from the top-level defaults.
 
-This keeps behavior predictable: you see exactly what a profile produces by reading its block alone, without tracing merge logic across layers.
+**MCP servers** use deep merge — profile keys win on collision, absent keys are inherited. Server `env` maps are also deep-merged. Set a server to `null` to remove an inherited entry.
+
+**Hooks** use per-event replace — if a profile declares `before_tool`, it replaces the default `before_tool`. Other events (like `after_tool`) are inherited.
+
+Using the example above, selecting the `ci` profile produces:
+- **hooks**: `before_tool` replaced with the CI lint hook; `after_tool` inherited from defaults
+- **mcp_servers**: `github` inherited, `postgres` removed (null), `ci-metrics` added
+
+Selecting `security-audit` produces:
+- **hooks**: all inherited (profile declares none)
+- **mcp_servers**: `github` and `postgres` inherited, `sast` added
 
 ## Profile Selection
 

--- a/docs/schema/harness.schema.json
+++ b/docs/schema/harness.schema.json
@@ -35,13 +35,14 @@
     "hooks": { "$ref": "#/$defs/hooks" },
     "mcp_servers": { "$ref": "#/$defs/mcp_servers" },
     "profiles": {
+      "description": "Named configuration variants. Merge semantics: mcp_servers are deep-merged (profile keys win), hooks use per-event replace (profile event replaces default, absent events inherited). Set a server to null to remove it.",
       "type": "object",
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
           "hooks": { "$ref": "#/$defs/hooks" },
-          "mcp_servers": { "$ref": "#/$defs/mcp_servers" }
+          "mcp_servers": { "$ref": "#/$defs/profile_mcp_servers" }
         }
       }
     },
@@ -81,6 +82,30 @@
         "oneOf": [
           { "required": ["command"] },
           { "required": ["url"] }
+        ]
+      }
+    },
+    "profile_mcp_servers": {
+      "description": "MCP servers within a profile. Null removes an inherited server.",
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          { "type": "null" },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "command": { "type": "string" },
+              "args": { "type": "array", "items": { "type": "string" } },
+              "env": { "type": "object", "additionalProperties": { "type": "string" } },
+              "url": { "type": "string" },
+              "headers": { "type": "object", "additionalProperties": { "type": "string" } }
+            },
+            "oneOf": [
+              { "required": ["command"] },
+              { "required": ["url"] }
+            ]
+          }
         ]
       }
     },

--- a/docs/tutorial/13-profiles.md
+++ b/docs/tutorial/13-profiles.md
@@ -80,8 +80,9 @@ EOF
 Key points:
 - `profiles` is a top-level field in `harness.json`
 - Each profile can contain `hooks` and `mcp_servers`
-- When a profile is selected, its `hooks` and `mcp_servers` **fully replace** the top-level values (no merge, no inheritance)
-- If a profile only defines `hooks`, the top-level `mcp_servers` are dropped (replaced with nothing)
+- Profiles declare only what they change — absent fields inherit from top-level defaults
+- MCP servers are deep-merged (profile keys win on collision); hooks use per-event replace
+- Set an MCP server to `null` in a profile to remove an inherited server
 
 ## T13.2: Validate profiles
 
@@ -103,8 +104,8 @@ ynd preview /tmp/ynh-tutorial/profile-harness -v claude --profile ci
 ```
 
 Expected output includes:
-- `.claude/hooks/hooks.json` with **only** the `ci` profile's `before_tool` hook (the base `after_tool` hook is replaced — profiles use replace semantics, not merge)
-- `.claude/.mcp.json` with the `ci-db` MCP server from the `ci` profile
+- `.claude/hooks/hooks.json` with the `ci` profile's `before_tool` hook **and** the inherited base `after_tool` hook (profiles use per-event merge — the `ci` profile's `before_tool` replaces the default, but `after_tool` is inherited)
+- `.claude/.mcp.json` with the `ci-db` MCP server from the `ci` profile (no base MCP servers to inherit)
 
 Compare with the base (no profile):
 
@@ -141,7 +142,7 @@ Expected reload output includes: `3 hooks · 1 plugin MCP server` (or similar co
 what hooks and MCP servers are configured?
 ```
 
-The `ci` profile's hooks and MCP servers fully replace the base values — only the profile's `before_tool` hook and `ci-db` MCP server are active.
+The `ci` profile's `before_tool` hook replaces the base, and the `ci-db` MCP server is added. The base `after_tool` hook is inherited since the profile doesn't declare it.
 
 > **Note:** Claude Code's `--plugin-dir` auto-activates skills and commands but not hooks or MCP servers. The `/plugin enable` + `/reload-plugins` step is needed to activate them. This is a Claude Code limitation — Codex and Cursor activate all plugin components automatically.
 
@@ -164,7 +165,7 @@ The `YNH_PROFILE` environment variable activates a profile without the flag:
 YNH_PROFILE=ci ynd preview /tmp/ynh-tutorial/profile-harness -v claude
 ```
 
-Expected: same output as `--profile ci` — the `ci` profile's hooks and MCP servers replace the base values.
+Expected: same output as `--profile ci` — the `ci` profile's settings are merged with the base values.
 
 This is useful in CI/CD pipelines:
 
@@ -215,7 +216,8 @@ rm -rf /tmp/ynh-tutorial
 
 - Profiles are declared in `harness.json` under `profiles` as named config objects
 - Each profile can override `hooks` and `mcp_servers`
-- Profile settings **fully replace** the base values (not additive — what you see in the profile is what you get)
+- Profiles use merge semantics: MCP servers are deep-merged (profile keys win), hooks use per-event replace (absent events inherited)
+- Set an MCP server to `null` in a profile to remove an inherited server
 - `--profile <name>` activates a profile on `ynh run`, `ynd preview`, and `ynd diff`
 - `YNH_PROFILE` env var activates a profile (flag takes precedence)
 - Invalid profile names produce helpful errors listing available profiles

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -158,8 +158,12 @@ func LoadDir(dir string) (*Harness, error) {
 	return p, nil
 }
 
-// ResolveProfile returns a copy of the harness with hooks and mcp_servers
-// replaced from the named profile. Returns an error if the profile is not defined.
+// ResolveProfile returns a copy of the harness with profile settings merged
+// into top-level values. MCP servers are deep-merged (profile keys win on
+// collision, absent keys inherited; nil pointer removes inherited entry).
+// Hooks use per-event replace (if profile declares an event, it replaces
+// the default; other events are inherited). Server env maps are deep-merged.
+// Returns an error if the profile is not defined.
 func ResolveProfile(h *Harness, profileName string) (*Harness, error) {
 	if profileName == "" {
 		return h, nil
@@ -170,10 +174,62 @@ func ResolveProfile(h *Harness, profileName string) (*Harness, error) {
 		return nil, fmt.Errorf("profile %q not defined in harness.json", profileName)
 	}
 
-	// Copy the harness, replacing hooks and mcp_servers from the profile
 	resolved := *h
-	resolved.Hooks = profile.Hooks
-	resolved.MCPServers = profile.MCPServers
+
+	// Merge hooks: per-event replace, inherit absent events
+	if profile.Hooks != nil {
+		merged := make(map[string][]plugin.HookEntry)
+		for k, v := range h.Hooks {
+			merged[k] = v
+		}
+		for k, v := range profile.Hooks {
+			merged[k] = v
+		}
+		resolved.Hooks = merged
+	}
+
+	// Merge MCP servers: deep merge, nil removes inherited
+	if profile.MCPServers != nil {
+		merged := make(map[string]plugin.MCPServer)
+		for k, v := range h.MCPServers {
+			merged[k] = v
+		}
+		for k, v := range profile.MCPServers {
+			if v == nil {
+				delete(merged, k)
+			} else {
+				existing, exists := merged[k]
+				if exists {
+					// Deep merge env maps
+					if v.Command != "" {
+						existing.Command = v.Command
+					}
+					if v.Args != nil {
+						existing.Args = v.Args
+					}
+					if v.URL != "" {
+						existing.URL = v.URL
+					}
+					if v.Headers != nil {
+						existing.Headers = v.Headers
+					}
+					if v.Env != nil {
+						if existing.Env == nil {
+							existing.Env = make(map[string]string)
+						}
+						for ek, ev := range v.Env {
+							existing.Env[ek] = ev
+						}
+					}
+					merged[k] = existing
+				} else {
+					merged[k] = *v
+				}
+			}
+		}
+		resolved.MCPServers = merged
+	}
+
 	return &resolved, nil
 }
 

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -361,21 +361,16 @@ func TestLoadDir_RegistryProvenance(t *testing.T) {
 	}
 }
 
-func TestResolveProfile_Replaces(t *testing.T) {
+func TestResolveProfile_MergesMCPServers(t *testing.T) {
 	h := &Harness{
 		Name: "test",
-		Hooks: map[string][]plugin.HookEntry{
-			"before_tool": {{Command: "echo default"}},
-		},
 		MCPServers: map[string]plugin.MCPServer{
-			"default-server": {Command: "default-cmd"},
+			"github": {Command: "gh-cmd", Env: map[string]string{"TOKEN": "abc"}},
+			"slack":  {Command: "slack-cmd"},
 		},
 		Profiles: map[string]plugin.Profile{
 			"ci": {
-				Hooks: map[string][]plugin.HookEntry{
-					"on_stop": {{Command: "echo ci-stop"}},
-				},
-				MCPServers: map[string]plugin.MCPServer{
+				MCPServers: map[string]*plugin.MCPServer{
 					"ci-server": {Command: "ci-cmd"},
 				},
 			},
@@ -387,25 +382,191 @@ func TestResolveProfile_Replaces(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Profile hooks should replace, not merge
-	if _, ok := resolved.Hooks["before_tool"]; ok {
-		t.Error("expected before_tool to be gone after profile resolution")
+	// Profile adds server, inherits others
+	if _, ok := resolved.MCPServers["github"]; !ok {
+		t.Error("expected inherited github server")
 	}
-	if _, ok := resolved.Hooks["on_stop"]; !ok {
-		t.Error("expected on_stop from profile")
-	}
-
-	// Profile MCP servers should replace, not merge
-	if _, ok := resolved.MCPServers["default-server"]; ok {
-		t.Error("expected default-server to be gone after profile resolution")
+	if _, ok := resolved.MCPServers["slack"]; !ok {
+		t.Error("expected inherited slack server")
 	}
 	if _, ok := resolved.MCPServers["ci-server"]; !ok {
 		t.Error("expected ci-server from profile")
 	}
-
-	// Name should be preserved
 	if resolved.Name != "test" {
 		t.Errorf("Name = %q, want test", resolved.Name)
+	}
+}
+
+func TestResolveProfile_NullRemovesServer(t *testing.T) {
+	h := &Harness{
+		Name: "test",
+		MCPServers: map[string]plugin.MCPServer{
+			"postgres": {Command: "pg-cmd"},
+			"github":   {Command: "gh-cmd"},
+		},
+		Profiles: map[string]plugin.Profile{
+			"ci": {
+				MCPServers: map[string]*plugin.MCPServer{
+					"postgres": nil, // remove
+				},
+			},
+		},
+	}
+
+	resolved, err := ResolveProfile(h, "ci")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := resolved.MCPServers["postgres"]; ok {
+		t.Error("expected postgres to be removed by null")
+	}
+	if _, ok := resolved.MCPServers["github"]; !ok {
+		t.Error("expected github to be inherited")
+	}
+}
+
+func TestResolveProfile_HooksPerEventReplace(t *testing.T) {
+	h := &Harness{
+		Name: "test",
+		Hooks: map[string][]plugin.HookEntry{
+			"before_tool": {{Command: "echo default-before"}},
+			"on_stop":     {{Command: "echo default-stop"}},
+		},
+		Profiles: map[string]plugin.Profile{
+			"ci": {
+				Hooks: map[string][]plugin.HookEntry{
+					"on_stop": {{Command: "echo ci-stop"}},
+				},
+			},
+		},
+	}
+
+	resolved, err := ResolveProfile(h, "ci")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// before_tool inherited (profile didn't declare it)
+	if _, ok := resolved.Hooks["before_tool"]; !ok {
+		t.Error("expected before_tool to be inherited")
+	}
+	// on_stop replaced by profile
+	entries := resolved.Hooks["on_stop"]
+	if len(entries) != 1 || entries[0].Command != "echo ci-stop" {
+		t.Errorf("on_stop = %v, want ci-stop", entries)
+	}
+}
+
+func TestResolveProfile_EmptyProfile(t *testing.T) {
+	h := &Harness{
+		Name: "test",
+		Hooks: map[string][]plugin.HookEntry{
+			"before_tool": {{Command: "echo default"}},
+		},
+		MCPServers: map[string]plugin.MCPServer{
+			"github": {Command: "gh-cmd"},
+		},
+		Profiles: map[string]plugin.Profile{
+			"empty": {},
+		},
+	}
+
+	resolved, err := ResolveProfile(h, "empty")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty profile inherits everything unchanged
+	if _, ok := resolved.Hooks["before_tool"]; !ok {
+		t.Error("expected hooks inherited from empty profile")
+	}
+	if _, ok := resolved.MCPServers["github"]; !ok {
+		t.Error("expected mcp_servers inherited from empty profile")
+	}
+}
+
+func TestResolveProfile_FullOverride(t *testing.T) {
+	h := &Harness{
+		Name: "test",
+		Hooks: map[string][]plugin.HookEntry{
+			"before_tool": {{Command: "echo default"}},
+		},
+		MCPServers: map[string]plugin.MCPServer{
+			"default-server": {Command: "default-cmd"},
+		},
+		Profiles: map[string]plugin.Profile{
+			"ci": {
+				Hooks: map[string][]plugin.HookEntry{
+					"before_tool": {{Command: "echo ci"}},
+					"on_stop":     {{Command: "echo ci-stop"}},
+				},
+				MCPServers: map[string]*plugin.MCPServer{
+					"default-server": nil,
+					"ci-server":      {Command: "ci-cmd"},
+				},
+			},
+		},
+	}
+
+	resolved, err := ResolveProfile(h, "ci")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// before_tool replaced by profile
+	entries := resolved.Hooks["before_tool"]
+	if len(entries) != 1 || entries[0].Command != "echo ci" {
+		t.Errorf("before_tool = %v, want ci", entries)
+	}
+	// on_stop added by profile
+	if _, ok := resolved.Hooks["on_stop"]; !ok {
+		t.Error("expected on_stop from profile")
+	}
+	// default-server removed, ci-server added
+	if _, ok := resolved.MCPServers["default-server"]; ok {
+		t.Error("expected default-server removed by null")
+	}
+	if _, ok := resolved.MCPServers["ci-server"]; !ok {
+		t.Error("expected ci-server from profile")
+	}
+}
+
+func TestResolveProfile_MCPServerEnvMerge(t *testing.T) {
+	h := &Harness{
+		Name: "test",
+		MCPServers: map[string]plugin.MCPServer{
+			"github": {
+				Command: "gh-cmd",
+				Env:     map[string]string{"TOKEN": "abc", "ORG": "myorg"},
+			},
+		},
+		Profiles: map[string]plugin.Profile{
+			"ci": {
+				MCPServers: map[string]*plugin.MCPServer{
+					"github": {Env: map[string]string{"TOKEN": "ci-token"}},
+				},
+			},
+		},
+	}
+
+	resolved, err := ResolveProfile(h, "ci")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gh := resolved.MCPServers["github"]
+	// Command inherited (profile didn't set it)
+	if gh.Command != "gh-cmd" {
+		t.Errorf("Command = %q, want gh-cmd", gh.Command)
+	}
+	// TOKEN overridden by profile
+	if gh.Env["TOKEN"] != "ci-token" {
+		t.Errorf("TOKEN = %q, want ci-token", gh.Env["TOKEN"])
+	}
+	// ORG inherited
+	if gh.Env["ORG"] != "myorg" {
+		t.Errorf("ORG = %q, want myorg", gh.Env["ORG"])
 	}
 }
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -26,10 +26,12 @@ type HarnessJSON struct {
 }
 
 // Profile is a named configuration variant. When selected, its fields
-// fully replace the corresponding top-level values (no merge).
+// are merged with top-level values: mcp_servers uses deep merge (profile
+// keys win), hooks uses per-event replace. A nil *MCPServer removes an
+// inherited server (JSON null).
 type Profile struct {
 	Hooks      map[string][]HookEntry `json:"hooks,omitempty"`
-	MCPServers map[string]MCPServer   `json:"mcp_servers,omitempty"`
+	MCPServers map[string]*MCPServer  `json:"mcp_servers,omitempty"`
 }
 
 // AuthorInfo holds harness author information.
@@ -95,13 +97,22 @@ func ValidateHooks(hooks map[string][]HookEntry) []string {
 }
 
 // ValidateProfiles validates hooks and mcp_servers within each profile.
+// Nil MCPServer entries (JSON null) are skipped — they signal removal of
+// an inherited server during profile merge.
 func ValidateProfiles(profiles map[string]Profile) []string {
 	var issues []string
 	for name, profile := range profiles {
 		for _, issue := range ValidateHooks(profile.Hooks) {
 			issues = append(issues, fmt.Sprintf("profile %q: %s", name, issue))
 		}
-		for _, issue := range ValidateMCPServers(profile.MCPServers) {
+		// Filter out nil entries (null removals) before validating
+		servers := make(map[string]MCPServer)
+		for k, v := range profile.MCPServers {
+			if v != nil {
+				servers[k] = *v
+			}
+		}
+		for _, issue := range ValidateMCPServers(servers) {
 			issues = append(issues, fmt.Sprintf("profile %q: %s", name, issue))
 		}
 	}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -367,7 +367,7 @@ func TestValidateProfiles_Valid(t *testing.T) {
 			Hooks: map[string][]HookEntry{
 				"before_tool": {{Command: "echo ci"}},
 			},
-			MCPServers: map[string]MCPServer{
+			MCPServers: map[string]*MCPServer{
 				"test": {Command: "npx"},
 			},
 		},
@@ -404,7 +404,7 @@ func TestValidateProfiles_InvalidHookEvent(t *testing.T) {
 func TestValidateProfiles_MCPServerNoCommand(t *testing.T) {
 	profiles := map[string]Profile{
 		"audit": {
-			MCPServers: map[string]MCPServer{
+			MCPServers: map[string]*MCPServer{
 				"bad": {},
 			},
 		},
@@ -412,6 +412,21 @@ func TestValidateProfiles_MCPServerNoCommand(t *testing.T) {
 	issues := ValidateProfiles(profiles)
 	if len(issues) == 0 {
 		t.Fatal("expected issues for MCP server with no command/url in profile")
+	}
+}
+
+func TestValidateProfiles_NullEntrySkipped(t *testing.T) {
+	profiles := map[string]Profile{
+		"ci": {
+			MCPServers: map[string]*MCPServer{
+				"postgres": nil, // null removal — should not cause validation error
+				"github":   {Command: "gh-cmd"},
+			},
+		},
+	}
+	issues := ValidateProfiles(profiles)
+	if len(issues) != 0 {
+		t.Errorf("expected no issues, got %v", issues)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Profile `mcp_servers` now deep-merge with top-level defaults (profile keys win, absent keys inherited, `null` removes inherited entry)
- Profile `hooks` now use per-event replace (profile event replaces default, absent events inherited)
- Server `env` maps are deep-merged within colliding MCP server entries
- `Profile.MCPServers` type changed to `map[string]*MCPServer` for null detection
- Add `.claude/rules/pre-remote.md` enforcing make check, evals, and manual verification before remote ops

Breaking change — profiles no longer fully replace top-level values. This is 0.0.x, no migration code needed.

## Test plan
- [x] `make check` passes (lint, tests, build)
- [x] 7 new/updated tests: MergesMCPServers, NullRemovesServer, HooksPerEventReplace, EmptyProfile, FullOverride, MCPServerEnvMerge, NullEntrySkipped
- [x] Manual test: `ynd preview` with `--profile ci` shows merged output
- [x] Full evals: PASS (13 tutorials, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)