### PR TITLE
fix: drop --session-name vendor passthrough, correct tutorial ordering

### DIFF
--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -119,7 +119,7 @@ Commands:
 
 Run flags:
   -v <vendor>                  Override vendor (claude, codex, cursor)
-  --session-name <name>        Set the session name (passed to vendor CLI as --session-name)
+  --session-name <name>        Session label (recorded by ynh, not forwarded to vendor CLI)
   --install                    Install symlinks for the vendor in current project
   --clean                      Remove symlinks for the vendor in current project
   All other flags are passed through to the vendor CLI.
@@ -544,9 +544,6 @@ func cmdRun(args []string) error {
 
 	prompt := ra.Prompt
 	vendorArgs := ra.VendorArgs
-	if ra.SessionName != "" {
-		vendorArgs = append([]string{"--session-name", ra.SessionName}, vendorArgs...)
-	}
 	action := ra.Action
 
 	// Determine vendor
@@ -896,7 +893,7 @@ type runArgs struct {
 	VendorFlag  string   // -v or YNH_VENDOR
 	ProfileFlag string   // --profile or YNH_PROFILE
 	FocusFlag   string   // --focus or YNH_FOCUS
-	SessionName string   // --session-name: passed through to vendor CLI as --session-name
+	SessionName string   // --session-name: consumed by ynh, not forwarded to vendor
 	Prompt      string   // trailing prompt after --
 	VendorArgs  []string // passthrough args for vendor CLI
 	Action      string   // "install", "clean", or ""

--- a/docs/tutorial/12-developer-preview.md
+++ b/docs/tutorial/12-developer-preview.md
@@ -117,13 +117,13 @@ Expected output structure:
 .cursor/
   agents/
   commands/
-  hooks.json
-  mcp.json
   rules/
     safety.md
   skills/
     deploy/
       SKILL.md
+  hooks.json
+  mcp.json
 .cursor-plugin/
   plugin.json
 .cursorrules

--- a/docs/tutorial/14-focus.md
+++ b/docs/tutorial/14-focus.md
@@ -156,8 +156,8 @@ ynh info focus-demo
 Expected output includes a `Focus:` section:
 ```
 Focus:
-  review    profile=ci    "Review staged changes for quality and correctness"
   docs    (default)    "Generate API documentation for all public interfaces"
+  review    profile=ci    "Review staged changes for quality and correctness"
 ```
 
 And a `Profiles:` section:


### PR DESCRIPTION
## Summary

- **`--session-name` fix**: flag accepted by `ynh run` but not forwarded to the vendor CLI. Claude's CLI does not support `--session-name`, causing `error: unknown option '--session-name'`.
- **Tutorial 12**: corrects cursor preview tree — directories before files (`rules/`, `skills/` before `hooks.json`, `mcp.json`)
- **Tutorial 14**: corrects focus listing order — alphabetical (`docs` before `review`)

## Test plan

- [ ] `ynh run <harness> --session-name foo` launches without error
- [ ] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)