### PR TITLE
docs: add focus and project-local config tutorials

### DIFF
--- a/.claude/commands/evals.md
+++ b/.claude/commands/evals.md
@@ -3,7 +3,7 @@ Evaluate ALL tutorials. This is a release gate — the verdict must be PASS befo
 ## Process
 
 1. Build and install the latest binaries: `make build && make install`
-2. For EVERY tutorial in `docs/tutorial/` (01 through 13, excluding README.md):
+2. For EVERY tutorial in `docs/tutorial/` (01 through 15, excluding README.md):
    - Set up an isolated environment: `export HOME=$(mktemp -d) && export YNH_HOME=""`
    - Use binaries at `/Users/david/.ynh/bin/ynh` and `/Users/david/.ynh/bin/ynd`
    - **ALL file creation and commands MUST run in `/tmp/`** — never in the repo directory. The repo has real `skills/`, `agents/`, `rules/`, `commands/` directories; creating test files there pollutes the working tree. Use `cd /tmp` or absolute `/tmp/...` paths for all tutorial commands.

--- a/cmd/ynd/validate.go
+++ b/cmd/ynd/validate.go
@@ -388,8 +388,8 @@ func validateHarnessProfiles(hj map[string]any) []string {
 		for _, issue := range validateHarnessHooks(profileMap) {
 			issues = append(issues, fmt.Sprintf("profile %q: %s", name, issue))
 		}
-		// Validate MCP servers within profile
-		for _, issue := range validateHarnessMCPServers(profileMap) {
+		// Validate MCP servers within profile (skip null entries — they signal removal)
+		for _, issue := range validateProfileMCPServers(profileMap) {
 			issues = append(issues, fmt.Sprintf("profile %q: %s", name, issue))
 		}
 	}
@@ -397,7 +397,46 @@ func validateHarnessProfiles(hj map[string]any) []string {
 	return issues
 }
 
-// validateHarnessFocus validates focus entries inside harness.json.
+// validateProfileMCPServers validates mcp_servers within a profile, skipping
+// null entries (which signal removal of inherited servers during merge).
+func validateProfileMCPServers(profile map[string]any) []string {
+	var issues []string
+
+	servers, ok := profile["mcp_servers"]
+	if !ok {
+		return issues
+	}
+	serversMap, ok := servers.(map[string]any)
+	if !ok {
+		issues = append(issues, "'mcp_servers' must be an object")
+		return issues
+	}
+
+	for name, entry := range serversMap {
+		if entry == nil {
+			continue // null = remove inherited server
+		}
+		serverMap, ok := entry.(map[string]any)
+		if !ok {
+			issues = append(issues, fmt.Sprintf("mcp_servers.%s must be an object or null", name))
+			continue
+		}
+		cmd, _ := serverMap["command"].(string)
+		url, _ := serverMap["url"].(string)
+		hasCommand := cmd != ""
+		hasURL := url != ""
+		if !hasCommand && !hasURL {
+			issues = append(issues, fmt.Sprintf("mcp_servers.%s: must have either command or url", name))
+		}
+		if hasCommand && hasURL {
+			issues = append(issues, fmt.Sprintf("mcp_servers.%s: must have command or url, not both", name))
+		}
+	}
+
+	return issues
+}
+
+// validateHarnessFocus validates focus entries inside .harness.json.
 func validateHarnessFocus(hj map[string]any) []string {
 	var issues []string
 

--- a/cmd/ynd/validate_test.go
+++ b/cmd/ynd/validate_test.go
@@ -754,6 +754,20 @@ func TestValidateHarness_ProfilesMCPServerInvalid(t *testing.T) {
 	}
 }
 
+func TestValidateHarness_ProfileNullMCPServerValid(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	hr := filepath.Join(dir, "null-mcp")
+	mkdirAll(t, hr)
+	writeFile(t, filepath.Join(hr, ".harness.json"),
+		[]byte(`{"name":"null-mcp","version":"0.1.0","mcp_servers":{"pg":{"command":"pg-mcp"}},"profiles":{"ci":{"mcp_servers":{"pg":null}}}}`))
+
+	if err := validateHarness(hr); err != nil {
+		t.Errorf("null MCP server in profile should pass validation: %v", err)
+	}
+}
+
 func TestValidateHarness_FocusValid(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/docs/tutorial/14-focus.md
+++ b/docs/tutorial/14-focus.md
@@ -1,0 +1,188 @@
+# Tutorial 14: Focus
+
+Define named focus entries that combine a profile with a prompt for repeatable, non-interactive AI execution. Focus entries are the bridge between harness configuration and CI automation.
+
+## Prerequisites
+
+```bash
+# Clean up from any previous run
+rm -rf /tmp/ynh-tutorial
+ynh uninstall focus-demo 2>/dev/null
+
+mkdir -p /tmp/ynh-tutorial
+```
+
+## T14.1: Create a harness with focus entries
+
+Create a harness with profiles and focus entries that reference them:
+
+```bash
+mkdir -p /tmp/ynh-tutorial/focus-harness/skills/deploy
+
+cat > /tmp/ynh-tutorial/focus-harness/.harness.json << 'EOF'
+{
+  "name": "focus-demo",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "hooks": {
+    "after_tool": [
+      { "command": "/usr/local/bin/format-check.sh" }
+    ]
+  },
+  "mcp_servers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "${GITHUB_TOKEN}" }
+    }
+  },
+  "profiles": {
+    "ci": {
+      "hooks": {
+        "before_tool": [
+          { "matcher": "Bash", "command": "/usr/local/bin/ci-guard.sh" }
+        ]
+      },
+      "mcp_servers": {
+        "github": null
+      }
+    }
+  },
+  "focus": {
+    "review": {
+      "profile": "ci",
+      "prompt": "Review staged changes for quality and correctness"
+    },
+    "docs": {
+      "prompt": "Generate API documentation for all public interfaces"
+    }
+  }
+}
+EOF
+
+cat > /tmp/ynh-tutorial/focus-harness/instructions.md << 'EOF'
+You are a development assistant. Follow team coding standards.
+EOF
+
+cat > /tmp/ynh-tutorial/focus-harness/skills/deploy/SKILL.md << 'EOF'
+---
+name: deploy
+description: Deploy to staging or production
+---
+
+Run the deployment pipeline for the target environment.
+EOF
+```
+
+Key points:
+- `focus` is a top-level field alongside `profiles`
+- Each focus has a `prompt` (required) and optional `profile`
+- The `review` focus activates the `ci` profile and sends a review prompt
+- The `docs` focus has no profile — it uses the base configuration
+- The `ci` profile uses `null` to remove the inherited `github` MCP server
+
+## T14.2: Validate focus entries
+
+```bash
+ynd validate /tmp/ynh-tutorial/focus-harness
+```
+
+Expected:
+```
+/tmp/ynh-tutorial/focus-harness: valid
+```
+
+The validator checks that each focus entry has a non-empty `prompt` and that any referenced profile exists.
+
+## T14.3: Preview with --focus review
+
+```bash
+ynd preview /tmp/ynh-tutorial/focus-harness -v claude --focus review
+```
+
+Expected output includes:
+- `.claude/hooks/hooks.json` with the `ci` profile's `before_tool` hook (PreToolUse) **and** the inherited base `after_tool` hook (PostToolUse) — profiles use merge semantics
+- No `.claude/.mcp.json` — the `ci` profile removes the `github` MCP server via `null`
+
+Compare with `--focus docs` (no profile, uses base config):
+
+```bash
+ynd preview /tmp/ynh-tutorial/focus-harness -v claude --focus docs
+```
+
+Expected: `.claude/hooks/hooks.json` has only the base `after_tool` hook (PostToolUse). `.claude/.mcp.json` has the `github` MCP server (inherited from base).
+
+## T14.4: Focus and profile are mutually exclusive
+
+```bash
+ynd preview /tmp/ynh-tutorial/focus-harness -v claude --focus review --profile ci
+```
+
+Expected error:
+```
+Error: cannot use --focus and --profile together
+```
+
+A focus already includes a profile — specifying both is ambiguous.
+
+## T14.5: Unknown focus is an error
+
+```bash
+ynd preview /tmp/ynh-tutorial/focus-harness -v claude --focus nonexistent
+```
+
+Expected error:
+```
+Error: focus "nonexistent" not defined in harness
+```
+
+## T14.6: Use YNH_FOCUS env var
+
+The `YNH_FOCUS` environment variable activates a focus without the flag:
+
+```bash
+YNH_FOCUS=review ynd preview /tmp/ynh-tutorial/focus-harness -v claude
+```
+
+Expected: same output as `--focus review` — the `ci` profile's hooks merged with base, no MCP servers.
+
+## T14.7: Install and view focus in ynh info
+
+```bash
+ynh install /tmp/ynh-tutorial/focus-harness
+ynh info focus-demo
+```
+
+Expected output includes a `Focus:` section:
+```
+Focus:
+  review    profile=ci    "Review staged changes for quality and correctness"
+  docs    (default)    "Generate API documentation for all public interfaces"
+```
+
+And a `Profiles:` section:
+```
+Profiles:
+  ci    hooks: before_tool    mcp_servers: github
+```
+
+## Clean up
+
+```bash
+ynh uninstall focus-demo 2>/dev/null
+rm -rf /tmp/ynh-tutorial
+```
+
+## What You Learned
+
+- Focus entries combine a profile + prompt for repeatable AI execution
+- Each focus requires a `prompt`; the `profile` field is optional
+- `--focus <name>` activates a focus on `ynh run`, `ynd preview`, `ynd diff`, and `ynd export`
+- `YNH_FOCUS` env var activates a focus (flag takes precedence)
+- `--focus` and `--profile` are mutually exclusive — focus already includes a profile
+- Focus entries that reference a non-existent profile are caught by `ynd validate`
+- `ynh info` displays focus entries and profiles
+
+## Next
+
+[Tutorial 15: Project-Local Config](15-project-local-config.md) — use `.harness.json` in your project root for zero-install AI configuration.

--- a/docs/tutorial/15-project-local-config.md
+++ b/docs/tutorial/15-project-local-config.md
@@ -1,0 +1,105 @@
+# Tutorial 15: Project-Local Config
+
+Use a `.harness.json` file in your project root for zero-install AI configuration. No `ynh install` needed — just drop the file and run.
+
+## Prerequisites
+
+```bash
+# Clean up from any previous run
+rm -rf /tmp/ynh-tutorial
+
+mkdir -p /tmp/ynh-tutorial
+```
+
+## T15.1: Create a project with .harness.json
+
+Create a project directory with a `.harness.json` file:
+
+```bash
+mkdir -p /tmp/ynh-tutorial/my-project/rules
+
+cat > /tmp/ynh-tutorial/my-project/.harness.json << 'EOF'
+{
+  "name": "my-project",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "hooks": {
+    "before_tool": [
+      { "matcher": "Write", "command": "/usr/local/bin/lint.sh" }
+    ]
+  },
+  "focus": {
+    "review": {
+      "prompt": "Review staged changes for quality"
+    }
+  }
+}
+EOF
+
+cat > /tmp/ynh-tutorial/my-project/rules/standards.md << 'EOF'
+Follow the team coding standards. Use meaningful variable names.
+EOF
+```
+
+Key points:
+- `.harness.json` in the project root — same format as an installed harness
+- No `ynh install` needed — ynh can discover and use this file directly
+- Rules, skills, agents, and commands sit alongside `.harness.json` as usual
+
+## T15.2: Validate the project config
+
+```bash
+ynd validate /tmp/ynh-tutorial/my-project
+```
+
+Expected:
+```
+/tmp/ynh-tutorial/my-project: valid
+```
+
+## T15.3: Preview the assembled output
+
+```bash
+ynd preview /tmp/ynh-tutorial/my-project -v claude
+```
+
+Expected output includes:
+- `.claude/hooks/hooks.json` with the `before_tool` hook (PreToolUse with Write matcher)
+- `.claude/rules/standards.md` with the rule content
+- `.claude-plugin/plugin.json` with the project name
+
+## T15.4: Preview with --focus
+
+```bash
+ynd preview /tmp/ynh-tutorial/my-project -v claude --focus review
+```
+
+Expected: same as base preview — the `review` focus has no profile, so it uses the default configuration. The focus prompt is used by `ynh run`, not by `ynd preview`.
+
+## Clean up
+
+```bash
+rm -rf /tmp/ynh-tutorial
+```
+
+## What You Learned
+
+- `.harness.json` in a project root provides zero-install AI configuration
+- `ynd validate`, `ynd preview`, and `ynd diff` work with project directories containing `.harness.json`
+- `ynh run` auto-discovers `.harness.json` in the current working directory
+- `ynh run --harness-file <path>` points to a specific `.harness.json` file
+- The file format is identical to installed harnesses — same hooks, MCP servers, profiles, and focus entries
+
+## Next
+
+The project-local config pattern works well with focus entries (Tutorial 14) for CI automation:
+
+```json
+{
+  "default_vendor": "claude",
+  "focus": {
+    "review": { "prompt": "Review staged changes" },
+    "security": { "profile": "ci", "prompt": "Audit for vulnerabilities" }
+  }
+}
+```

--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -2,7 +2,7 @@
 
 Verification checklist for ynh and ynd. Each test references a tutorial step or is an edge case tested here.
 
-Run all 13 tutorials in sequence to cover the happy path. This file adds edge cases and error handling tests that tutorials don't cover, plus a reference table for tracking.
+Run all 15 tutorials in sequence to cover the happy path. This file adds edge cases and error handling tests that tutorials don't cover, plus a reference table for tracking.
 
 ---
 
@@ -378,6 +378,44 @@ ynh info
 # Expected: Error: usage: ynh info <harness-name>
 ```
 
+### E19: Focus and profile mutual exclusivity
+
+```bash
+ynd preview /tmp/some-harness -v claude --focus review --profile ci
+# Expected: Error: cannot use --focus and --profile together
+```
+
+### E20: Unknown focus name
+
+```bash
+ynd preview /tmp/some-harness -v claude --focus nonexistent
+# Expected: Error: focus "nonexistent" not defined in harness
+```
+
+### E21: Focus with missing prompt in .harness.json
+
+```bash
+mkdir -p /tmp/ynh-bad-focus
+cat > /tmp/ynh-bad-focus/.harness.json << 'EOF'
+{"name":"bad","version":"0.1.0","focus":{"review":{"profile":"ci"}}}
+EOF
+ynd validate /tmp/ynh-bad-focus
+# Expected: INVALID with "focus.review: prompt must not be empty"
+rm -rf /tmp/ynh-bad-focus
+```
+
+### E22: Focus referencing unknown profile
+
+```bash
+mkdir -p /tmp/ynh-bad-focus
+cat > /tmp/ynh-bad-focus/.harness.json << 'EOF'
+{"name":"bad","version":"0.1.0","focus":{"review":{"profile":"nonexistent","prompt":"Review code"}}}
+EOF
+ynd validate /tmp/ynh-bad-focus
+# Expected: INVALID with "focus.review: references unknown profile"
+rm -rf /tmp/ynh-bad-focus
+```
+
 ---
 
 ## Summary
@@ -397,5 +435,7 @@ ynh info
 | Tutorial 11: MCP Servers | 6 |
 | Tutorial 12: Developer Preview | 5 |
 | Tutorial 13: Profiles | 8 |
-| Edge Cases | 18 |
-| **Total** | **124** |
+| Tutorial 14: Focus | 7 |
+| Tutorial 15: Project-Local Config | 4 |
+| Edge Cases | 22 |
+| **Total** | **139** |


### PR DESCRIPTION
## Summary
- **Tutorial 14 (Focus)**: Declaring focus entries, `--focus` flag, `YNH_FOCUS` env var, mutual exclusivity errors, `ynh info` display
- **Tutorial 15 (Project-Local Config)**: `.harness.json` in project root, zero-install workflow, validate/preview
- **Manual test plan**: Add E19-E22 (focus mutual exclusivity, unknown focus, missing prompt, unknown profile ref)
- **Bug fix**: `validateHarnessProfiles` now skips null MCP server entries (was rejecting valid `null` removal syntax)
- **Evals command**: Updated to cover tutorials 01-15

## Test plan
- [x] `make check` passes
- [x] Evals: Tutorial 14 PASS (7/7 steps), Tutorial 15 PASS (4/4 steps), E19-E22 PASS
- [x] Gate 3: manual spot-check via eval agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)