### PR TITLE
feat: ynh registry list --format json with name and description

### DIFF
--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -107,7 +107,7 @@ Commands:
   include remove <harness> <url>  Remove a Git include from a harness
   include update <harness> <url>  Update a Git include's options
   registry add <url>           Add a harness registry
-  registry list                Show configured registries
+  registry list                Show configured registries (supports --format json)
   registry remove <url>        Remove a registry
   registry update              Refresh all cached registries
   image <name> [flags]         Build a Docker image with a harness baked in

--- a/cmd/ynh/registry.go
+++ b/cmd/ynh/registry.go
@@ -58,8 +58,10 @@ func cmdRegistryAdd(args []string) error {
 }
 
 type registryListEntry struct {
-	URL string `json:"url"`
-	Ref string `json:"ref,omitempty"`
+	URL         string `json:"url"`
+	Ref         string `json:"ref,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 func cmdRegistryList(args []string) error {
@@ -84,7 +86,15 @@ func cmdRegistryList(args []string) error {
 	case "json":
 		entries := make([]registryListEntry, len(cfg.Registries))
 		for i, r := range cfg.Registries {
-			entries[i] = registryListEntry{URL: r.URL, Ref: r.Ref}
+			e := registryListEntry{URL: r.URL, Ref: r.Ref}
+			// Enrich with name/description from cached registry.json if available.
+			if result, resErr := resolver.EnsureRepo(r.URL, r.Ref); resErr == nil {
+				if reg, regErr := registry.LoadFromDir(result.Path); regErr == nil {
+					e.Name = reg.Name
+					e.Description = reg.Description
+				}
+			}
+			entries[i] = e
 		}
 		data, err := json.MarshalIndent(entries, "", "  ")
 		if err != nil {

--- a/cmd/ynh/registry.go
+++ b/cmd/ynh/registry.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/registry"
@@ -17,7 +19,7 @@ func cmdRegistry(args []string) error {
 	case "add":
 		return cmdRegistryAdd(args[1:])
 	case "list", "ls":
-		return cmdRegistryList()
+		return cmdRegistryList(args[1:])
 	case "remove", "rm":
 		return cmdRegistryRemove(args[1:])
 	case "update":
@@ -55,27 +57,58 @@ func cmdRegistryAdd(args []string) error {
 	return nil
 }
 
-func cmdRegistryList() error {
+type registryListEntry struct {
+	URL string `json:"url"`
+	Ref string `json:"ref,omitempty"`
+}
+
+func cmdRegistryList(args []string) error {
+	format := "text"
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--format":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--format requires a value")
+			}
+			i++
+			format = args[i]
+		}
+	}
+
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	if len(cfg.Registries) == 0 {
-		fmt.Println("No registries configured.")
-		fmt.Println("Add one with: ynh registry add <url>")
-		return nil
-	}
-
-	for _, r := range cfg.Registries {
-		if r.Ref != "" {
-			fmt.Printf("  %s (ref: %s)\n", r.URL, r.Ref)
-		} else {
-			fmt.Printf("  %s\n", r.URL)
+	switch format {
+	case "json":
+		entries := make([]registryListEntry, len(cfg.Registries))
+		for i, r := range cfg.Registries {
+			entries[i] = registryListEntry{URL: r.URL, Ref: r.Ref}
 		}
+		data, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encoding json: %w", err)
+		}
+		_, err = fmt.Fprintf(os.Stdout, "%s\n", data)
+		return err
+	case "text":
+		if len(cfg.Registries) == 0 {
+			fmt.Println("No registries configured.")
+			fmt.Println("Add one with: ynh registry add <url>")
+			return nil
+		}
+		for _, r := range cfg.Registries {
+			if r.Ref != "" {
+				fmt.Printf("  %s (ref: %s)\n", r.URL, r.Ref)
+			} else {
+				fmt.Printf("  %s\n", r.URL)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid --format value %q (want text or json)", format)
 	}
-
-	return nil
 }
 
 func cmdRegistryRemove(args []string) error {

--- a/cmd/ynh/registry_test.go
+++ b/cmd/ynh/registry_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"io"
 	"os"
 	"testing"
 
@@ -38,7 +40,7 @@ func TestCmdRegistryAddAndList(t *testing.T) {
 	}
 
 	// List should work
-	err = cmdRegistryList()
+	err = cmdRegistryList(nil)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -127,7 +129,7 @@ func TestCmdRegistryListEmpty(t *testing.T) {
 	}
 
 	// Should not error, just print message
-	err := cmdRegistryList()
+	err := cmdRegistryList(nil)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -158,5 +160,114 @@ func TestCmdRegistryUnknownSubcommand(t *testing.T) {
 	err := cmdRegistry([]string{"destroy"})
 	if err == nil {
 		t.Fatal("expected error for unknown subcommand")
+	}
+}
+
+func TestCmdRegistryListJSON(t *testing.T) {
+	t.Setenv("YNH_HOME", t.TempDir())
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		DefaultVendor: "claude",
+		Registries: []config.RegistrySource{
+			{URL: "github.com/org/registry-a"},
+			{URL: "github.com/org/registry-b", Ref: "v2"},
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture stdout
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+
+	err := cmdRegistryList([]string{"--format", "json"})
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("list --format json: %v", err)
+	}
+
+	out, err2 := io.ReadAll(r)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+
+	var got []registryListEntry
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid json: %v\noutput: %s", err, out)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got))
+	}
+	if got[0].URL != "github.com/org/registry-a" {
+		t.Errorf("entry 0 url = %q", got[0].URL)
+	}
+	if got[1].URL != "github.com/org/registry-b" || got[1].Ref != "v2" {
+		t.Errorf("entry 1 = %+v", got[1])
+	}
+}
+
+func TestCmdRegistryListJSONEmpty(t *testing.T) {
+	t.Setenv("YNH_HOME", t.TempDir())
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{DefaultVendor: "claude"}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+
+	err := cmdRegistryList([]string{"--format", "json"})
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("list --format json empty: %v", err)
+	}
+
+	out, err2 := io.ReadAll(r)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+
+	var got []registryListEntry
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty array, got %d entries", len(got))
+	}
+}
+
+func TestCmdRegistryListInvalidFormat(t *testing.T) {
+	t.Setenv("YNH_HOME", t.TempDir())
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{DefaultVendor: "claude"}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cmdRegistryList([]string{"--format", "yaml"})
+	if err == nil {
+		t.Fatal("expected error for invalid format")
 	}
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -45,7 +45,10 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | `ynh sources add <path>` | `--name`, `--description` |
 | `ynh sources list` | `--format <text\|json>` |
 | `ynh sources remove <name>` | |
-| `ynh registry <subcommand>` | |
+| `ynh registry add <url>` | |
+| `ynh registry list` | `--format <text\|json>` |
+| `ynh registry remove <url>` | |
+| `ynh registry update` | |
 | `ynh image <subcommand>` | |
 | `ynh paths` | `--format <text\|json>` |
 | `ynh status` | |


### PR DESCRIPTION
## Summary

Adds `--format json` to `ynh registry list`, consistent with all other list commands (`ynh ls`, `ynh sources list`, `ynh vendors`, `ynh search`, `ynh paths`).

Output includes `name` and `description` loaded from the registry's `registry.json` (when cached), alongside `url` and `ref`.

```json
[
  {
    "url": "github.com/eyelock/assistants",
    "name": "eyelock-assistants",
    "description": "Harnesses, plugins, and skills for development workflows, media management, and conversational alignment."
  }
]
```

`name` and `description` are omitted if the registry hasn't been fetched yet. `ref` is omitted when empty.

## Test plan

- [ ] `ynh registry list --format json` returns valid JSON with name/description when registry is cached
- [ ] `ynh registry list --format json` with no registries returns `[]`
- [ ] `ynh registry list --format invalid` errors
- [ ] `ynh registry list` (no flag) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)