### PR TITLE
release: promote develop to main (v0.0.18)

### DIFF
--- a/cmd/ynh/registry.go
+++ b/cmd/ynh/registry.go
@@ -152,6 +152,10 @@ func cmdRegistryRemove(args []string) error {
 		return fmt.Errorf("saving config: %w", err)
 	}
 
+	if err := resolver.PurgeCacheDirsForURL(url); err != nil {
+		return fmt.Errorf("purging registry cache: %w", err)
+	}
+
 	fmt.Printf("Removed registry: %s\n", url)
 	return nil
 }

--- a/cmd/ynh/registry_test.go
+++ b/cmd/ynh/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/eyelock/ynh/internal/config"
@@ -114,6 +115,41 @@ func TestCmdRegistryRemoveNotFound(t *testing.T) {
 	err := cmdRegistryRemove([]string{"github.com/test/nonexistent"})
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestCmdRegistryRemove_PurgesCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("YNH_HOME", "")
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		DefaultVendor: "claude",
+		Registries:    []config.RegistrySource{{URL: "github.com/myorg/myrepo"}},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-create fake cache dirs that would belong to this registry URL
+	cacheDir := config.CacheDir()
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cacheEntry := filepath.Join(cacheDir, "myorg--myrepo--aabb1122")
+	if err := os.MkdirAll(cacheEntry, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdRegistryRemove([]string{"github.com/myorg/myrepo"}); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	if _, err := os.Stat(cacheEntry); !os.IsNotExist(err) {
+		t.Error("registry remove should have deleted the cache directory")
 	}
 }
 

--- a/cmd/ynh/search.go
+++ b/cmd/ynh/search.go
@@ -37,10 +37,6 @@ func cmdSearchTo(args []string, stdout, stderr io.Writer) error {
 		i++
 	}
 
-	if len(queryParts) == 0 {
-		return cliError(stderr, structured, errCodeInvalidInput, "usage: ynh search <term>")
-	}
-
 	query := strings.Join(queryParts, " ")
 
 	cfg, err := config.Load()
@@ -157,7 +153,11 @@ func matchesSourceQuery(h sources.DiscoveredHarness, query string) bool {
 
 func printSearchText(w io.Writer, query string, results []searchResultEntry) error {
 	if len(results) == 0 {
-		_, _ = fmt.Fprintf(w, "No results for %q\n", query)
+		if query == "" {
+			_, _ = fmt.Fprintln(w, "No harnesses found")
+		} else {
+			_, _ = fmt.Fprintf(w, "No results for %q\n", query)
+		}
 		return nil
 	}
 

--- a/cmd/ynh/search_test.go
+++ b/cmd/ynh/search_test.go
@@ -32,23 +32,72 @@ func TestCmdSearchNoRegistries(t *testing.T) {
 	}
 }
 
-func TestCmdSearchMissingArgs(t *testing.T) {
+func TestCmdSearch_NoQuery_ListsAll(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("YNH_HOME", "")
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := filepath.Join(home, "sources")
+	writeSourceHarness(t, filepath.Join(srcDir, "alice"), "alice")
+	writeSourceHarness(t, filepath.Join(srcDir, "bob"), "bob")
+
+	cfg := &config.Config{
+		DefaultVendor: "claude",
+		Sources:       []config.Source{{Name: "dev", Path: srcDir}},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
 	var stdout, stderr bytes.Buffer
 	err := cmdSearchTo([]string{}, &stdout, &stderr)
-	if err == nil {
-		t.Fatal("expected error for missing search term")
+	if err != nil {
+		t.Fatalf("no-query search should succeed: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "alice") {
+		t.Error("expected alice in no-query results")
+	}
+	if !strings.Contains(out, "bob") {
+		t.Error("expected bob in no-query results")
 	}
 }
 
-func TestCmdSearchMissingArgs_Structured(t *testing.T) {
+func TestCmdSearch_NoQuery_JSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("YNH_HOME", "")
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := filepath.Join(home, "sources")
+	writeSourceHarness(t, filepath.Join(srcDir, "alice"), "alice")
+	writeSourceHarness(t, filepath.Join(srcDir, "bob"), "bob")
+
+	cfg := &config.Config{
+		DefaultVendor: "claude",
+		Sources:       []config.Source{{Name: "dev", Path: srcDir}},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
 	var stdout, stderr bytes.Buffer
 	err := cmdSearchTo([]string{"--format", "json"}, &stdout, &stderr)
-	if err == nil {
-		t.Fatal("expected error for missing search term")
+	if err != nil {
+		t.Fatalf("no-query JSON search should succeed: %v", err)
 	}
-	// Should be a structured error
-	if !strings.Contains(stderr.String(), "invalid_input") {
-		t.Errorf("expected structured error, got stderr: %s", stderr.String())
+
+	var results []searchResultEntry
+	if err := json.Unmarshal(stdout.Bytes(), &results); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
 	}
 }
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -38,7 +38,7 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | `ynh ls` | `--format <text\|json>` |
 | `ynh info <harness>` | `--format <text\|json>` |
 | `ynh vendors` | `--format <text\|json>` |
-| `ynh search <query>` | `--format <text\|json>` |
+| `ynh search [query]` | `--format <text\|json>` |
 | `ynh include add <harness> <url>` | `--path`, `--pick`, `--ref`, `--replace` |
 | `ynh include remove <harness> <url>` | `--path` |
 | `ynh include update <harness> <url>` | `--from-path`, `--path`, `--pick`, `--ref` |
@@ -82,7 +82,7 @@ Commands that take `--format json` emit machine-readable output conforming to [S
 | `ynh info <name>` | Single harness object: `name`, `version`, `description`, `default_vendor`, `path`, `installed_from`, `manifest` (raw `.harness.json` body) |
 | `ynh ls` | Array of harness objects: `name`, `version`, `description`, `default_vendor`, `path`, `installed_from`, `artifacts`, `includes`, `delegates_to` |
 | `ynh paths` | `home`, `config`, `harnesses`, `symlinks`, `cache`, `run`, `bin` — all absolute paths resolved for the current `$YNH_HOME` |
-| `ynh search <term>` | Array of result objects: `name`, `description`, `keywords`, `repo`, `path`, `vendors`, `version`, `from` (`type`, `name`) |
+| `ynh search [query]` | Array of result objects: `name`, `description`, `keywords`, `repo`, `path`, `vendors`, `version`, `from` (`type`, `name`) |
 | `ynh vendors` | Array of vendor objects: `name`, `display_name`, `cli`, `config_dir`, `available` (bool) |
 | `ynh sources list` | Array of source objects: `name`, `path`, `description`, `harnesses` (discovery count) |
 

--- a/docs/tutorial/07-registry-and-discovery.md
+++ b/docs/tutorial/07-registry-and-discovery.md
@@ -121,6 +121,18 @@ ynh search "nonexistent"
 # Expected: No results for "nonexistent"
 ```
 
+Omit the query to list every harness across all registries and sources:
+
+```bash
+ynh search
+```
+
+```bash
+ynh search --format json
+```
+
+Expected: all three harnesses from `tutorial-registry` (david, planner, media-management) in the output.
+
 ## T7.5: Install — by exact name
 
 ```bash
@@ -251,7 +263,7 @@ ynh uninstall tester 2>/dev/null
 
 - A registry is a Git repo with `registry.json` listing available harnesses
 - `ynh registry add/list/remove/update` manages registry sources
-- `ynh search` does text matching on name, description, and keywords
+- `ynh search [query]` does text matching on name, description, and keywords; omit the query to list all
 - `ynh install <name>` resolves from registries (exact match installs, multiple matches prompt)
 - `name@registry` disambiguates across registries
 - Git URLs and local paths still work as before (higher precedence)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -143,17 +143,60 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 	// Update existing clone — capture HEAD before and after
 	before := gitHead(repoDir)
 
+	var fetchErr error
 	if ref != "" {
-		if err := gitCmd("-C", repoDir, "fetch", "--depth", "1", "origin", ref); err != nil {
-			return RepoResult{}, fmt.Errorf("git fetch %s ref %s: %w", fullURL, ref, err)
+		fetchErr = gitCmd("-C", repoDir, "fetch", "--depth", "1", "origin", ref)
+	} else {
+		fetchErr = gitCmd("-C", repoDir, "fetch", "--depth", "1", "origin")
+	}
+
+	if fetchErr != nil {
+		errStr := fetchErr.Error()
+
+		// Stale lock file from an interrupted fetch — remove it and retry once.
+		// This is the most common cause of "first call fails, retry succeeds".
+		if strings.Contains(errStr, ".lock") {
+			_ = os.Remove(filepath.Join(repoDir, ".git", "shallow.lock"))
+			_ = os.Remove(filepath.Join(repoDir, ".git", "index.lock"))
+			if ref != "" {
+				fetchErr = gitCmd("-C", repoDir, "fetch", "--depth", "1", "origin", ref)
+			} else {
+				fetchErr = gitCmd("-C", repoDir, "fetch", "--depth", "1", "origin")
+			}
+			errStr = ""
+			if fetchErr != nil {
+				errStr = fetchErr.Error()
+			}
 		}
+
+		if fetchErr != nil {
+			// Shallow clone corruption — delete the stale cache and re-clone clean.
+			if strings.Contains(errStr, "shallow file has changed") {
+				if err := os.RemoveAll(repoDir); err != nil {
+					return RepoResult{}, fmt.Errorf("removing corrupt registry cache: %w", err)
+				}
+				args := []string{"clone", "--depth", "1"}
+				if ref != "" {
+					args = append(args, "--branch", ref)
+				}
+				args = append(args, fullURL, repoDir)
+				if err := gitCmd(args...); err != nil {
+					return RepoResult{}, fmt.Errorf("git clone %s: %w", fullURL, err)
+				}
+				return RepoResult{Path: repoDir, Cloned: true, Changed: true}, nil
+			}
+			if ref != "" {
+				return RepoResult{}, fmt.Errorf("git fetch %s ref %s: %w", fullURL, ref, fetchErr)
+			}
+			return RepoResult{}, fmt.Errorf("git fetch %s: %w", fullURL, fetchErr)
+		}
+	}
+
+	if ref != "" {
 		if err := gitCmd("-C", repoDir, "checkout", "FETCH_HEAD"); err != nil {
 			return RepoResult{}, fmt.Errorf("git checkout FETCH_HEAD in %s: %w", repoDir, err)
 		}
 	} else {
-		if err := gitCmd("-C", repoDir, "fetch", "--depth", "1", "origin"); err != nil {
-			return RepoResult{}, fmt.Errorf("git fetch %s: %w", fullURL, err)
-		}
 		if err := gitCmd("-C", repoDir, "reset", "--hard", "origin/HEAD"); err != nil {
 			return RepoResult{}, fmt.Errorf("git reset in %s: %w", repoDir, err)
 		}
@@ -192,8 +235,30 @@ func ResolveFromCache(p *harness.Harness, cfg *config.Config) ([]ResolveResult, 
 }
 
 // gitHead returns the short HEAD SHA for a repo, or empty string on error.
+// gitBin is the resolved path to the git binary. Resolved once at startup so
+// that callers invoked from GUI apps (which have a minimal PATH) can still
+// find git even when PATH doesn't include Homebrew or developer tool dirs.
+var gitBin = resolveGitBin()
+
+func resolveGitBin() string {
+	if path, err := exec.LookPath("git"); err == nil {
+		return path
+	}
+	// Common macOS locations not always on GUI app PATH
+	for _, candidate := range []string{
+		"/usr/bin/git",
+		"/opt/homebrew/bin/git",
+		"/usr/local/bin/git",
+	} {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return "git" // last resort — let exec fail with a clear error
+}
+
 func gitHead(repoDir string) string {
-	cmd := exec.Command("git", "-C", repoDir, "rev-parse", "HEAD")
+	cmd := exec.Command(gitBin, "-C", repoDir, "rev-parse", "HEAD")
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -202,13 +267,58 @@ func gitHead(repoDir string) string {
 }
 
 // gitCmd runs a git command, suppressing output unless it fails.
-func gitCmd(args ...string) error {
-	cmd := exec.Command("git", args...)
+// Replaceable in tests via gitCmdFunc.
+var gitCmdFunc = func(args ...string) error {
+	cmd := exec.Command(gitBin, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%w\n%s", err, out)
 	}
 	return nil
+}
+
+func gitCmd(args ...string) error { return gitCmdFunc(args...) }
+
+// PurgeCacheDirsForURL removes all cache directories associated with the given
+// Git URL (all refs). It derives the org--repo name prefix from the URL and
+// deletes every subdirectory of the cache that starts with that prefix.
+func PurgeCacheDirsForURL(gitURL string) error {
+	cacheDir := config.CacheDir()
+	prefix := repoDirPrefix(gitURL)
+
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading cache dir: %w", err)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), prefix+"--") {
+			if err := os.RemoveAll(filepath.Join(cacheDir, e.Name())); err != nil {
+				return fmt.Errorf("removing cache dir %s: %w", e.Name(), err)
+			}
+		}
+	}
+	return nil
+}
+
+// repoDirPrefix returns the org--repo portion of the cache dir name (without the hash suffix).
+func repoDirPrefix(url string) string {
+	cleaned := strings.TrimSuffix(url, ".git")
+	if strings.HasPrefix(cleaned, "git@") {
+		if idx := strings.Index(cleaned, ":"); idx > 0 {
+			cleaned = cleaned[idx+1:]
+		}
+	}
+	cleaned = strings.TrimPrefix(cleaned, "https://")
+	cleaned = strings.TrimPrefix(cleaned, "http://")
+	parts := strings.Split(cleaned, "/")
+	if len(parts) >= 2 {
+		return fmt.Sprintf("%s--%s", parts[len(parts)-2], parts[len(parts)-1])
+	}
+	return parts[len(parts)-1]
 }
 
 // NormalizeGitURL ensures a full Git URL from shorthand.

--- a/internal/resolver/resolver_cache_test.go
+++ b/internal/resolver/resolver_cache_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -308,6 +309,156 @@ func TestResolveGitSourceFromCache_WithPath(t *testing.T) {
 	_, _, err = ResolveGitSourceFromCache(gsBad)
 	if err == nil {
 		t.Fatal("expected error for nonexistent path")
+	}
+}
+
+func TestEnsureRepo_StaleLockFile_RecoversViaRetry(t *testing.T) {
+	srcDir := t.TempDir()
+	runGit(t, srcDir, "init")
+	runGit(t, srcDir, "config", "user.email", "test@test.com")
+	runGit(t, srcDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(srcDir, "data.txt"), []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, srcDir, "add", ".")
+	runGit(t, srcDir, "commit", "-m", "init")
+
+	t.Setenv("YNH_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	// First clone
+	result, err := EnsureRepo(srcDir, "")
+	if err != nil {
+		t.Fatalf("initial clone: %v", err)
+	}
+
+	// Simulate a stale shallow.lock left by an interrupted prior fetch
+	lockFile := filepath.Join(result.Path, ".git", "shallow.lock")
+	if err := os.WriteFile(lockFile, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Inject a gitCmdFunc that fails with a lock error on the first fetch,
+	// then delegates to real git for the retry and all subsequent calls.
+	callCount := 0
+	orig := gitCmdFunc
+	t.Cleanup(func() { gitCmdFunc = orig })
+	gitCmdFunc = func(args ...string) error {
+		callCount++
+		isFetch := len(args) > 0 && args[0] == "-C" && len(args) > 2 && args[2] == "fetch"
+		if callCount == 1 && isFetch {
+			return errors.New("exit status 128\nfatal: Unable to create '...shallow.lock': File exists.")
+		}
+		return orig(args...)
+	}
+
+	result2, err := EnsureRepo(srcDir, "")
+	if err != nil {
+		t.Fatalf("EnsureRepo should recover from stale lock: %v", err)
+	}
+	if result2.Path != result.Path {
+		t.Errorf("expected same cache path, got %q", result2.Path)
+	}
+
+	// Lock file should be gone after recovery
+	if _, err := os.Stat(lockFile); !os.IsNotExist(err) {
+		t.Error("shallow.lock should have been removed during recovery")
+	}
+}
+
+func TestEnsureRepo_ShallowCorruption_RecoversViaReclone(t *testing.T) {
+	// Set up a local git repo to clone
+	srcDir := t.TempDir()
+	runGit(t, srcDir, "init")
+	runGit(t, srcDir, "config", "user.email", "test@test.com")
+	runGit(t, srcDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(srcDir, "data.txt"), []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, srcDir, "add", ".")
+	runGit(t, srcDir, "commit", "-m", "init")
+
+	t.Setenv("YNH_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	// First clone succeeds
+	result, err := EnsureRepo(srcDir, "")
+	if err != nil {
+		t.Fatalf("initial clone failed: %v", err)
+	}
+	repoDir := result.Path
+
+	// Simulate a shallow file corruption: replace gitCmdFunc so that the next
+	// fetch returns the exact error git produces for this condition, then restores
+	// to real git for the subsequent re-clone.
+	callCount := 0
+	orig := gitCmdFunc
+	t.Cleanup(func() { gitCmdFunc = orig })
+	gitCmdFunc = func(args ...string) error {
+		callCount++
+		// First call is the fetch — simulate shallow corruption
+		if callCount == 1 && len(args) > 0 && args[0] == "-C" {
+			return errors.New("exit status 128\nfatal: shallow file has changed since we read it")
+		}
+		return orig(args...)
+	}
+
+	result2, err := EnsureRepo(srcDir, "")
+	if err != nil {
+		t.Fatalf("EnsureRepo should recover from shallow corruption: %v", err)
+	}
+	if result2.Path != repoDir {
+		t.Errorf("expected same cache path after recovery, got %q", result2.Path)
+	}
+	if !result2.Cloned {
+		t.Error("expected Cloned=true after re-clone recovery")
+	}
+
+	// Content should be accessible after recovery
+	data, err := os.ReadFile(filepath.Join(result2.Path, "data.txt"))
+	if err != nil {
+		t.Fatalf("file not readable after recovery: %v", err)
+	}
+	if string(data) != "original" {
+		t.Errorf("unexpected content after recovery: %q", string(data))
+	}
+}
+
+func TestPurgeCacheDirsForURL(t *testing.T) {
+	t.Setenv("YNH_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	cacheDir := config.CacheDir()
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create fake cache dirs matching the URL's org--repo prefix
+	prefix := repoDirPrefix("https://github.com/myorg/myrepo")
+	dirs := []string{
+		prefix + "--aabbccdd",           // ref=""
+		prefix + "--11223344",           // ref="v1"
+		"otherorg--otherrepo--deadbeef", // different URL — must not be deleted
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(cacheDir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := PurgeCacheDirsForURL("https://github.com/myorg/myrepo"); err != nil {
+		t.Fatalf("PurgeCacheDirsForURL: %v", err)
+	}
+
+	// Both matching dirs should be gone
+	for _, d := range dirs[:2] {
+		if _, err := os.Stat(filepath.Join(cacheDir, d)); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be deleted, stat err: %v", d, err)
+		}
+	}
+	// Unrelated dir must survive
+	if _, err := os.Stat(filepath.Join(cacheDir, dirs[2])); err != nil {
+		t.Errorf("unrelated cache dir should survive: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- fix: clear stale git lock files before retrying fetch (root cause of "first open fails, retry works")
- fix: recover from shallow git corruption via re-clone
- fix: resolve git binary path explicitly (handles minimal GUI app PATH)
- fix: ynh registry remove now purges associated cache directories

## Changes since v0.0.17

- #57: fix: recover from shallow git corruption, purge cache on registry remove + git PATH + lock file recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)