### PR TITLE
feat(plugins): add .cursor-plugin/plugin.json manifest

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "ynh",
+  "description": "User skills for ynh: create harnesses, inspect projects, compress artifacts, validate, and set up team delegation.",
+  "version": "0.1.0",
+  "author": {
+    "name": "eyelock"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.cursor-plugin/plugin.json` so the ynh plugin is discoverable in Cursor-compatible marketplaces
- Mirrors the existing `.claude-plugin/plugin.json` with the same name, description, and version

## Test plan

- [ ] Refresh `eyelock/assistants` marketplace in TermQ — ynh appears as Claude + Cursor plugin
- [ ] Install into a harness — all 5 skills, 2 agents, 1 rule, 1 command resolve from `eyelock/ynh`

**Merge order:** merge this before `eyelock/assistants` `feat/add-ynh-termq-marketplace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)