### PR TITLE
ci: adopt Gitflow — develop/main model with branch protection

### DIFF
--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -1,0 +1,55 @@
+# Branching Model
+
+This project uses Gitflow. All feature and fix work targets `develop`. Only `develop` and `hotfix/*` branches may PR into `main`.
+
+## NEVER commit directly to `main` or `develop`
+
+Every change goes through a branch and PR — no exceptions.
+
+## Branch targets
+
+| Work type | Branch from | PR into |
+|-----------|-------------|---------|
+| Feature / fix / docs / ci | `develop` | `develop` |
+| Release promotion | `develop` | `main` |
+| Hotfix | release tag | `main` (forward-port to `develop` after) |
+
+## Branch naming
+
+Use hyphens, not slashes:
+
+```
+feat-<description>
+fix-<description>
+docs-<description>
+ci-<description>
+refactor-<description>
+test-<description>
+hotfix-<description>
+```
+
+## Workflow
+
+```bash
+# Start work
+git checkout develop
+git pull origin develop
+git checkout -b feat-my-thing
+
+# Before opening a PR — sync with develop
+git fetch origin develop
+git merge origin/develop
+git push
+
+# Merge (squash only)
+gh pr merge --squash
+```
+
+**Never use `gh pr merge --admin`** — it bypasses CI and is forbidden.
+
+## Post-merge cleanup
+
+```bash
+git branch -d <branch-name>
+git push origin --delete <branch-name>
+```

--- a/.claude/rules/pre-remote.md
+++ b/.claude/rules/pre-remote.md
@@ -1,5 +1,7 @@
 Before ANY remote operation (`git push`, `gh pr create`, `gh pr merge`), ALL of the following gates must pass. No exceptions. If blocked, stop and ask the user for help.
 
+**PR target:** feature and fix branches always PR into `develop`, not `main`. Only `develop` and `hotfix/*` may target `main`.
+
 ## Gate 1: make check
 
 Run `make check`. It must pass with zero issues. If it fails, fix the issue and re-run until green.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop, 'hotfix/*']
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -1,0 +1,24 @@
+name: Protect Main
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    name: Verify PR source branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that PR targets main only from develop or hotfix/*
+        run: |
+          SOURCE="${{ github.head_ref }}"
+          echo "PR source branch: $SOURCE"
+
+          if [[ "$SOURCE" == "develop" ]] || [[ "$SOURCE" == hotfix/* ]]; then
+            echo "✅ Source branch '$SOURCE' is allowed to target main"
+          else
+            echo "❌ PRs to main must come from 'develop' or 'hotfix/*'"
+            echo "   Source branch '$SOURCE' is not allowed."
+            echo "   Open your PR against 'develop' instead."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Expands `ci.yml` triggers to cover `develop` and `hotfix/*` branches and PRs
- Adds `protect-main.yml` to fail any PR to `main` not sourced from `develop` or `hotfix/*`
- Adds `.claude/rules/branching.md` with project-level Gitflow conventions for agents
- Updates `.claude/rules/pre-remote.md` to note that feature PRs target `develop`

## Post-merge steps

After this merges:
1. Create `develop` branch from `main`
2. In GitHub Settings → Branches, configure protection rules:
   - **`main`**: require PR, required checks: `All Clear` + `Verify PR source branch`, no force push
   - **`develop`**: require PR, required check: `All Clear`, no force push

## Test plan

- [ ] CI runs on PRs targeting `develop`
- [ ] PRs to `main` from a feature branch are blocked by `protect-main`
- [ ] PRs to `main` from `develop` pass `protect-main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)