### PR TITLE
fix: ynh search with no query arg lists all harnesses

### DIFF
--- a/cmd/ynh/search.go
+++ b/cmd/ynh/search.go
@@ -37,10 +37,6 @@ func cmdSearchTo(args []string, stdout, stderr io.Writer) error {
 		i++
 	}
 
-	if len(queryParts) == 0 {
-		return cliError(stderr, structured, errCodeInvalidInput, "usage: ynh search <term>")
-	}
-
 	query := strings.Join(queryParts, " ")
 
 	cfg, err := config.Load()
@@ -157,7 +153,11 @@ func matchesSourceQuery(h sources.DiscoveredHarness, query string) bool {
 
 func printSearchText(w io.Writer, query string, results []searchResultEntry) error {
 	if len(results) == 0 {
-		_, _ = fmt.Fprintf(w, "No results for %q\n", query)
+		if query == "" {
+			_, _ = fmt.Fprintln(w, "No harnesses found")
+		} else {
+			_, _ = fmt.Fprintf(w, "No results for %q\n", query)
+		}
 		return nil
 	}
 

--- a/cmd/ynh/search_test.go
+++ b/cmd/ynh/search_test.go
@@ -32,23 +32,72 @@ func TestCmdSearchNoRegistries(t *testing.T) {
 	}
 }
 
-func TestCmdSearchMissingArgs(t *testing.T) {
+func TestCmdSearch_NoQuery_ListsAll(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("YNH_HOME", "")
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := filepath.Join(home, "sources")
+	writeSourceHarness(t, filepath.Join(srcDir, "alice"), "alice")
+	writeSourceHarness(t, filepath.Join(srcDir, "bob"), "bob")
+
+	cfg := &config.Config{
+		DefaultVendor: "claude",
+		Sources:       []config.Source{{Name: "dev", Path: srcDir}},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
 	var stdout, stderr bytes.Buffer
 	err := cmdSearchTo([]string{}, &stdout, &stderr)
-	if err == nil {
-		t.Fatal("expected error for missing search term")
+	if err != nil {
+		t.Fatalf("no-query search should succeed: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "alice") {
+		t.Error("expected alice in no-query results")
+	}
+	if !strings.Contains(out, "bob") {
+		t.Error("expected bob in no-query results")
 	}
 }
 
-func TestCmdSearchMissingArgs_Structured(t *testing.T) {
+func TestCmdSearch_NoQuery_JSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("YNH_HOME", "")
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := filepath.Join(home, "sources")
+	writeSourceHarness(t, filepath.Join(srcDir, "alice"), "alice")
+	writeSourceHarness(t, filepath.Join(srcDir, "bob"), "bob")
+
+	cfg := &config.Config{
+		DefaultVendor: "claude",
+		Sources:       []config.Source{{Name: "dev", Path: srcDir}},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
 	var stdout, stderr bytes.Buffer
 	err := cmdSearchTo([]string{"--format", "json"}, &stdout, &stderr)
-	if err == nil {
-		t.Fatal("expected error for missing search term")
+	if err != nil {
+		t.Fatalf("no-query JSON search should succeed: %v", err)
 	}
-	// Should be a structured error
-	if !strings.Contains(stderr.String(), "invalid_input") {
-		t.Errorf("expected structured error, got stderr: %s", stderr.String())
+
+	var results []searchResultEntry
+	if err := json.Unmarshal(stdout.Bytes(), &results); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
 	}
 }
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -38,7 +38,7 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | `ynh ls` | `--format <text\|json>` |
 | `ynh info <harness>` | `--format <text\|json>` |
 | `ynh vendors` | `--format <text\|json>` |
-| `ynh search <query>` | `--format <text\|json>` |
+| `ynh search [query]` | `--format <text\|json>` |
 | `ynh include add <harness> <url>` | `--path`, `--pick`, `--ref`, `--replace` |
 | `ynh include remove <harness> <url>` | `--path` |
 | `ynh include update <harness> <url>` | `--from-path`, `--path`, `--pick`, `--ref` |
@@ -82,7 +82,7 @@ Commands that take `--format json` emit machine-readable output conforming to [S
 | `ynh info <name>` | Single harness object: `name`, `version`, `description`, `default_vendor`, `path`, `installed_from`, `manifest` (raw `.harness.json` body) |
 | `ynh ls` | Array of harness objects: `name`, `version`, `description`, `default_vendor`, `path`, `installed_from`, `artifacts`, `includes`, `delegates_to` |
 | `ynh paths` | `home`, `config`, `harnesses`, `symlinks`, `cache`, `run`, `bin` — all absolute paths resolved for the current `$YNH_HOME` |
-| `ynh search <term>` | Array of result objects: `name`, `description`, `keywords`, `repo`, `path`, `vendors`, `version`, `from` (`type`, `name`) |
+| `ynh search [query]` | Array of result objects: `name`, `description`, `keywords`, `repo`, `path`, `vendors`, `version`, `from` (`type`, `name`) |
 | `ynh vendors` | Array of vendor objects: `name`, `display_name`, `cli`, `config_dir`, `available` (bool) |
 | `ynh sources list` | Array of source objects: `name`, `path`, `description`, `harnesses` (discovery count) |
 

--- a/docs/tutorial/07-registry-and-discovery.md
+++ b/docs/tutorial/07-registry-and-discovery.md
@@ -121,6 +121,18 @@ ynh search "nonexistent"
 # Expected: No results for "nonexistent"
 ```
 
+Omit the query to list every harness across all registries and sources:
+
+```bash
+ynh search
+```
+
+```bash
+ynh search --format json
+```
+
+Expected: all three harnesses from `tutorial-registry` (david, planner, media-management) in the output.
+
 ## T7.5: Install — by exact name
 
 ```bash
@@ -251,7 +263,7 @@ ynh uninstall tester 2>/dev/null
 
 - A registry is a Git repo with `registry.json` listing available harnesses
 - `ynh registry add/list/remove/update` manages registry sources
-- `ynh search` does text matching on name, description, and keywords
+- `ynh search [query]` does text matching on name, description, and keywords; omit the query to list all
 - `ynh install <name>` resolves from registries (exact match installs, multiple matches prompt)
 - `name@registry` disambiguates across registries
 - Git URLs and local paths still work as before (higher precedence)


### PR DESCRIPTION
## Summary

- `ynh search` (no query) previously returned an error; now treats a missing query as "list all" — returning every harness from all registries and sources
- `ynh search --format json` likewise works without a query arg, returning `[]` when nothing is registered
- Removes the need for callers to pass an explicit empty string `""`

## Changes

- `cmd/ynh/search.go`: drop the guard that rejected empty `queryParts`; handle "no results" message for empty-query case
- `cmd/ynh/search_test.go`: replace the "missing args → error" tests with "no-query → list all" tests; add JSON variant
- `docs/reference.md`: `ynh search <query>` → `ynh search [query]` (optional)
- `docs/tutorial/07-registry-and-discovery.md`: add no-query examples; update "what you learned" bullet

## Test plan

- [x] `make check` passes (format, lint, test, build all green)
- [x] `ynh search` returns "No harnesses found" with exit 0 against empty config
- [x] `ynh search --format json` returns `[]` with exit 0 against empty config
- [x] Evals: PASS (17 tutorials, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)