### PR TITLE
docs: fix hotfix branch naming — must use slash not hyphen

### DIFF
--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -16,7 +16,7 @@ Every change goes through a branch and PR — no exceptions.
 
 ## Branch naming
 
-Use hyphens, not slashes:
+Use hyphens for all branches except hotfixes, which must use a slash (CI enforces `hotfix/*`):
 
 ```
 feat-<description>
@@ -25,7 +25,7 @@ docs-<description>
 ci-<description>
 refactor-<description>
 test-<description>
-hotfix-<description>
+hotfix/<description>
 ```
 
 ## Workflow


### PR DESCRIPTION
CI enforces `hotfix/*` (slash) but the branching doc said `hotfix-<description>` (hyphen). Discovered when a `hotfix-v0.0.19-fetch-recovery` PR was rejected by the Verify PR source branch check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)