### PR TITLE
fix: treat any git fetch failure as unrecoverable, nuke and re-clone

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -151,11 +151,9 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 	}
 
 	if fetchErr != nil {
-		errStr := fetchErr.Error()
-
-		// Stale lock file from an interrupted fetch — remove it and retry once.
-		// This is the most common cause of "first call fails, retry succeeds".
-		if strings.Contains(errStr, ".lock") {
+		// Stale lock file from an interrupted fetch — remove it and retry once
+		// before falling through to the full re-clone path.
+		if strings.Contains(fetchErr.Error(), ".lock") {
 			_ = os.Remove(filepath.Join(repoDir, ".git", "shallow.lock"))
 			_ = os.Remove(filepath.Join(repoDir, ".git", "index.lock"))
 			if ref != "" {
@@ -163,33 +161,26 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 			} else {
 				fetchErr = gitCmd("-C", repoDir, "fetch", "--depth", "1", "origin")
 			}
-			errStr = ""
-			if fetchErr != nil {
-				errStr = fetchErr.Error()
-			}
 		}
+	}
 
-		if fetchErr != nil {
-			// Shallow clone corruption — delete the stale cache and re-clone clean.
-			if strings.Contains(errStr, "shallow file has changed") {
-				if err := os.RemoveAll(repoDir); err != nil {
-					return RepoResult{}, fmt.Errorf("removing corrupt registry cache: %w", err)
-				}
-				args := []string{"clone", "--depth", "1"}
-				if ref != "" {
-					args = append(args, "--branch", ref)
-				}
-				args = append(args, fullURL, repoDir)
-				if err := gitCmd(args...); err != nil {
-					return RepoResult{}, fmt.Errorf("git clone %s: %w", fullURL, err)
-				}
-				return RepoResult{Path: repoDir, Cloned: true, Changed: true}, nil
-			}
-			if ref != "" {
-				return RepoResult{}, fmt.Errorf("git fetch %s ref %s: %w", fullURL, ref, fetchErr)
-			}
-			return RepoResult{}, fmt.Errorf("git fetch %s: %w", fullURL, fetchErr)
+	if fetchErr != nil {
+		// Any fetch failure on a shallow clone is unrecoverable: the shallow
+		// graft history may be inconsistent with what the remote sends (stale
+		// grafts, missing objects, changed history). Nuke the cache and
+		// re-clone clean — the cache is disposable.
+		if err := os.RemoveAll(repoDir); err != nil {
+			return RepoResult{}, fmt.Errorf("removing stale registry cache: %w", err)
 		}
+		args := []string{"clone", "--depth", "1"}
+		if ref != "" {
+			args = append(args, "--branch", ref)
+		}
+		args = append(args, fullURL, repoDir)
+		if err := gitCmd(args...); err != nil {
+			return RepoResult{}, fmt.Errorf("git clone %s: %w", fullURL, err)
+		}
+		return RepoResult{Path: repoDir, Cloned: true, Changed: true}, nil
 	}
 
 	if ref != "" {

--- a/internal/resolver/resolver_cache_test.go
+++ b/internal/resolver/resolver_cache_test.go
@@ -85,28 +85,66 @@ func TestEnsureRepo_UpdateErrorsNotSwallowed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("initial clone failed: %v", err)
 	}
-	_ = result
 
 	// Corrupt the remote by removing the source repo's .git
 	if err := os.RemoveAll(filepath.Join(srcDir, ".git")); err != nil {
 		t.Fatal(err)
 	}
 
-	// Second call: update should fail (fetch from a non-git directory)
+	// Second call: fetch fails → re-clone attempted → re-clone also fails (remote gone).
+	// Error should surface from the clone attempt, not the original fetch.
 	_, err = EnsureRepo(srcDir, "")
 	if err == nil {
-		t.Fatal("expected error when fetching from corrupted remote, got nil")
+		t.Fatal("expected error when remote is gone, got nil")
+	}
+	if !strings.Contains(err.Error(), "git clone") {
+		t.Errorf("error should mention git clone (re-clone after fetch failure), got: %s", err.Error())
+	}
+	_ = result
+}
+
+func TestEnsureRepo_AnyFetchFailure_TriggersReclone(t *testing.T) {
+	srcDir := t.TempDir()
+	runGit(t, srcDir, "init")
+	runGit(t, srcDir, "config", "user.email", "test@test.com")
+	runGit(t, srcDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(srcDir, "data.txt"), []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, srcDir, "add", ".")
+	runGit(t, srcDir, "commit", "-m", "init")
+
+	t.Setenv("YNH_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	result, err := EnsureRepo(srcDir, "")
+	if err != nil {
+		t.Fatalf("initial clone: %v", err)
 	}
 
-	// Verify the error message contains useful context
-	errStr := err.Error()
-	if !strings.Contains(errStr, "git fetch") {
-		t.Errorf("error should mention git fetch, got: %s", errStr)
+	// Inject a fetch failure with an arbitrary git error (e.g. "remote did not
+	// send all necessary objects") — should trigger nuke-and-reclone, not propagate.
+	orig := gitCmdFunc
+	t.Cleanup(func() { gitCmdFunc = orig })
+	calls := 0
+	gitCmdFunc = func(args ...string) error {
+		calls++
+		isFetch := len(args) > 0 && args[0] == "-C" && len(args) > 2 && args[2] == "fetch"
+		if calls == 1 && isFetch {
+			return errors.New("exit status 1\nerror: remote did not send all necessary objects")
+		}
+		return orig(args...)
 	}
 
-	// Verify the cached repo still exists (we don't blow it away on update failure)
-	if _, statErr := os.Stat(result.Path); os.IsNotExist(statErr) {
-		t.Error("cached repo should still exist after failed update")
+	result2, err := EnsureRepo(srcDir, "")
+	if err != nil {
+		t.Fatalf("EnsureRepo should recover via re-clone: %v", err)
+	}
+	if result2.Path != result.Path {
+		t.Errorf("expected same cache path after recovery")
+	}
+	if !result2.Cloned {
+		t.Error("expected Cloned=true after re-clone recovery")
 	}
 }
 
@@ -396,8 +434,8 @@ func TestEnsureRepo_ShallowCorruption_RecoversViaReclone(t *testing.T) {
 	t.Cleanup(func() { gitCmdFunc = orig })
 	gitCmdFunc = func(args ...string) error {
 		callCount++
-		// First call is the fetch — simulate shallow corruption
-		if callCount == 1 && len(args) > 0 && args[0] == "-C" {
+		isFetch := len(args) > 0 && args[0] == "-C" && len(args) > 2 && args[2] == "fetch"
+		if callCount == 1 && isFetch {
 			return errors.New("exit status 128\nfatal: shallow file has changed since we read it")
 		}
 		return orig(args...)


### PR DESCRIPTION
## Summary

Shallow clone fetch failures come in many forms — stale grafts, missing objects, changed remote history, lock files. Playing whack-a-mole with specific error strings is fragile.

The fix: any fetch failure on an existing shallow clone now:
1. Clears stale lock files (`shallow.lock`, `index.lock`) and retries once
2. If still failing (for **any** reason), removes the cache dir and performs a fresh clone

The cache is disposable — re-cloning is always safe and cheap.

Fixes the "remote did not send all necessary objects" error seen after the lock-file fix in v0.0.18.

## Test plan

- [x] `make check` passes
- [x] `TestEnsureRepo_AnyFetchFailure_TriggersReclone` — verifies arbitrary fetch errors trigger re-clone
- [x] `TestEnsureRepo_StaleLockFile_RecoversViaRetry` — lock file cleared and retried before re-clone
- [x] `TestEnsureRepo_ShallowCorruption_RecoversViaReclone` — specific shallow error still recovers
- [x] `TestEnsureRepo_UpdateErrorsNotSwallowed` — updated: error now surfaces from clone (remote truly gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)