### PR TITLE
chore: add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ bin/
 .claude/**/*.local.*
 .claude/sessions/
 .claude/plans/
+.worktrees/
 
 # OS
 .DS_Store


### PR DESCRIPTION
`.worktrees/` was showing up as an untracked directory in `git status`. Missing from both `main` and `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)