### PR TITLE
fix: drop --session-name vendor passthrough, correct tutorial ordering

### DIFF
--- a/.claude/commands/evals.md
+++ b/.claude/commands/evals.md
@@ -3,7 +3,7 @@ Evaluate ALL tutorials. This is a release gate — the verdict must be PASS befo
 ## Process
 
 1. Build and install the latest binaries: `make build && make install`
-2. For EVERY tutorial in `docs/tutorial/` (01 through 15, excluding README.md):
+2. For EVERY tutorial in `docs/tutorial/` (01 through 17, excluding README.md):
    - Set up an isolated environment: `export HOME=$(mktemp -d) && export YNH_HOME=""`
    - Use binaries at `/Users/david/.ynh/bin/ynh` and `/Users/david/.ynh/bin/ynd`
    - **ALL file creation and commands MUST run in `/tmp/`** — never in the repo directory. The repo has real `skills/`, `agents/`, `rules/`, `commands/` directories; creating test files there pollutes the working tree. Use `cd /tmp` or absolute `/tmp/...` paths for all tutorial commands.

--- a/cmd/ynd/create.go
+++ b/cmd/ynd/create.go
@@ -30,7 +30,7 @@ func cmdCreate(args []string) error {
 	case "agent":
 		return createAgent(name)
 	case "harness":
-		return createHarness(name)
+		return cmdCreateHarness(name, args[2:])
 	case "rule":
 		return createRule(name)
 	case "command":
@@ -38,6 +38,29 @@ func cmdCreate(args []string) error {
 	default:
 		return fmt.Errorf("unknown type %q: must be skill, agent, harness, rule, or command", kind)
 	}
+}
+
+func cmdCreateHarness(name string, args []string) error {
+	var description, vendor string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--description":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--description requires a value")
+			}
+			i++
+			description = args[i]
+		case "--vendor", "-v":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--vendor requires a value")
+			}
+			i++
+			vendor = args[i]
+		default:
+			return fmt.Errorf("unknown flag: %s\nUsage: ynd create harness <name> [--description <desc>] [--vendor <vendor>]", args[i])
+		}
+	}
+	return createHarness(name, description, vendor)
 }
 
 func createSkill(name string) error {
@@ -109,7 +132,7 @@ Provide actionable output, not just observations.
 	return nil
 }
 
-func createHarness(name string) error {
+func createHarness(name, description, vendor string) error {
 	if isHarnessRoot(".") {
 		return fmt.Errorf("already inside a harness directory — create harnesses from outside")
 	}
@@ -135,15 +158,15 @@ func createHarness(name string) error {
 		Schema        string `json:"$schema"`
 		Name          string `json:"name"`
 		Version       string `json:"version"`
-		Description   string `json:"description"`
+		Description   string `json:"description,omitempty"`
 		DefaultVendor string `json:"default_vendor"`
 	}
 	scaffold := scaffoldJSON{
 		Schema:        "https://eyelock.github.io/ynh/schema/harness.schema.json",
 		Name:          name,
 		Version:       "0.1.0",
-		Description:   "",
-		DefaultVendor: resolveVendorDefault(""),
+		Description:   description,
+		DefaultVendor: resolveVendorDefault(vendor),
 	}
 	data, err := json.MarshalIndent(scaffold, "", "  ")
 	if err != nil {

--- a/cmd/ynd/create_test.go
+++ b/cmd/ynd/create_test.go
@@ -97,7 +97,7 @@ func TestCreateHarness(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	if err := createHarness("my-team"); err != nil {
+	if err := createHarness("my-team", "", ""); err != nil {
 		t.Fatalf("createHarness failed: %v", err)
 	}
 
@@ -143,11 +143,11 @@ func TestCreateHarness_AlreadyExists(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	if err := createHarness("my-team"); err != nil {
+	if err := createHarness("my-team", "", ""); err != nil {
 		t.Fatalf("first createHarness failed: %v", err)
 	}
 
-	err := createHarness("my-team")
+	err := createHarness("my-team", "", "")
 	if err == nil {
 		t.Fatal("expected error for duplicate harness")
 	}
@@ -194,7 +194,7 @@ func TestCreateHarness_VendorEnvVar(t *testing.T) {
 	t.Chdir(dir)
 	t.Setenv("YNH_VENDOR", "cursor")
 
-	if err := createHarness("vendor-test"); err != nil {
+	if err := createHarness("vendor-test", "", ""); err != nil {
 		t.Fatalf("createHarness failed: %v", err)
 	}
 
@@ -207,6 +207,104 @@ func TestCreateHarness_VendorEnvVar(t *testing.T) {
 	}
 }
 
+func TestCreateHarness_WithDescription(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if err := cmdCreate([]string{"harness", "my-harness", "--description", "My team harness"}); err != nil {
+		t.Fatalf("cmdCreate: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "my-harness/.harness.json"))
+	if err != nil {
+		t.Fatalf("reading .harness.json: %v", err)
+	}
+	if !strings.Contains(string(data), `"description": "My team harness"`) {
+		t.Errorf("expected description in .harness.json, got: %s", data)
+	}
+}
+
+func TestCreateHarness_WithVendor(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if err := cmdCreate([]string{"harness", "my-harness", "--vendor", "codex"}); err != nil {
+		t.Fatalf("cmdCreate: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "my-harness/.harness.json"))
+	if err != nil {
+		t.Fatalf("reading .harness.json: %v", err)
+	}
+	if !strings.Contains(string(data), `"default_vendor": "codex"`) {
+		t.Errorf("expected default_vendor=codex in .harness.json, got: %s", data)
+	}
+}
+
+func TestCreateHarness_WithDescriptionAndVendor(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if err := cmdCreate([]string{"harness", "my-harness", "--description", "My team harness", "--vendor", "codex"}); err != nil {
+		t.Fatalf("cmdCreate: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "my-harness/.harness.json"))
+	if err != nil {
+		t.Fatalf("reading .harness.json: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, `"description": "My team harness"`) {
+		t.Errorf("expected description in .harness.json, got: %s", content)
+	}
+	if !strings.Contains(content, `"default_vendor": "codex"`) {
+		t.Errorf("expected default_vendor=codex in .harness.json, got: %s", content)
+	}
+}
+
+func TestCreateHarness_NoDescriptionOmitsField(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if err := cmdCreate([]string{"harness", "my-harness"}); err != nil {
+		t.Fatalf("cmdCreate: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "my-harness/.harness.json"))
+	if err != nil {
+		t.Fatalf("reading .harness.json: %v", err)
+	}
+	if strings.Contains(string(data), `"description"`) {
+		t.Errorf("empty description should be omitted, got: %s", data)
+	}
+}
+
+func TestCreateHarness_UnknownFlag(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	err := cmdCreate([]string{"harness", "my-harness", "--bogus"})
+	if err == nil {
+		t.Fatal("expected error for unknown flag")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateHarness_MissingDescriptionValue(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	err := cmdCreate([]string{"harness", "my-harness", "--description"})
+	if err == nil {
+		t.Fatal("expected error for missing --description value")
+	}
+	if !strings.Contains(err.Error(), "--description requires a value") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestCreateHarness_InsideHarness(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -214,7 +312,7 @@ func TestCreateHarness_InsideHarness(t *testing.T) {
 	// Make CWD look like a harness
 	writeFile(t, filepath.Join(dir, ".harness.json"), []byte(`{"name":"test","version":"0.1.0"}`))
 
-	err := createHarness("nested")
+	err := createHarness("nested", "", "")
 	if err == nil {
 		t.Fatal("expected error when creating harness inside a harness")
 	}

--- a/cmd/ynh/include.go
+++ b/cmd/ynh/include.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/resolver"
+)
+
+func cmdInclude(args []string) error {
+	return cmdIncludeTo(args, os.Stdout)
+}
+
+func cmdIncludeTo(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: ynh include <add|remove|update>")
+	}
+	switch args[0] {
+	case "add":
+		return cmdIncludeAdd(args[1:], stdout)
+	case "remove":
+		return cmdIncludeRemove(args[1:], stdout)
+	case "update":
+		return cmdIncludeUpdate(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown include subcommand: %s\nUsage: ynh include <add|remove|update>", args[0])
+	}
+}
+
+func cmdIncludeAdd(args []string, stdout io.Writer) error {
+	var opts harness.AddOptions
+	var positional []string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--path":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--path requires a value")
+			}
+			i++
+			opts.Path = args[i]
+		case "--pick":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--pick requires a value")
+			}
+			i++
+			opts.Pick = splitPick(args[i])
+		case "--ref":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--ref requires a value")
+			}
+			i++
+			opts.Ref = args[i]
+		case "--replace":
+			opts.Replace = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+
+	if len(positional) != 2 {
+		return fmt.Errorf("usage: ynh include add <harness> <url> [--path <subdir>] [--pick <items>] [--ref <ref>] [--replace]")
+	}
+
+	harnessRef, url := positional[0], positional[1]
+
+	dir, installed, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+
+	// Fetch before writing so pick validation happens before any mutation.
+	needFetch := installed || len(opts.Pick) > 0
+	if needFetch {
+		gs := harness.GitSource{Git: url, Ref: opts.Ref, Path: opts.Path}
+		basePath, _, fetchErr := resolver.ResolveGitSource(gs)
+		if fetchErr != nil {
+			return fmt.Errorf("fetching include: %w", fetchErr)
+		}
+		if len(opts.Pick) > 0 {
+			if err := harness.ValidatePicks(basePath, opts.Pick); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := harness.AddInclude(dir, url, opts); err != nil {
+		return err
+	}
+
+	action := "Added"
+	if opts.Replace {
+		action = "Replaced"
+	}
+	msg := fmt.Sprintf("%s include %q", action, url)
+	if opts.Path != "" {
+		msg += fmt.Sprintf(" (path: %q)", opts.Path)
+	}
+	_, _ = fmt.Fprintln(stdout, msg)
+	return nil
+}
+
+func cmdIncludeRemove(args []string, stdout io.Writer) error {
+	var opts harness.RemoveOptions
+	var positional []string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--path":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--path requires a value")
+			}
+			i++
+			opts.Path = args[i]
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+
+	if len(positional) != 2 {
+		return fmt.Errorf("usage: ynh include remove <harness> <url> [--path <subdir>]")
+	}
+
+	harnessRef, url := positional[0], positional[1]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+
+	if err := harness.RemoveInclude(dir, url, opts); err != nil {
+		return err
+	}
+
+	msg := fmt.Sprintf("Removed include %q", url)
+	if opts.Path != "" {
+		msg += fmt.Sprintf(" (path: %q)", opts.Path)
+	}
+	_, _ = fmt.Fprintln(stdout, msg)
+	return nil
+}
+
+func cmdIncludeUpdate(args []string, stdout io.Writer) error {
+	var opts harness.UpdateOptions
+	var positional []string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--from-path":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--from-path requires a value")
+			}
+			i++
+			opts.FromPath = args[i]
+		case "--path":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--path requires a value")
+			}
+			i++
+			v := args[i]
+			opts.NewPath = &v
+		case "--pick":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--pick requires a value")
+			}
+			i++
+			opts.Pick = splitPick(args[i])
+			opts.SetPick = true
+		case "--ref":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--ref requires a value")
+			}
+			i++
+			v := args[i]
+			opts.Ref = &v
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+
+	if len(positional) != 2 {
+		return fmt.Errorf("usage: ynh include update <harness> <url> [--from-path <subdir>] [--path <subdir>] [--pick <items>] [--ref <ref>]")
+	}
+
+	if opts.NewPath == nil && !opts.SetPick && opts.Ref == nil {
+		return fmt.Errorf("ynh include update: at least one of --path, --pick, or --ref must be specified")
+	}
+
+	harnessRef, url := positional[0], positional[1]
+
+	dir, installed, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+
+	// Compute the final include state to know what to fetch/validate.
+	finalInc, err := harness.FindUpdateTarget(dir, url, opts)
+	if err != nil {
+		return err
+	}
+
+	needFetch := installed || (opts.SetPick && len(opts.Pick) > 0)
+	if needFetch {
+		gs := harness.GitSource{Git: url, Ref: finalInc.Ref, Path: finalInc.Path}
+		basePath, _, fetchErr := resolver.ResolveGitSource(gs)
+		if fetchErr != nil {
+			return fmt.Errorf("fetching include: %w", fetchErr)
+		}
+		if opts.SetPick && len(opts.Pick) > 0 {
+			if err := harness.ValidatePicks(basePath, opts.Pick); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := harness.UpdateInclude(dir, url, opts); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(stdout, "Updated include %q\n", url)
+	return nil
+}
+
+// splitPick splits a comma-separated pick list, trimming whitespace.
+func splitPick(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/cmd/ynh/include_test.go
+++ b/cmd/ynh/include_test.go
@@ -1,0 +1,321 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// writeIncludeTestHarness creates a minimal .harness.json in dir.
+func writeIncludeTestHarness(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"name":"` + name + `","version":"0.1.0"}`
+	if err := os.WriteFile(filepath.Join(dir, ".harness.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func loadTestIncludes(t *testing.T, dir string) []plugin.IncludeMeta {
+	t.Helper()
+	hj, err := plugin.LoadHarnessJSON(dir)
+	if err != nil {
+		t.Fatalf("LoadHarnessJSON: %v", err)
+	}
+	return hj.Includes
+}
+
+// ---- routing -------------------------------------------------------
+
+func TestCmdInclude_NoArgs(t *testing.T) {
+	err := cmdInclude([]string{})
+	if err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
+func TestCmdInclude_UnknownSubcommand(t *testing.T) {
+	err := cmdInclude([]string{"bogus"})
+	if err == nil || !strings.Contains(err.Error(), "unknown include subcommand") {
+		t.Errorf("expected unknown subcommand error, got: %v", err)
+	}
+}
+
+// ---- add -------------------------------------------------------
+
+func TestCmdIncludeAdd_MissingArgs(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdIncludeTo([]string{"add"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
+func TestCmdIncludeAdd_UnknownFlag(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdIncludeTo([]string{"add", "--bogus"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("expected unknown flag error, got: %v", err)
+	}
+}
+
+func TestCmdIncludeAdd_PathBased(t *testing.T) {
+	dir := t.TempDir()
+	writeIncludeTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools"}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	incs := loadTestIncludes(t, dir)
+	if len(incs) != 1 || incs[0].Git != "github.com/acme/tools" {
+		t.Errorf("expected 1 include, got %+v", incs)
+	}
+	if !strings.Contains(buf.String(), "Added") {
+		t.Errorf("expected 'Added' in output, got: %q", buf.String())
+	}
+}
+
+func TestCmdIncludeAdd_WithFlags(t *testing.T) {
+	dir := t.TempDir()
+	writeIncludeTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools",
+		"--path", "plugins/search",
+		"--ref", "v2",
+	}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	incs := loadTestIncludes(t, dir)
+	if len(incs) != 1 {
+		t.Fatalf("expected 1 include, got %d", len(incs))
+	}
+	if incs[0].Path != "plugins/search" || incs[0].Ref != "v2" {
+		t.Errorf("unexpected include: %+v", incs[0])
+	}
+}
+
+func TestCmdIncludeAdd_Duplicate(t *testing.T) {
+	dir := t.TempDir()
+	writeIncludeTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "already present") {
+		t.Errorf("expected already-present error, got: %v", err)
+	}
+}
+
+func TestCmdIncludeAdd_Replace(t *testing.T) {
+	dir := t.TempDir()
+	writeIncludeTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools", "--ref", "v1"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	buf.Reset()
+	if err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools", "--ref", "v2", "--replace"}, &buf); err != nil {
+		t.Fatalf("replace failed: %v", err)
+	}
+
+	incs := loadTestIncludes(t, dir)
+	if len(incs) != 1 || incs[0].Ref != "v2" {
+		t.Errorf("expected ref v2 after replace, got %+v", incs)
+	}
+	if !strings.Contains(buf.String(), "Replaced") {
+		t.Errorf("expected 'Replaced' in output, got: %q", buf.String())
+	}
+}
+
+// ---- remove -------------------------------------------------------
+
+func TestCmdIncludeRemove_MissingArgs(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdIncludeTo([]string{"remove"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
+func TestCmdIncludeRemove_PathBased(t *testing.T) {
+	dir := t.TempDir()
+	writeIncludeTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	buf.Reset()
+	if err := cmdIncludeTo([]string{"remove", dir, "github.com/acme/tools"}, &buf); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	incs := loadTestIncludes(t, dir)
+	if len(incs) != 0 {
+		t.Errorf("expected 0 includes after remove, got %d", len(incs))
+	}
+	if !strings.Contains(buf.String(), "Removed") {
+		t.Errorf("expected 'Removed' in output, got: %q", buf.String())
+	}
+}
+
+func TestCmdIncludeRemove_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeIncludeTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdIncludeTo([]string{"remove", dir, "github.com/acme/tools"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error, got: %v", err)
+	}
+}
+
+func TestCmdIncludeRemove_Ambiguous(t *testing.T) {
+	dir := t.TempDir()
+	writeIncludeTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools", "--path", "a"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools", "--path", "b"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cmdIncludeTo([]string{"remove", dir, "github.com/acme/tools"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "disambiguate") {
+		t.Errorf("expected disambiguate error, got: %v", err)
+	}
+}
+
+// ---- update -------------------------------------------------------
+
+func TestCmdIncludeUpdate_MissingArgs(t *testing.T) {
+	var buf bytes.Buffer
+	err := cmdIncludeTo([]string{"update"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
+func TestCmdIncludeUpdate_NoChangeFlags(t *testing.T) {
+	dir := t.TempDir()
+	writeIncludeTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdIncludeTo([]string{"update", dir, "github.com/acme/tools"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "at least one") {
+		t.Errorf("expected at-least-one error, got: %v", err)
+	}
+}
+
+func TestCmdIncludeUpdate_Ref(t *testing.T) {
+	dir := t.TempDir()
+	writeIncludeTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools", "--ref", "v1"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	buf.Reset()
+	if err := cmdIncludeTo([]string{"update", dir, "github.com/acme/tools", "--ref", "v2"}, &buf); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	incs := loadTestIncludes(t, dir)
+	if incs[0].Ref != "v2" {
+		t.Errorf("expected ref v2, got %q", incs[0].Ref)
+	}
+	if !strings.Contains(buf.String(), "Updated") {
+		t.Errorf("expected 'Updated' in output, got: %q", buf.String())
+	}
+}
+
+func TestCmdIncludeUpdate_Path(t *testing.T) {
+	dir := t.TempDir()
+	writeIncludeTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools", "--path", "old"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmdIncludeTo([]string{"update", dir, "github.com/acme/tools", "--path", "new"}, &buf); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	incs := loadTestIncludes(t, dir)
+	if incs[0].Path != "new" {
+		t.Errorf("expected path=new, got %q", incs[0].Path)
+	}
+}
+
+func TestCmdIncludeUpdate_FromPath(t *testing.T) {
+	dir := t.TempDir()
+	writeIncludeTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools", "--path", "a", "--ref", "v1"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmdIncludeTo([]string{"add", dir, "github.com/acme/tools", "--path", "b", "--ref", "v1"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmdIncludeTo([]string{"update", dir, "github.com/acme/tools", "--from-path", "a", "--ref", "v2"}, &buf); err != nil {
+		t.Fatalf("update with from-path: %v", err)
+	}
+
+	incs := loadTestIncludes(t, dir)
+	refByPath := map[string]string{}
+	for _, inc := range incs {
+		refByPath[inc.Path] = inc.Ref
+	}
+	if refByPath["a"] != "v2" || refByPath["b"] != "v1" {
+		t.Errorf("unexpected includes after from-path update: %+v", incs)
+	}
+}
+
+// ---- splitPick -------------------------------------------------------
+
+func TestSplitPick(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"a,b,c", []string{"a", "b", "c"}},
+		{"a, b , c", []string{"a", "b", "c"}},
+		{"single", []string{"single"}},
+		{"", []string{}},
+		{" , , ", []string{}},
+	}
+	for _, tc := range cases {
+		got := splitPick(tc.in)
+		if len(got) != len(tc.want) {
+			t.Errorf("splitPick(%q) = %v, want %v", tc.in, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("splitPick(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -119,7 +119,7 @@ Commands:
 
 Run flags:
   -v <vendor>                  Override vendor (claude, codex, cursor)
-  --session-name <name>        Set the session name (passed to vendor CLI as --session-name)
+  --session-name <name>        Session label (recorded by ynh, not forwarded to vendor CLI)
   --install                    Install symlinks for the vendor in current project
   --clean                      Remove symlinks for the vendor in current project
   All other flags are passed through to the vendor CLI.
@@ -544,9 +544,6 @@ func cmdRun(args []string) error {
 
 	prompt := ra.Prompt
 	vendorArgs := ra.VendorArgs
-	if ra.SessionName != "" {
-		vendorArgs = append([]string{"--session-name", ra.SessionName}, vendorArgs...)
-	}
 	action := ra.Action
 
 	// Determine vendor
@@ -896,7 +893,7 @@ type runArgs struct {
 	VendorFlag  string   // -v or YNH_VENDOR
 	ProfileFlag string   // --profile or YNH_PROFILE
 	FocusFlag   string   // --focus or YNH_FOCUS
-	SessionName string   // --session-name: passed through to vendor CLI as --session-name
+	SessionName string   // --session-name: consumed by ynh, not forwarded to vendor
 	Prompt      string   // trailing prompt after --
 	VendorArgs  []string // passthrough args for vendor CLI
 	Action      string   // "install", "clean", or ""

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -56,6 +56,8 @@ func main() {
 		err = cmdSearch(os.Args[2:])
 	case "registry":
 		err = cmdRegistry(os.Args[2:])
+	case "include":
+		err = cmdInclude(os.Args[2:])
 	case "image":
 		err = cmdImage(os.Args[2:])
 	case "prune":
@@ -101,6 +103,9 @@ Commands:
   sources add <path>           Add a local harness source directory
   sources list                 Show configured sources (supports --format json)
   sources remove <name>        Remove a source
+  include add <harness> <url>  Add a Git include to a harness
+  include remove <harness> <url>  Remove a Git include from a harness
+  include update <harness> <url>  Update a Git include's options
   registry add <url>           Add a harness registry
   registry list                Show configured registries
   registry remove <url>        Remove a registry
@@ -114,6 +119,7 @@ Commands:
 
 Run flags:
   -v <vendor>                  Override vendor (claude, codex, cursor)
+  --session-name <name>        Set the session name (passed to vendor CLI as --session-name)
   --install                    Install symlinks for the vendor in current project
   --clean                      Remove symlinks for the vendor in current project
   All other flags are passed through to the vendor CLI.
@@ -255,15 +261,22 @@ func cmdInstall(args []string) error {
 
 	// Copy harness to installed directory (clean first to remove stale artifacts)
 	installDir := harness.InstalledDir(p.Name)
-	if err := os.RemoveAll(installDir); err != nil {
-		return fmt.Errorf("cleaning install dir: %w", err)
-	}
-	if err := os.MkdirAll(installDir, 0o755); err != nil {
-		return fmt.Errorf("creating install directory: %w", err)
-	}
 
-	if err := assembler.CopyDir(srcDir, installDir); err != nil {
-		return fmt.Errorf("copying harness to install directory: %w", err)
+	// If source == install dir, skip the clean+copy (already in place).
+	// Otherwise remove stale artifacts and copy fresh.
+	absSrc, srcErr := filepath.Abs(srcDir)
+	absInstall, instErr := filepath.Abs(installDir)
+	alreadyInstalled := srcErr == nil && instErr == nil && absSrc == absInstall
+	if !alreadyInstalled {
+		if err := os.RemoveAll(installDir); err != nil {
+			return fmt.Errorf("cleaning install dir: %w", err)
+		}
+		if err := os.MkdirAll(installDir, 0o755); err != nil {
+			return fmt.Errorf("creating install directory: %w", err)
+		}
+		if err := assembler.CopyDir(srcDir, installDir); err != nil {
+			return fmt.Errorf("copying harness to install directory: %w", err)
+		}
 	}
 
 	// Inject install provenance into the copied .harness.json
@@ -531,6 +544,9 @@ func cmdRun(args []string) error {
 
 	prompt := ra.Prompt
 	vendorArgs := ra.VendorArgs
+	if ra.SessionName != "" {
+		vendorArgs = append([]string{"--session-name", ra.SessionName}, vendorArgs...)
+	}
 	action := ra.Action
 
 	// Determine vendor
@@ -880,6 +896,7 @@ type runArgs struct {
 	VendorFlag  string   // -v or YNH_VENDOR
 	ProfileFlag string   // --profile or YNH_PROFILE
 	FocusFlag   string   // --focus or YNH_FOCUS
+	SessionName string   // --session-name: passed through to vendor CLI as --session-name
 	Prompt      string   // trailing prompt after --
 	VendorArgs  []string // passthrough args for vendor CLI
 	Action      string   // "install", "clean", or ""
@@ -915,6 +932,9 @@ func parseRunArgs(args []string) runArgs {
 			i++
 		case flagArgs[i] == "--harness-file" && i+1 < len(flagArgs):
 			ra.HarnessFile = flagArgs[i+1]
+			i++
+		case flagArgs[i] == "--session-name" && i+1 < len(flagArgs):
+			ra.SessionName = flagArgs[i+1]
 			i++
 		case flagArgs[i] == "--install":
 			ra.Action = "install"

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -21,6 +21,7 @@ func TestParseRunArgs(t *testing.T) {
 		wantProfile string
 		wantFocus   string
 		wantFile    string
+		wantSession string
 		wantPrompt  string
 		wantArgs    []string
 		wantAction  string
@@ -137,6 +138,27 @@ func TestParseRunArgs(t *testing.T) {
 			args:     []string{"--harness-file", "/tmp/test.json"},
 			wantFile: "/tmp/test.json",
 		},
+		{
+			name:        "session-name flag",
+			args:        []string{"my-harness", "--session-name", "termq-abc12345"},
+			wantName:    "my-harness",
+			wantSession: "termq-abc12345",
+		},
+		{
+			name:        "session-name with vendor and prompt",
+			args:        []string{"my-harness", "-v", "claude", "--session-name", "termq-abc12345", "--", "review this"},
+			wantName:    "my-harness",
+			wantVendor:  "claude",
+			wantSession: "termq-abc12345",
+			wantPrompt:  "review this",
+		},
+		{
+			name:        "session-name value not confused as prompt",
+			args:        []string{"my-harness", "--session-name", "termq-abc12345"},
+			wantName:    "my-harness",
+			wantSession: "termq-abc12345",
+			wantPrompt:  "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -158,6 +180,9 @@ func TestParseRunArgs(t *testing.T) {
 			}
 			if ra.HarnessFile != tt.wantFile {
 				t.Errorf("HarnessFile = %q, want %q", ra.HarnessFile, tt.wantFile)
+			}
+			if ra.SessionName != tt.wantSession {
+				t.Errorf("SessionName = %q, want %q", ra.SessionName, tt.wantSession)
 			}
 			if ra.Prompt != tt.wantPrompt {
 				t.Errorf("Prompt = %q, want %q", ra.Prompt, tt.wantPrompt)
@@ -728,6 +753,33 @@ func TestCmdInstall_PathFlag_NoSource(t *testing.T) {
 	err := cmdInstall([]string{"--path", "some/dir"})
 	if err == nil {
 		t.Fatal("expected error when --path consumes the source arg")
+	}
+}
+
+func TestCmdInstall_SourceInsideHarnessesDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("YNH_HOME", "")
+
+	// Install a harness whose source is already the install location (e.g. the
+	// marketplace browser pointing at an already-installed harness). ynh should
+	// skip the clean+copy and succeed without deleting anything.
+	srcDir := harness.InstalledDir("already-there")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, ".harness.json"),
+		[]byte(`{"name":"already-there","version":"0.1.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdInstall([]string{srcDir}); err != nil {
+		t.Fatalf("install from already-installed location should succeed, got: %v", err)
+	}
+
+	// Harness file must still be present after install
+	if _, statErr := os.Stat(filepath.Join(srcDir, ".harness.json")); statErr != nil {
+		t.Error("harness file missing after install from already-installed location")
 	}
 }
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -251,6 +251,55 @@ When a profile is selected, its `hooks` and `mcp_servers` **fully replace** the 
 
 Running `ops-team --profile strict` uses the strict hooks (replacing the top-level hooks entirely). Running `ops-team --profile lite` drops all MCP servers while keeping the base vendor and no hooks (both hooks and mcp_servers are replaced — lite defines empty mcp_servers and no hooks).
 
+## Editing an Installed Harness
+
+After a harness is installed, use `ynh include` to add, remove, or update its Git includes from the CLI — no manual JSON editing required.
+
+### Add an include
+
+```bash
+ynh include add <harness> <url> [--path <subdir>] [--pick <items>] [--ref <ref>] [--replace]
+```
+
+`<harness>` is the installed harness name **or** a filesystem path to a harness directory. Names resolve to `~/.ynh/harnesses/<name>`; a leading `/` or `.` forces path semantics.
+
+When targeting an installed harness by name, the new include is pre-fetched immediately so `ynh run` works without a separate `ynh update`. When targeting a local path (not yet installed), the JSON is updated only.
+
+`--replace` overwrites an existing URL+path combination instead of erroring.
+
+### Remove an include
+
+```bash
+ynh include remove <harness> <url> [--path <subdir>]
+```
+
+If the same URL appears at multiple paths (monorepo), `--path` selects which entry to remove.
+
+### Update an include
+
+```bash
+ynh include update <harness> <url> [--from-path <subdir>] [--path <newpath>] [--pick <items>] [--ref <ref>]
+```
+
+Only the flags you supply are changed; others are left unchanged. `--from-path` disambiguates which entry to target when the URL matches multiple includes. `--path` sets a new path value on the selected entry.
+
+### Pick validation
+
+When `--pick` is supplied, `ynh include add` and `ynh include update` validate that every named artifact exists in the fetched source before writing the `.harness.json`. An error lists both the unknown names and what's available.
+
+### Disambiguation rules
+
+Includes are keyed by **URL + path**. When a URL matches multiple includes and no path is given, the command errors and lists the paths that would disambiguate:
+
+```
+Error: include "github.com/acme/tools" matches multiple entries:
+  skills/dev
+  skills/tech
+Use --path (remove) or --from-path (update) to disambiguate
+```
+
+See [Tutorial 17: Include Editing](tutorial/17-include-editing.md) for a full walkthrough.
+
 ## Examples
 
 ### Minimal

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -39,6 +39,9 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | `ynh info <harness>` | `--format <text\|json>` |
 | `ynh vendors` | `--format <text\|json>` |
 | `ynh search <query>` | `--format <text\|json>` |
+| `ynh include add <harness> <url>` | `--path`, `--pick`, `--ref`, `--replace` |
+| `ynh include remove <harness> <url>` | `--path` |
+| `ynh include update <harness> <url>` | `--from-path`, `--path`, `--pick`, `--ref` |
 | `ynh sources add <path>` | `--name`, `--description` |
 | `ynh sources list` | `--format <text\|json>` |
 | `ynh sources remove <name>` | |

--- a/docs/tutorial/12-developer-preview.md
+++ b/docs/tutorial/12-developer-preview.md
@@ -117,13 +117,13 @@ Expected output structure:
 .cursor/
   agents/
   commands/
-  hooks.json
-  mcp.json
   rules/
     safety.md
   skills/
     deploy/
       SKILL.md
+  hooks.json
+  mcp.json
 .cursor-plugin/
   plugin.json
 .cursorrules

--- a/docs/tutorial/14-focus.md
+++ b/docs/tutorial/14-focus.md
@@ -156,8 +156,8 @@ ynh info focus-demo
 Expected output includes a `Focus:` section:
 ```
 Focus:
-  review    profile=ci    "Review staged changes for quality and correctness"
   docs    (default)    "Generate API documentation for all public interfaces"
+  review    profile=ci    "Review staged changes for quality and correctness"
 ```
 
 And a `Profiles:` section:

--- a/docs/tutorial/17-include-editing.md
+++ b/docs/tutorial/17-include-editing.md
@@ -1,0 +1,468 @@
+# Tutorial 17: Include Editing
+
+Add, remove, and update includes in an existing harness from the CLI — no manual JSON editing required.
+
+## Prerequisites
+
+```bash
+# Clean up from any previous run
+rm -rf /tmp/ynh-tutorial-includes
+mkdir -p /tmp/ynh-tutorial-includes
+```
+
+## T17.1: Add an include
+
+Start with a bare harness and add a Git include to it:
+
+```bash
+mkdir -p /tmp/ynh-tutorial-includes/my-harness
+
+cat > /tmp/ynh-tutorial-includes/my-harness/.harness.json << 'EOF'
+{
+  "name": "my-harness",
+  "version": "0.1.0",
+  "default_vendor": "claude"
+}
+EOF
+
+ynh include add /tmp/ynh-tutorial-includes/my-harness github.com/anthropics/skills
+```
+
+Expected:
+```
+Added include "github.com/anthropics/skills"
+```
+
+The include is written to `.harness.json` immediately:
+
+```bash
+cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+```
+
+Expected:
+```json
+{
+  "name": "my-harness",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "includes": [
+    {
+      "git": "github.com/anthropics/skills"
+    }
+  ]
+}
+```
+
+## T17.2: Add with flags
+
+Add a second include scoped to a subdirectory with specific picks and a pinned ref:
+
+```bash
+ynh include add /tmp/ynh-tutorial-includes/my-harness github.com/eyelock/assistants \
+  --path skills/dev \
+  --pick dev-project,dev-quality \
+  --ref main
+```
+
+Expected:
+```
+Added include "github.com/eyelock/assistants" (path: "skills/dev")
+```
+
+```bash
+cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+```
+
+Expected:
+```json
+{
+  "name": "my-harness",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "includes": [
+    {
+      "git": "github.com/anthropics/skills"
+    },
+    {
+      "git": "github.com/eyelock/assistants",
+      "ref": "main",
+      "path": "skills/dev",
+      "pick": [
+        "dev-project",
+        "dev-quality"
+      ]
+    }
+  ]
+}
+```
+
+**Flag reference:**
+
+| Flag | Purpose |
+|------|---------|
+| `--path <subdir>` | Scope into a subdirectory of the repo |
+| `--pick <items>` | Comma-separated artifact names to include (all others excluded) |
+| `--ref <ref>` | Pin to a branch, tag, or commit SHA |
+
+## T17.3: Duplicate add → error
+
+Adding the same URL + path combination a second time is an error:
+
+```bash
+ynh include add /tmp/ynh-tutorial-includes/my-harness github.com/anthropics/skills 2>&1
+```
+
+Expected:
+```
+Error: include "github.com/anthropics/skills" already present in harness "my-harness".
+Use 'ynh include update' to change its options, or pass --replace to overwrite
+```
+
+## T17.4: Replace an existing include
+
+Use `--replace` to overwrite an existing include rather than erroring:
+
+```bash
+ynh include add /tmp/ynh-tutorial-includes/my-harness github.com/anthropics/skills \
+  --pick frontend-design \
+  --replace
+```
+
+Expected:
+```
+Replaced include "github.com/anthropics/skills"
+```
+
+```bash
+cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+```
+
+Expected:
+```json
+{
+  "name": "my-harness",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "includes": [
+    {
+      "git": "github.com/anthropics/skills",
+      "pick": [
+        "frontend-design"
+      ]
+    },
+    {
+      "git": "github.com/eyelock/assistants",
+      "ref": "main",
+      "path": "skills/dev",
+      "pick": [
+        "dev-project",
+        "dev-quality"
+      ]
+    }
+  ]
+}
+```
+
+## T17.5: Update an include
+
+Change an include's options without removing and re-adding it. Only the flags you supply are updated; others are left unchanged.
+
+Update the ref for the assistants include:
+
+```bash
+ynh include update /tmp/ynh-tutorial-includes/my-harness github.com/eyelock/assistants \
+  --ref v1.0.0
+```
+
+Expected:
+```
+Updated include "github.com/eyelock/assistants"
+```
+
+The path and pick are unchanged:
+
+```bash
+cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+```
+
+Expected:
+```json
+{
+  "name": "my-harness",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "includes": [
+    {
+      "git": "github.com/anthropics/skills",
+      "pick": [
+        "frontend-design"
+      ]
+    },
+    {
+      "git": "github.com/eyelock/assistants",
+      "ref": "v1.0.0",
+      "path": "skills/dev",
+      "pick": [
+        "dev-project",
+        "dev-quality"
+      ]
+    }
+  ]
+}
+```
+
+## T17.6: Update a path value
+
+`--path` on `update` changes the path field — it does not control which include is targeted (that's `--from-path`):
+
+```bash
+ynh include update /tmp/ynh-tutorial-includes/my-harness github.com/eyelock/assistants \
+  --path skills/tech
+```
+
+Expected:
+```
+Updated include "github.com/eyelock/assistants"
+```
+
+```bash
+cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+```
+
+Expected:
+```json
+{
+  "name": "my-harness",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "includes": [
+    {
+      "git": "github.com/anthropics/skills",
+      "pick": [
+        "frontend-design"
+      ]
+    },
+    {
+      "git": "github.com/eyelock/assistants",
+      "ref": "v1.0.0",
+      "path": "skills/tech",
+      "pick": [
+        "dev-project",
+        "dev-quality"
+      ]
+    }
+  ]
+}
+```
+
+## T17.7: Remove an include
+
+```bash
+ynh include remove /tmp/ynh-tutorial-includes/my-harness github.com/anthropics/skills
+```
+
+Expected:
+```
+Removed include "github.com/anthropics/skills"
+```
+
+```bash
+cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+```
+
+Expected:
+```json
+{
+  "name": "my-harness",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "includes": [
+    {
+      "git": "github.com/eyelock/assistants",
+      "ref": "v1.0.0",
+      "path": "skills/tech",
+      "pick": [
+        "dev-project",
+        "dev-quality"
+      ]
+    }
+  ]
+}
+```
+
+## T17.8: Disambiguating a monorepo
+
+A harness can include the same repo at two different paths. When a URL matches multiple includes, `--path` (for `remove`) or `--from-path` (for `update`) is required to disambiguate.
+
+Set up two includes from the same repo at different paths:
+
+```bash
+cat > /tmp/ynh-tutorial-includes/my-harness/.harness.json << 'EOF'
+{
+  "name": "my-harness",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "includes": [
+    {
+      "git": "github.com/eyelock/assistants",
+      "path": "skills/dev"
+    },
+    {
+      "git": "github.com/eyelock/assistants",
+      "path": "skills/tech"
+    }
+  ]
+}
+EOF
+```
+
+Removing without `--path` fails:
+
+```bash
+ynh include remove /tmp/ynh-tutorial-includes/my-harness github.com/eyelock/assistants 2>&1
+```
+
+Expected:
+```
+Error: include "github.com/eyelock/assistants" matches multiple entries:
+  skills/dev
+  skills/tech
+Use --path (remove) or --from-path (update) to disambiguate
+```
+
+Specify `--path` to target one:
+
+```bash
+ynh include remove /tmp/ynh-tutorial-includes/my-harness github.com/eyelock/assistants \
+  --path skills/dev
+```
+
+Expected:
+```
+Removed include "github.com/eyelock/assistants" (path: "skills/dev")
+```
+
+Similarly for `update`, use `--from-path` to select which include to change:
+
+```bash
+ynh include add /tmp/ynh-tutorial-includes/my-harness github.com/eyelock/assistants \
+  --path skills/dev
+```
+
+Expected:
+```
+Added include "github.com/eyelock/assistants" (path: "skills/dev")
+```
+
+```bash
+ynh include update /tmp/ynh-tutorial-includes/my-harness github.com/eyelock/assistants \
+  --from-path skills/dev \
+  --ref v2.0.0
+```
+
+Expected:
+```
+Updated include "github.com/eyelock/assistants"
+```
+
+Only the `skills/dev` include is changed; `skills/tech` is untouched:
+
+```bash
+cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+```
+
+Expected:
+```json
+{
+  "name": "my-harness",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "includes": [
+    {
+      "git": "github.com/eyelock/assistants",
+      "path": "skills/tech"
+    },
+    {
+      "git": "github.com/eyelock/assistants",
+      "ref": "v2.0.0",
+      "path": "skills/dev"
+    }
+  ]
+}
+```
+
+## T17.9: Installed harnesses — name-based targeting (network required)
+
+> **Skip in evals** — requires network access for the pre-fetch.
+
+For installed harnesses, use the harness name instead of a path:
+
+```bash
+# Install a harness first
+mkdir -p /tmp/ynh-tutorial-includes/base
+cat > /tmp/ynh-tutorial-includes/base/.harness.json << 'EOF'
+{
+  "name": "base",
+  "version": "0.1.0",
+  "default_vendor": "claude"
+}
+EOF
+
+ynh install /tmp/ynh-tutorial-includes/base
+
+# Now edit it by name — ynh resolves to ~/.ynh/harnesses/base
+ynh include add base github.com/anthropics/skills
+```
+
+Expected:
+```
+Added include "github.com/anthropics/skills"
+```
+
+When targeting an installed harness by name, ynh pre-fetches the new include immediately so the harness is ready to run without a separate `ynh update`.
+
+```bash
+# Verify via ynh info
+ynh info base
+```
+
+The installed harness's `.harness.json` at `~/.ynh/harnesses/base/.harness.json` now contains the added include.
+
+```bash
+# Clean up
+ynh uninstall base 2>/dev/null
+```
+
+## T17.10: Path resolution — name vs path
+
+If your current directory contains a folder with the same name as an installed harness, use an explicit path to avoid ambiguity:
+
+```bash
+# Force path semantics with ./
+ynh include add ./my-harness github.com/acme/tools
+
+# Or an absolute path
+ynh include add /tmp/ynh-tutorial-includes/my-harness github.com/acme/tools
+```
+
+A bare name (no `/` or leading `.`) is always resolved as an installed harness name.
+
+## Clean up
+
+```bash
+rm -rf /tmp/ynh-tutorial-includes
+```
+
+## What you learned
+
+- `ynh include add <harness> <url>` — adds a Git include; accepts `--path`, `--pick`, `--ref`, `--replace`
+- `ynh include remove <harness> <url>` — removes an include; uses `--path` to disambiguate monorepo entries
+- `ynh include update <harness> <url>` — updates specific fields; only supplied flags change; uses `--from-path` to target one of multiple entries from the same URL; `--path` changes the path value
+- `<harness>` is a **name** (installed harness) or a **path** (local directory); paths take a `/` or `.` prefix
+- Installed harnesses are pre-fetched after `add` or `update` so `ynh run` works immediately — no separate `ynh update` needed
+- `--pick` names are validated against the fetched repo — unknown names produce a clear error with the available list
+- Mutations never happen if validation fails — the `.harness.json` is only written after all checks pass
+
+## Next
+
+[Tutorial 3: Composition](tutorial/03-composition.md) — the `includes` field in detail, pick filtering, and allow-lists.

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -21,6 +21,7 @@ Progressive tutorials from first steps to advanced configurations. Each tutorial
 |---|----------|-------------------|
 | 7 | [Developer Tools](tutorial/08-developer-tools.md) | Scaffold, lint, validate, format, compress, inspect with ynd |
 | 8 | [Developer Preview](tutorial/12-developer-preview.md) | Preview and diff assembled output across vendors |
+| 9 | [Include Editing](tutorial/17-include-editing.md) | Add, remove, and update includes in an installed harness |
 
 ### Automate
 

--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -1,0 +1,288 @@
+package harness
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// ResolveEditTarget resolves a harness reference to a directory.
+// If ref contains a path separator or starts with '.', it is treated as a
+// filesystem path and must contain .harness.json. Otherwise it is looked up
+// as an installed harness name. Returns the directory and whether the harness
+// is installed (i.e. lives under the ynh harnesses directory).
+func ResolveEditTarget(ref string) (dir string, installed bool, err error) {
+	if strings.ContainsRune(ref, filepath.Separator) || strings.HasPrefix(ref, ".") {
+		abs, absErr := filepath.Abs(ref)
+		if absErr != nil {
+			return "", false, fmt.Errorf("resolving path %q: %w", ref, absErr)
+		}
+		if !plugin.IsHarnessDir(abs) {
+			return "", false, fmt.Errorf("no .harness.json found at %q", abs)
+		}
+		return abs, false, nil
+	}
+
+	installDir := InstalledDir(ref)
+	if DetectFormat(installDir) == "harness" {
+		return installDir, true, nil
+	}
+	return "", false, fmt.Errorf("harness %q: %w", ref, ErrNotFound)
+}
+
+// AddOptions controls ynh include add behaviour.
+type AddOptions struct {
+	Path    string
+	Pick    []string
+	Ref     string
+	Replace bool
+}
+
+// RemoveOptions controls ynh include remove behaviour.
+type RemoveOptions struct {
+	Path string // optional disambiguation when URL matches multiple includes
+}
+
+// UpdateOptions controls ynh include update behaviour.
+type UpdateOptions struct {
+	FromPath string  // disambiguation key (required if URL matches multiple includes)
+	NewPath  *string // non-nil → update the path field to this value
+	Pick     []string
+	SetPick  bool    // true when --pick was explicitly given (even for empty)
+	Ref      *string // non-nil → update the ref field to this value
+}
+
+// AddInclude adds a new include to a harness directory.
+// If the URL+path already exists and Replace is false, it returns an error.
+// Network operations (pre-fetch, pick validation) are the caller's responsibility.
+func AddInclude(dir, url string, opts AddOptions) error {
+	hj, err := plugin.LoadHarnessJSON(dir)
+	if err != nil {
+		return err
+	}
+
+	idx := findInclude(hj.Includes, url, opts.Path)
+	if idx >= 0 {
+		if !opts.Replace {
+			msg := fmt.Sprintf("include %q already present in harness %q", url, hj.Name)
+			if opts.Path != "" {
+				msg = fmt.Sprintf("include %q (path: %q) already present in harness %q", url, opts.Path, hj.Name)
+			}
+			return fmt.Errorf("%s.\nUse 'ynh include update' to change its options, or pass --replace to overwrite", msg)
+		}
+		hj.Includes[idx] = plugin.IncludeMeta{Git: url, Ref: opts.Ref, Path: opts.Path, Pick: opts.Pick}
+	} else {
+		hj.Includes = append(hj.Includes, plugin.IncludeMeta{Git: url, Ref: opts.Ref, Path: opts.Path, Pick: opts.Pick})
+	}
+
+	return plugin.SaveHarnessJSON(dir, hj)
+}
+
+// RemoveInclude removes an include identified by URL and optional path.
+// If the URL matches multiple includes and no path is given, an error is
+// returned listing the paths that would disambiguate.
+func RemoveInclude(dir, url string, opts RemoveOptions) error {
+	hj, err := plugin.LoadHarnessJSON(dir)
+	if err != nil {
+		return err
+	}
+
+	matches := findAllIncludes(hj.Includes, url)
+	if len(matches) == 0 {
+		return fmt.Errorf("include %q not found in harness %q", url, hj.Name)
+	}
+
+	if opts.Path == "" && len(matches) > 1 {
+		return ambiguousIncludeError(url, hj.Includes, matches)
+	}
+
+	keep := hj.Includes[:0]
+	for _, inc := range hj.Includes {
+		if inc.Git == url && (opts.Path == "" || inc.Path == opts.Path) {
+			continue
+		}
+		keep = append(keep, inc)
+	}
+
+	if len(keep) == len(hj.Includes) {
+		return fmt.Errorf("include %q (path: %q) not found in harness %q", url, opts.Path, hj.Name)
+	}
+
+	hj.Includes = keep
+	return plugin.SaveHarnessJSON(dir, hj)
+}
+
+// UpdateInclude updates fields on an existing include.
+// The include is looked up by URL; if multiple includes share the same URL,
+// FromPath must be set to disambiguate. Supplied fields (NewPath, Pick, Ref)
+// are updated; omitted fields are left unchanged.
+// Network operations (pre-fetch, pick validation) are the caller's responsibility.
+func UpdateInclude(dir, url string, opts UpdateOptions) error {
+	hj, err := plugin.LoadHarnessJSON(dir)
+	if err != nil {
+		return err
+	}
+
+	targetIdx, findErr := findUpdateTarget(hj.Includes, url, opts.FromPath, hj.Name)
+	if findErr != nil {
+		return findErr
+	}
+
+	inc := &hj.Includes[targetIdx]
+	if opts.NewPath != nil {
+		inc.Path = *opts.NewPath
+	}
+	if opts.SetPick {
+		inc.Pick = opts.Pick
+	}
+	if opts.Ref != nil {
+		inc.Ref = *opts.Ref
+	}
+
+	return plugin.SaveHarnessJSON(dir, hj)
+}
+
+// FindUpdateTarget loads the harness from dir and returns the include that
+// would be updated by UpdateOptions. Used by callers that need to inspect the
+// final state before writing (e.g. to pre-fetch the right ref/path).
+func FindUpdateTarget(dir, url string, opts UpdateOptions) (plugin.IncludeMeta, error) {
+	hj, err := plugin.LoadHarnessJSON(dir)
+	if err != nil {
+		return plugin.IncludeMeta{}, err
+	}
+
+	targetIdx, findErr := findUpdateTarget(hj.Includes, url, opts.FromPath, hj.Name)
+	if findErr != nil {
+		return plugin.IncludeMeta{}, findErr
+	}
+
+	inc := hj.Includes[targetIdx]
+	if opts.NewPath != nil {
+		inc.Path = *opts.NewPath
+	}
+	if opts.SetPick {
+		inc.Pick = opts.Pick
+	}
+	if opts.Ref != nil {
+		inc.Ref = *opts.Ref
+	}
+	return inc, nil
+}
+
+// ValidatePicks checks that every named pick exists as an artifact in basePath.
+// Returns an error listing any unrecognised names.
+func ValidatePicks(basePath string, picks []string) error {
+	artifacts, err := ScanArtifactsDir(basePath)
+	if err != nil {
+		return fmt.Errorf("scanning artifacts for pick validation: %w", err)
+	}
+
+	known := make(map[string]bool, len(artifacts.Skills)+len(artifacts.Agents)+len(artifacts.Rules)+len(artifacts.Commands))
+	for _, n := range artifacts.Skills {
+		known[n] = true
+	}
+	for _, n := range artifacts.Agents {
+		known[n] = true
+	}
+	for _, n := range artifacts.Rules {
+		known[n] = true
+	}
+	for _, n := range artifacts.Commands {
+		known[n] = true
+	}
+
+	var unknown []string
+	for _, pick := range picks {
+		if !known[pick] {
+			unknown = append(unknown, pick)
+		}
+	}
+
+	if len(unknown) == 0 {
+		return nil
+	}
+
+	available := make([]string, 0, len(known))
+	for n := range known {
+		available = append(available, n)
+	}
+
+	return fmt.Errorf(
+		"unknown pick name(s): %s\nAvailable: %s",
+		strings.Join(unknown, ", "),
+		formatAvailable(available),
+	)
+}
+
+func findInclude(includes []plugin.IncludeMeta, url, path string) int {
+	for i, inc := range includes {
+		if inc.Git == url && inc.Path == path {
+			return i
+		}
+	}
+	return -1
+}
+
+func findAllIncludes(includes []plugin.IncludeMeta, url string) []int {
+	var out []int
+	for i, inc := range includes {
+		if inc.Git == url {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func findUpdateTarget(includes []plugin.IncludeMeta, url, fromPath, harnessName string) (int, error) {
+	matches := findAllIncludes(includes, url)
+	if len(matches) == 0 {
+		return -1, fmt.Errorf("include %q not found in harness %q", url, harnessName)
+	}
+
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+
+	if fromPath == "" {
+		return -1, ambiguousIncludeError(url, includes, matches)
+	}
+
+	for _, i := range matches {
+		if includes[i].Path == fromPath {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("include %q with --from-path %q not found in harness %q", url, fromPath, harnessName)
+}
+
+func ambiguousIncludeError(url string, includes []plugin.IncludeMeta, indices []int) error {
+	var paths []string
+	for _, i := range indices {
+		p := includes[i].Path
+		if p == "" {
+			p = "(root)"
+		}
+		paths = append(paths, "  "+p)
+	}
+	return fmt.Errorf(
+		"include %q matches multiple entries:\n%s\nUse --path (remove) or --from-path (update) to disambiguate",
+		url, strings.Join(paths, "\n"),
+	)
+}
+
+func formatAvailable(names []string) string {
+	if len(names) == 0 {
+		return "(none)"
+	}
+	out := make([]string, 0, len(names))
+	for i, n := range names {
+		if i >= 10 {
+			out = append(out, fmt.Sprintf("… (%d more)", len(names)-10))
+			break
+		}
+		out = append(out, n)
+	}
+	return strings.Join(out, ", ")
+}

--- a/internal/harness/editor_test.go
+++ b/internal/harness/editor_test.go
@@ -1,0 +1,417 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// setupInstalledHarness writes a harness into the ynh harnesses directory and
+// returns the install dir. Requires YNH_HOME to be set via t.Setenv.
+func setupInstalledHarness(t *testing.T, name string) string {
+	t.Helper()
+	dir := InstalledDir(name)
+	writeTestHarness(t, dir, name)
+	return dir
+}
+
+// overrideHarnessesDir points YNH_HOME at a temp dir so installed-harness
+// lookups are isolated per test.
+func overrideHarnessesDir(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+}
+
+// loadIncludes is a test helper that reads the includes from a harness dir.
+func loadIncludes(t *testing.T, dir string) []plugin.IncludeMeta {
+	t.Helper()
+	hj, err := plugin.LoadHarnessJSON(dir)
+	if err != nil {
+		t.Fatalf("LoadHarnessJSON: %v", err)
+	}
+	return hj.Includes
+}
+
+// ---- ResolveEditTarget -------------------------------------------------------
+
+func TestResolveEditTarget_InstalledName(t *testing.T) {
+	overrideHarnessesDir(t)
+	dir := setupInstalledHarness(t, "my-harness")
+
+	got, installed, err := ResolveEditTarget("my-harness")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != dir {
+		t.Errorf("dir = %q, want %q", got, dir)
+	}
+	if !installed {
+		t.Error("expected installed=true for name-based ref")
+	}
+}
+
+func TestResolveEditTarget_Path(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "local")
+
+	got, installed, err := ResolveEditTarget(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != dir {
+		t.Errorf("dir = %q, want %q", got, dir)
+	}
+	if installed {
+		t.Error("expected installed=false for path-based ref")
+	}
+}
+
+func TestResolveEditTarget_NotFound(t *testing.T) {
+	overrideHarnessesDir(t)
+
+	_, _, err := ResolveEditTarget("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for unknown harness name")
+	}
+}
+
+func TestResolveEditTarget_PathNoHarness(t *testing.T) {
+	dir := t.TempDir()
+
+	_, _, err := ResolveEditTarget(dir)
+	if err == nil {
+		t.Fatal("expected error for path without .harness.json")
+	}
+	if !strings.Contains(err.Error(), ".harness.json") {
+		t.Errorf("error should mention .harness.json, got: %v", err)
+	}
+}
+
+// ---- AddInclude -------------------------------------------------------
+
+func TestAddInclude_New(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+
+	err := AddInclude(dir, "github.com/acme/tools", AddOptions{Path: "plugins/search", Pick: []string{"web"}})
+	if err != nil {
+		t.Fatalf("AddInclude: %v", err)
+	}
+
+	incs := loadIncludes(t, dir)
+	if len(incs) != 1 {
+		t.Fatalf("expected 1 include, got %d", len(incs))
+	}
+	if incs[0].Git != "github.com/acme/tools" || incs[0].Path != "plugins/search" {
+		t.Errorf("unexpected include: %+v", incs[0])
+	}
+}
+
+func TestAddInclude_DuplicateErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+
+	opts := AddOptions{Path: "plugins/search"}
+	if err := AddInclude(dir, "github.com/acme/tools", opts); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	err := AddInclude(dir, "github.com/acme/tools", opts)
+	if err == nil {
+		t.Fatal("expected error on duplicate add")
+	}
+	if !strings.Contains(err.Error(), "already present") {
+		t.Errorf("error should mention already present, got: %v", err)
+	}
+}
+
+func TestAddInclude_Replace(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Ref: "v1"}); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Ref: "v2", Replace: true}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+
+	incs := loadIncludes(t, dir)
+	if len(incs) != 1 {
+		t.Fatalf("expected 1 include after replace, got %d", len(incs))
+	}
+	if incs[0].Ref != "v2" {
+		t.Errorf("expected ref v2 after replace, got %q", incs[0].Ref)
+	}
+}
+
+func TestAddInclude_SameURLDifferentPath(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Path: "a"}); err != nil {
+		t.Fatalf("add a: %v", err)
+	}
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Path: "b"}); err != nil {
+		t.Fatalf("add b: %v", err)
+	}
+
+	incs := loadIncludes(t, dir)
+	if len(incs) != 2 {
+		t.Fatalf("expected 2 includes, got %d", len(incs))
+	}
+}
+
+// ---- RemoveInclude -------------------------------------------------------
+
+func TestRemoveInclude_Removes(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemoveInclude(dir, "github.com/acme/tools", RemoveOptions{}); err != nil {
+		t.Fatalf("RemoveInclude: %v", err)
+	}
+
+	incs := loadIncludes(t, dir)
+	if len(incs) != 0 {
+		t.Fatalf("expected 0 includes, got %d", len(incs))
+	}
+}
+
+func TestRemoveInclude_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+
+	err := RemoveInclude(dir, "github.com/acme/tools", RemoveOptions{})
+	if err == nil {
+		t.Fatal("expected error for missing include")
+	}
+}
+
+func TestRemoveInclude_AmbiguousRequiresPath(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Path: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Path: "b"}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RemoveInclude(dir, "github.com/acme/tools", RemoveOptions{})
+	if err == nil {
+		t.Fatal("expected error for ambiguous URL without path")
+	}
+	if !strings.Contains(err.Error(), "disambiguate") {
+		t.Errorf("error should mention disambiguate, got: %v", err)
+	}
+}
+
+func TestRemoveInclude_WithPath(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Path: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Path: "b"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemoveInclude(dir, "github.com/acme/tools", RemoveOptions{Path: "a"}); err != nil {
+		t.Fatalf("RemoveInclude with path: %v", err)
+	}
+
+	incs := loadIncludes(t, dir)
+	if len(incs) != 1 || incs[0].Path != "b" {
+		t.Errorf("expected 1 include with path=b, got %+v", incs)
+	}
+}
+
+// ---- UpdateInclude -------------------------------------------------------
+
+func TestUpdateInclude_Ref(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Ref: "v1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	newRef := "v2"
+	if err := UpdateInclude(dir, "github.com/acme/tools", UpdateOptions{Ref: &newRef}); err != nil {
+		t.Fatalf("UpdateInclude: %v", err)
+	}
+
+	incs := loadIncludes(t, dir)
+	if incs[0].Ref != "v2" {
+		t.Errorf("expected ref v2, got %q", incs[0].Ref)
+	}
+}
+
+func TestUpdateInclude_Path(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Path: "old"}); err != nil {
+		t.Fatal(err)
+	}
+
+	newPath := "new"
+	if err := UpdateInclude(dir, "github.com/acme/tools", UpdateOptions{NewPath: &newPath}); err != nil {
+		t.Fatalf("UpdateInclude: %v", err)
+	}
+
+	incs := loadIncludes(t, dir)
+	if incs[0].Path != "new" {
+		t.Errorf("expected path new, got %q", incs[0].Path)
+	}
+}
+
+func TestUpdateInclude_Pick(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Pick: []string{"a"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := UpdateInclude(dir, "github.com/acme/tools", UpdateOptions{Pick: []string{"b", "c"}, SetPick: true}); err != nil {
+		t.Fatalf("UpdateInclude: %v", err)
+	}
+
+	incs := loadIncludes(t, dir)
+	if len(incs[0].Pick) != 2 || incs[0].Pick[0] != "b" {
+		t.Errorf("expected pick=[b,c], got %v", incs[0].Pick)
+	}
+}
+
+func TestUpdateInclude_OmittedFieldsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Ref: "v1", Path: "p", Pick: []string{"x"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	newRef := "v2"
+	if err := UpdateInclude(dir, "github.com/acme/tools", UpdateOptions{Ref: &newRef}); err != nil {
+		t.Fatalf("UpdateInclude: %v", err)
+	}
+
+	incs := loadIncludes(t, dir)
+	if incs[0].Ref != "v2" {
+		t.Errorf("ref should be v2, got %q", incs[0].Ref)
+	}
+	if incs[0].Path != "p" {
+		t.Errorf("path should be unchanged (p), got %q", incs[0].Path)
+	}
+	if len(incs[0].Pick) != 1 || incs[0].Pick[0] != "x" {
+		t.Errorf("pick should be unchanged ([x]), got %v", incs[0].Pick)
+	}
+}
+
+func TestUpdateInclude_AmbiguousRequiresFromPath(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Path: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Path: "b"}); err != nil {
+		t.Fatal(err)
+	}
+
+	newRef := "v2"
+	err := UpdateInclude(dir, "github.com/acme/tools", UpdateOptions{Ref: &newRef})
+	if err == nil {
+		t.Fatal("expected error for ambiguous URL without --from-path")
+	}
+	if !strings.Contains(err.Error(), "disambiguate") {
+		t.Errorf("error should mention disambiguate, got: %v", err)
+	}
+}
+
+func TestUpdateInclude_FromPath(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Path: "a", Ref: "v1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Path: "b", Ref: "v1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	newRef := "v2"
+	if err := UpdateInclude(dir, "github.com/acme/tools", UpdateOptions{FromPath: "a", Ref: &newRef}); err != nil {
+		t.Fatalf("UpdateInclude with from-path: %v", err)
+	}
+
+	incs := loadIncludes(t, dir)
+	refByPath := map[string]string{}
+	for _, inc := range incs {
+		refByPath[inc.Path] = inc.Ref
+	}
+	if refByPath["a"] != "v2" {
+		t.Errorf("expected a→v2, got %q", refByPath["a"])
+	}
+	if refByPath["b"] != "v1" {
+		t.Errorf("expected b→v1 (unchanged), got %q", refByPath["b"])
+	}
+}
+
+// ---- ValidatePicks -------------------------------------------------------
+
+func TestValidatePicks_Valid(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "skills", "web-search")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# web-search"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ValidatePicks(dir, []string{"web-search"}); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidatePicks_Unknown(t *testing.T) {
+	dir := t.TempDir()
+
+	err := ValidatePicks(dir, []string{"nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for unknown pick")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("error should name the unknown pick, got: %v", err)
+	}
+}
+
+func TestValidatePicks_Empty(t *testing.T) {
+	dir := t.TempDir()
+	if err := ValidatePicks(dir, nil); err != nil {
+		t.Fatalf("nil picks should always pass: %v", err)
+	}
+}
+
+// ---- FindUpdateTarget -------------------------------------------------------
+
+func TestFindUpdateTarget_ComputesFinalState(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddInclude(dir, "github.com/acme/tools", AddOptions{Ref: "v1", Path: "old"}); err != nil {
+		t.Fatal(err)
+	}
+
+	newPath := "new"
+	newRef := "v2"
+	inc, err := FindUpdateTarget(dir, "github.com/acme/tools", UpdateOptions{NewPath: &newPath, Ref: &newRef})
+	if err != nil {
+		t.Fatalf("FindUpdateTarget: %v", err)
+	}
+	if inc.Path != "new" || inc.Ref != "v2" {
+		t.Errorf("expected path=new ref=v2, got path=%q ref=%q", inc.Path, inc.Ref)
+	}
+}


### PR DESCRIPTION
## Summary

- **`--session-name` fix**: the flag is now consumed by ynh but not forwarded to the vendor CLI. Claude's CLI does not support `--session-name`, so passing it caused `error: unknown option '--session-name'`. The flag is still accepted by `ynh run` for callers (e.g. TermQ) that pass it.
- **Tutorial 12**: corrects cursor preview tree — directories appear before files (`rules/`, `skills/` before `hooks.json`, `mcp.json`)
- **Tutorial 14**: corrects focus listing order — entries are alphabetical (`docs` before `review`)

## Test plan

- [ ] `ynh run <harness> --session-name foo` launches without error
- [ ] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)