### PR TITLE
feat: add Focus type, validation, and inline schema variant

### DIFF
--- a/cmd/ynd/validate.go
+++ b/cmd/ynd/validate.go
@@ -179,6 +179,8 @@ func validateHarness(dir string) error {
 			issues = append(issues, validateHarnessMCPServers(hj)...)
 			// Validate profiles
 			issues = append(issues, validateHarnessProfiles(hj)...)
+			// Validate focus entries
+			issues = append(issues, validateHarnessFocus(hj)...)
 		}
 	}
 
@@ -389,6 +391,47 @@ func validateHarnessProfiles(hj map[string]any) []string {
 		// Validate MCP servers within profile
 		for _, issue := range validateHarnessMCPServers(profileMap) {
 			issues = append(issues, fmt.Sprintf("profile %q: %s", name, issue))
+		}
+	}
+
+	return issues
+}
+
+// validateHarnessFocus validates focus entries inside harness.json.
+func validateHarnessFocus(hj map[string]any) []string {
+	var issues []string
+
+	focus, ok := hj["focus"]
+	if !ok {
+		return issues
+	}
+	focusMap, ok := focus.(map[string]any)
+	if !ok {
+		issues = append(issues, "'focus' must be an object")
+		return issues
+	}
+
+	// Collect profile names for cross-field validation
+	profileNames := map[string]bool{}
+	if profiles, ok := hj["profiles"].(map[string]any); ok {
+		for name := range profiles {
+			profileNames[name] = true
+		}
+	}
+
+	for name, entry := range focusMap {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			issues = append(issues, fmt.Sprintf("focus.%s must be an object", name))
+			continue
+		}
+		prompt, _ := entryMap["prompt"].(string)
+		if prompt == "" {
+			issues = append(issues, fmt.Sprintf("focus.%s: prompt must not be empty", name))
+		}
+		profile, _ := entryMap["profile"].(string)
+		if profile != "" && !profileNames[profile] {
+			issues = append(issues, fmt.Sprintf("focus.%s: references unknown profile %q", name, profile))
 		}
 	}
 

--- a/cmd/ynd/validate_test.go
+++ b/cmd/ynd/validate_test.go
@@ -754,6 +754,64 @@ func TestValidateHarness_ProfilesMCPServerInvalid(t *testing.T) {
 	}
 }
 
+func TestValidateHarness_FocusValid(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	hr := filepath.Join(dir, "focus-valid")
+	mkdirAll(t, hr)
+	writeFile(t, filepath.Join(hr, "harness.json"),
+		[]byte(`{"name":"focus-valid","version":"0.1.0","profiles":{"ci":{}},"focus":{"review":{"profile":"ci","prompt":"Review code"}}}`))
+
+	if err := validateHarness(hr); err != nil {
+		t.Errorf("valid focus should pass: %v", err)
+	}
+}
+
+func TestValidateHarness_FocusMissingPrompt(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	hr := filepath.Join(dir, "focus-no-prompt")
+	mkdirAll(t, hr)
+	writeFile(t, filepath.Join(hr, "harness.json"),
+		[]byte(`{"name":"focus-no-prompt","version":"0.1.0","focus":{"review":{"profile":"ci"}}}`))
+
+	err := validateHarness(hr)
+	if err == nil {
+		t.Fatal("expected validation error for focus with missing prompt")
+	}
+}
+
+func TestValidateHarness_FocusUnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	hr := filepath.Join(dir, "focus-bad-profile")
+	mkdirAll(t, hr)
+	writeFile(t, filepath.Join(hr, "harness.json"),
+		[]byte(`{"name":"focus-bad-profile","version":"0.1.0","focus":{"review":{"profile":"nonexistent","prompt":"Review code"}}}`))
+
+	err := validateHarness(hr)
+	if err == nil {
+		t.Fatal("expected validation error for focus referencing unknown profile")
+	}
+}
+
+func TestValidateHarness_FocusNoProfile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	hr := filepath.Join(dir, "focus-no-profile")
+	mkdirAll(t, hr)
+	writeFile(t, filepath.Join(hr, "harness.json"),
+		[]byte(`{"name":"focus-no-profile","version":"0.1.0","focus":{"docs":{"prompt":"Generate docs"}}}`))
+
+	if err := validateHarness(hr); err != nil {
+		t.Errorf("focus without profile ref should pass: %v", err)
+	}
+}
+
 func TestValidateHarness_AgentsMDOnly(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/docs/schema/harness-inline.schema.json
+++ b/docs/schema/harness-inline.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eyelock.github.io/ynh/schema/harness-inline.schema.json",
+  "title": "YNH Inline Harness",
+  "description": "Project-local harness config (.harness.json) — same as harness.schema.json but name and version are optional.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": { "type": "string" },
+    "version": { "type": "string" },
+    "description": { "type": "string" },
+    "author": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "email": { "type": "string" },
+        "url": { "type": "string" }
+      }
+    },
+    "keywords": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "default_vendor": {
+      "type": "string",
+      "enum": ["claude", "cursor", "codex"]
+    },
+    "includes": { "$ref": "harness.schema.json#/$defs/includes" },
+    "delegates_to": { "$ref": "harness.schema.json#/$defs/delegates" },
+    "hooks": { "$ref": "harness.schema.json#/$defs/hooks" },
+    "mcp_servers": { "$ref": "harness.schema.json#/$defs/mcp_servers" },
+    "profiles": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "hooks": { "$ref": "harness.schema.json#/$defs/hooks" },
+          "mcp_servers": { "$ref": "harness.schema.json#/$defs/profile_mcp_servers" }
+        }
+      }
+    },
+    "focus": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["prompt"],
+        "additionalProperties": false,
+        "properties": {
+          "profile": { "type": "string" },
+          "prompt": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "installed_from": { "$ref": "harness.schema.json#/$defs/provenance" }
+  }
+}

--- a/docs/schema/harness.schema.json
+++ b/docs/schema/harness.schema.json
@@ -46,6 +46,19 @@
         }
       }
     },
+    "focus": {
+      "description": "Named combinations of profile + prompt for repeatable AI execution.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["prompt"],
+        "additionalProperties": false,
+        "properties": {
+          "profile": { "type": "string" },
+          "prompt": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
     "installed_from": { "$ref": "#/$defs/provenance" }
   },
   "$defs": {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -51,6 +51,7 @@ type Harness struct {
 	Hooks         map[string][]plugin.HookEntry
 	MCPServers    map[string]plugin.MCPServer
 	Profiles      map[string]plugin.Profile
+	Focuses       map[string]plugin.Focus
 	InstalledFrom *Provenance
 }
 
@@ -143,6 +144,9 @@ func LoadDir(dir string) (*Harness, error) {
 	}
 	if len(hj.Profiles) > 0 {
 		p.Profiles = hj.Profiles
+	}
+	if len(hj.Focuses) > 0 {
+		p.Focuses = hj.Focuses
 	}
 	if hj.InstalledFrom != nil {
 		prov := hj.InstalledFrom

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -22,7 +22,14 @@ type HarnessJSON struct {
 	Hooks         map[string][]HookEntry `json:"hooks,omitempty"`
 	MCPServers    map[string]MCPServer   `json:"mcp_servers,omitempty"`
 	Profiles      map[string]Profile     `json:"profiles,omitempty"`
+	Focuses       map[string]Focus       `json:"focus,omitempty"`
 	InstalledFrom *ProvenanceMeta        `json:"installed_from,omitempty"`
+}
+
+// Focus is a named combination of profile + prompt for repeatable AI execution.
+type Focus struct {
+	Profile string `json:"profile,omitempty"`
+	Prompt  string `json:"prompt"`
 }
 
 // Profile is a named configuration variant. When selected, its fields
@@ -114,6 +121,17 @@ func ValidateProfiles(profiles map[string]Profile) []string {
 		}
 		for _, issue := range ValidateMCPServers(servers) {
 			issues = append(issues, fmt.Sprintf("profile %q: %s", name, issue))
+		}
+	}
+	return issues
+}
+
+// ValidateFocus checks that each focus entry has a non-empty prompt.
+func ValidateFocus(focuses map[string]Focus) []string {
+	var issues []string
+	for name, f := range focuses {
+		if f.Prompt == "" {
+			issues = append(issues, fmt.Sprintf("focus.%s: prompt must not be empty", name))
 		}
 	}
 	return issues

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -430,6 +430,63 @@ func TestValidateProfiles_NullEntrySkipped(t *testing.T) {
 	}
 }
 
+func TestValidateFocus_Valid(t *testing.T) {
+	focuses := map[string]Focus{
+		"review":   {Profile: "ci", Prompt: "Review staged changes"},
+		"security": {Prompt: "Audit for OWASP Top 10"},
+	}
+	issues := ValidateFocus(focuses)
+	if len(issues) != 0 {
+		t.Errorf("expected no issues, got %v", issues)
+	}
+}
+
+func TestValidateFocus_MissingPrompt(t *testing.T) {
+	focuses := map[string]Focus{
+		"review": {Profile: "ci", Prompt: ""},
+	}
+	issues := ValidateFocus(focuses)
+	if len(issues) == 0 {
+		t.Fatal("expected issues for focus with empty prompt")
+	}
+	found := false
+	for _, issue := range issues {
+		if strings.Contains(issue, "focus.review") && strings.Contains(issue, "prompt") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected focus.review prompt error, got %v", issues)
+	}
+}
+
+func TestLoadHarnessJSON_WithFocus(t *testing.T) {
+	dir := t.TempDir()
+	writeHarnessJSON(t, dir, `{
+		"name": "test",
+		"version": "0.1.0",
+		"focus": {
+			"review": {"profile": "ci", "prompt": "Review staged changes"},
+			"docs": {"prompt": "Generate API docs"}
+		}
+	}`)
+	hj, err := LoadHarnessJSON(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hj.Focuses) != 2 {
+		t.Fatalf("Focuses = %d, want 2", len(hj.Focuses))
+	}
+	review := hj.Focuses["review"]
+	if review.Profile != "ci" || review.Prompt != "Review staged changes" {
+		t.Errorf("review = %+v", review)
+	}
+	docs := hj.Focuses["docs"]
+	if docs.Profile != "" || docs.Prompt != "Generate API docs" {
+		t.Errorf("docs = %+v", docs)
+	}
+}
+
 func TestLoadHarnessJSON_TestdataRoundTrip(t *testing.T) {
 	// Verify all testdata harness.json files parse without error
 	entries, err := filepath.Glob("../../testdata/*/harness.json")


### PR DESCRIPTION
## Summary
- Add `Focus` struct (profile + prompt) to `HarnessJSON` and `Harness` — pure additive, no CLI behavior change
- Add `ValidateFocus()` in `internal/plugin/` for prompt validation
- Extend `ynd validate` with focus cross-field checks (unknown profile references)
- Add `focus` field to `harness.schema.json`
- Create `harness-inline.schema.json` variant where `name`/`version` are optional (for `.harness.json` project-local config in PR 3)

## Test plan
- [x] `make check` passes (lint, tests, build)
- [x] New tests: ValidateFocus_Valid, ValidateFocus_MissingPrompt, LoadHarnessJSON_WithFocus, FocusValid, FocusMissingPrompt, FocusUnknownProfile, FocusNoProfile
- [x] Manual spot-check: `ynd validate` correctly accepts valid focus, rejects missing prompt, rejects unknown profile ref
- Evals skipped: purely additive change, no existing behavior affected, no tutorials reference focus yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)