### PR TITLE
feat: 0.2 foundations — migration chain, namespace, plugin types (1/4)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,12 +22,14 @@ cmd/ynh/                  CLI entry point: harness template manager (init, insta
 cmd/ynd/                  CLI entry point: developer tools (create, lint, validate, fmt, compress, export, marketplace, inspect, preview, diff)
 internal/
   config/                 Global config (~/.ynh/) and path management
-  harness/                Harness loading, format detection, name validation
-  plugin/                 Harness manifest types (.harness.json)
+  harness/                Harness loading, name validation, namespaced storage
+  migration/              Format migration filter chain (see Migration Chain below)
+  plugin/                 Harness manifest types (.ynh-plugin/plugin.json, marketplace.json)
   resolver/               Git clone, cache, and content extraction
   assembler/              Build vendor config dir from resolved content
   exporter/               Produce vendor-native plugin dirs from harness definitions
   marketplace/            Generate marketplace indexes from sets of harnesses/plugins
+  namespace/              @ syntax parsing, URL → namespace derivation, FS name encoding
   registry/               Registry discovery: fetch, search, lookup across Git-hosted indexes
   symlink/                Symlink transaction log (~/.ynh/symlinks.json)
   vendor/                 Vendor adapter interface and implementations
@@ -54,7 +56,9 @@ docs/                     User guide (GitHub Pages)
 
 **Vendor-adaptive launch.** Each vendor gets the strategy that matches its capabilities. Claude supports `--plugin-dir`, so ynh does a clean `exec` with no running process. Codex and Cursor lack native plugin loading, so ynh installs symlinks and manages a child process with signal forwarding. This pragmatic split avoids forcing a lowest-common-denominator approach.
 
-**Single manifest.** Harnesses use a single `.harness.json` file as their manifest — all config (identity, includes, hooks, MCP servers, profiles) lives in one place. The legacy two-file format (`.claude-plugin/plugin.json` + `metadata.json`) is no longer supported.
+**Single manifest.** Harnesses use a single `plugin.json` inside `.ynh-plugin/` as their manifest — all config (identity, includes, hooks, MCP servers, profiles) lives in one place.
+
+**Migration via filter chain.** All backward compatibility lives in `internal/migration/`. Each migration is one struct implementing `Migrator` — its own `Applies` conditions and `Run` transform. Loaders call the chain once before reading; they never branch on old formats themselves. Removing support for a legacy format means deleting that one file and unregistering the struct. No other code changes.
 
 ## Technologies
 
@@ -122,9 +126,31 @@ The exporter reuses `assembler.CopyPicked`, `CopyAllArtifacts`, `CopyFile`, and 
 
 ### Registry
 
-The registry system (`internal/registry/`) enables harness discovery from Git-hosted indexes. A registry is a Git repo with a `registry.json` at its root. Registries are configured in `~/.ynh/config.json` and fetched/cached via `resolver.EnsureRepo`.
+The registry system (`internal/registry/`) enables harness discovery from Git-hosted indexes. A registry is a Git repo with a `.ynh-plugin/marketplace.json` at its root. Registries are configured in `~/.ynh/config.json` and fetched/cached via `resolver.EnsureRepo`.
 
-The install command uses a 6-rule disambiguation chain: local path → SSH URL → HTTPS URL → `name@registry` → Git shorthand → plain name registry search. See `cmd/ynh/install_resolve.go`.
+The install command uses a 6-rule disambiguation chain: local path → SSH URL → HTTPS URL → `name@org/repo` → Git shorthand → plain name registry search. See `cmd/ynh/install_resolve.go`.
+
+### Migration Chain
+
+All backward compatibility lives in `internal/migration/`. The pattern:
+
+```go
+type Migrator interface {
+    Applies(dir string) bool  // check conditions — should this run?
+    Run(dir string) error     // perform the transform
+    Description() string      // user-facing label for what was migrated
+}
+
+type Chain []Migrator
+
+func (c Chain) Run(dir string) ([]string, error)  // returns descriptions of applied migrations
+```
+
+**Adding a migration:** create one file in `internal/migration/`, implement `Migrator`, add to `DefaultChain()`.
+
+**Removing a migration:** delete the file and remove the struct from `DefaultChain()`. No other code changes — loaders never branch on old formats directly.
+
+**Rule:** loaders (`internal/plugin`, `internal/registry`, `internal/harness`) call the migration chain before reading. They assume the new format. Legacy detection logic lives only in `Applies()` methods inside `internal/migration/`.
 
 ## Code Patterns
 

--- a/docs/schema/marketplace.schema.json
+++ b/docs/schema/marketplace.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eyelock.github.io/ynh/schema/marketplace.schema.json",
+  "title": "YNH Marketplace",
+  "description": "Registry index for ynh 0.2+ — lives at .ynh-plugin/marketplace.json. Lists harnesses published by a registry.",
+  "type": "object",
+  "required": ["name", "owner", "harnesses"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$",
+      "description": "Kebab-case registry identifier."
+    },
+    "owner": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "email": { "type": "string" }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": { "type": "string" },
+        "version": { "type": "string" },
+        "harnessRoot": {
+          "type": "string",
+          "description": "Path prefix prepended to relative source paths. Example: \"./ynh\""
+        }
+      }
+    },
+    "harnesses": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/harnessEntry" }
+    }
+  },
+  "$defs": {
+    "harnessEntry": {
+      "type": "object",
+      "required": ["name", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+        },
+        "source": { "$ref": "#/$defs/source" },
+        "description": { "type": "string" },
+        "version": { "type": "string" },
+        "author": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "email": { "type": "string" },
+            "url": { "type": "string" }
+          }
+        },
+        "keywords": { "type": "array", "items": { "type": "string" } },
+        "category": { "type": "string" },
+        "tags": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "source": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Relative path under the marketplace repo root. Must start with ./"
+        },
+        { "$ref": "#/$defs/sourceGitHub" },
+        { "$ref": "#/$defs/sourceURL" },
+        { "$ref": "#/$defs/sourceGitSubdir" }
+      ]
+    },
+    "sourceGitHub": {
+      "type": "object",
+      "required": ["type", "repo"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "github" },
+        "repo": {
+          "type": "string",
+          "description": "owner/repo shorthand"
+        },
+        "path": { "type": "string" },
+        "ref": { "type": "string" },
+        "sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$",
+          "description": "Full 40-character commit SHA. When both ref and sha are present, ref controls what is fetched; sha is verified against the fetched commit."
+        }
+      }
+    },
+    "sourceURL": {
+      "type": "object",
+      "required": ["type", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "url" },
+        "url": { "type": "string" },
+        "path": { "type": "string" },
+        "ref": { "type": "string" },
+        "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
+      }
+    },
+    "sourceGitSubdir": {
+      "type": "object",
+      "required": ["type", "url", "path"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "git-subdir" },
+        "url": { "type": "string" },
+        "path": {
+          "type": "string",
+          "description": "Subdirectory to sparse-clone. Required — no point in sparse clone of the root."
+        },
+        "ref": { "type": "string" },
+        "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
+      }
+    }
+  }
+}

--- a/docs/schema/plugin.schema.json
+++ b/docs/schema/plugin.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "title": "YNH Plugin",
+  "description": "Harness plugin manifest for ynh 0.2+ — lives at .ynh-plugin/plugin.json. Install-time provenance lives in a separate .ynh-plugin/installed.json file written by ynh install.",
+  "type": "object",
+  "required": ["name", "version"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+    },
+    "version": { "type": "string" },
+    "description": { "type": "string" },
+    "author": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "email": { "type": "string" },
+        "url": { "type": "string" }
+      }
+    },
+    "keywords": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "default_vendor": {
+      "type": "string",
+      "enum": ["claude", "cursor", "codex"]
+    },
+    "includes": { "$ref": "#/$defs/includes" },
+    "delegates_to": { "$ref": "#/$defs/delegates" },
+    "hooks": { "$ref": "#/$defs/hooks" },
+    "mcp_servers": { "$ref": "#/$defs/mcp_servers" },
+    "profiles": {
+      "description": "Named configuration variants. Merge semantics: mcp_servers are deep-merged (profile keys win), hooks use per-event replace (profile event replaces default, absent events inherited). Set a server to null to remove it.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "hooks": { "$ref": "#/$defs/hooks" },
+          "mcp_servers": { "$ref": "#/$defs/profile_mcp_servers" }
+        }
+      }
+    },
+    "focus": {
+      "description": "Named combinations of profile + prompt for repeatable AI execution.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["prompt"],
+        "additionalProperties": false,
+        "properties": {
+          "profile": { "type": "string" },
+          "prompt": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "hooks": {
+      "type": "object",
+      "propertyNames": {
+        "enum": ["before_tool", "after_tool", "before_prompt", "on_stop"]
+      },
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["command"],
+          "additionalProperties": false,
+          "properties": {
+            "command": { "type": "string", "minLength": 1 },
+            "matcher": { "type": "string" }
+          }
+        }
+      }
+    },
+    "mcp_servers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "env": { "type": "object", "additionalProperties": { "type": "string" } },
+          "url": { "type": "string" },
+          "headers": { "type": "object", "additionalProperties": { "type": "string" } }
+        },
+        "oneOf": [
+          { "required": ["command"] },
+          { "required": ["url"] }
+        ]
+      }
+    },
+    "profile_mcp_servers": {
+      "description": "MCP servers within a profile. Null removes an inherited server.",
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          { "type": "null" },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "command": { "type": "string" },
+              "args": { "type": "array", "items": { "type": "string" } },
+              "env": { "type": "object", "additionalProperties": { "type": "string" } },
+              "url": { "type": "string" },
+              "headers": { "type": "object", "additionalProperties": { "type": "string" } }
+            },
+            "oneOf": [
+              { "required": ["command"] },
+              { "required": ["url"] }
+            ]
+          }
+        ]
+      }
+    },
+    "includes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["git"],
+        "additionalProperties": false,
+        "properties": {
+          "git": { "type": "string" },
+          "ref": { "type": "string" },
+          "path": { "type": "string" },
+          "pick": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "delegates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["git"],
+        "additionalProperties": false,
+        "properties": {
+          "git": { "type": "string" },
+          "ref": { "type": "string" },
+          "path": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/internal/migration/harness_format.go
+++ b/internal/migration/harness_format.go
@@ -1,0 +1,56 @@
+package migration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// HarnessFormatMigrator converts .harness.json → .ynh-plugin/plugin.json.
+//
+// It extracts installed_from into .ynh-plugin/installed.json, writes
+// plugin.json without that field, then removes .harness.json.
+// Safe to run multiple times — Applies returns false once the new format exists.
+type HarnessFormatMigrator struct{}
+
+func (HarnessFormatMigrator) Description() string {
+	return "harness format: .harness.json → .ynh-plugin/plugin.json"
+}
+
+func (HarnessFormatMigrator) Applies(dir string) bool {
+	_, oldErr := os.Stat(filepath.Join(dir, plugin.HarnessFile))
+	_, newErr := os.Stat(filepath.Join(dir, plugin.PluginDir, plugin.PluginFile))
+	return oldErr == nil && newErr != nil
+}
+
+func (HarnessFormatMigrator) Run(dir string) error {
+	hj, err := plugin.LoadHarnessJSON(dir)
+	if err != nil {
+		return fmt.Errorf("reading .harness.json: %w", err)
+	}
+
+	if hj.InstalledFrom != nil {
+		ins := &plugin.InstalledJSON{
+			SourceType:   hj.InstalledFrom.SourceType,
+			Source:       hj.InstalledFrom.Source,
+			Path:         hj.InstalledFrom.Path,
+			RegistryName: hj.InstalledFrom.RegistryName,
+			InstalledAt:  hj.InstalledFrom.InstalledAt,
+		}
+		if err := plugin.SaveInstalledJSON(dir, ins); err != nil {
+			return fmt.Errorf("writing installed.json: %w", err)
+		}
+	}
+
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
+		return fmt.Errorf("writing plugin.json: %w", err)
+	}
+
+	if err := os.Remove(filepath.Join(dir, plugin.HarnessFile)); err != nil {
+		return fmt.Errorf("removing .harness.json: %w", err)
+	}
+
+	return nil
+}

--- a/internal/migration/harness_format_test.go
+++ b/internal/migration/harness_format_test.go
@@ -1,0 +1,113 @@
+package migration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+var harnessFormatM = HarnessFormatMigrator{}
+
+func TestHarnessFormatMigrator_Applies(t *testing.T) {
+	t.Run("true when only harness.json exists", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, plugin.HarnessFile), `{"name":"x","version":"0.1.0"}`)
+		if !harnessFormatM.Applies(dir) {
+			t.Error("expected Applies=true")
+		}
+	})
+
+	t.Run("false when plugin.json already exists", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, plugin.HarnessFile), `{"name":"x","version":"0.1.0"}`)
+		if err := os.MkdirAll(filepath.Join(dir, plugin.PluginDir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(dir, plugin.PluginDir, plugin.PluginFile), `{"name":"x","version":"0.1.0"}`)
+		if harnessFormatM.Applies(dir) {
+			t.Error("expected Applies=false")
+		}
+	})
+
+	t.Run("false when neither file exists", func(t *testing.T) {
+		dir := t.TempDir()
+		if harnessFormatM.Applies(dir) {
+			t.Error("expected Applies=false")
+		}
+	})
+}
+
+func TestHarnessFormatMigrator_Run(t *testing.T) {
+	t.Run("converts harness.json to plugin.json", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, plugin.HarnessFile), `{"name":"myharness","version":"1.0.0","description":"test"}`)
+
+		if err := harnessFormatM.Run(dir); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+
+		if _, err := os.Stat(filepath.Join(dir, plugin.HarnessFile)); err == nil {
+			t.Error(".harness.json should have been removed")
+		}
+
+		hj, err := plugin.LoadPluginJSON(dir)
+		if err != nil {
+			t.Fatalf("LoadPluginJSON: %v", err)
+		}
+		if hj.Name != "myharness" {
+			t.Errorf("Name = %q, want %q", hj.Name, "myharness")
+		}
+	})
+
+	t.Run("extracts installed_from to installed.json", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, plugin.HarnessFile), `{
+			"name":"myharness","version":"1.0.0",
+			"installed_from":{"source_type":"github","source":"https://github.com/org/repo","installed_at":"2026-04-22T00:00:00Z"}
+		}`)
+
+		if err := harnessFormatM.Run(dir); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+
+		ins, err := plugin.LoadInstalledJSON(dir)
+		if err != nil {
+			t.Fatalf("LoadInstalledJSON: %v", err)
+		}
+		if ins.Source != "https://github.com/org/repo" {
+			t.Errorf("Source = %q, want %q", ins.Source, "https://github.com/org/repo")
+		}
+
+		hj, err := plugin.LoadPluginJSON(dir)
+		if err != nil {
+			t.Fatalf("LoadPluginJSON: %v", err)
+		}
+		if hj.InstalledFrom != nil {
+			t.Error("plugin.json should not contain installed_from")
+		}
+	})
+
+	t.Run("idempotent via Applies guard", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, plugin.HarnessFile), `{"name":"x","version":"0.1.0"}`)
+
+		if err := harnessFormatM.Run(dir); err != nil {
+			t.Fatalf("first Run: %v", err)
+		}
+		if harnessFormatM.Applies(dir) {
+			t.Error("Applies should return false after migration")
+		}
+	})
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/migration/harness_storage.go
+++ b/internal/migration/harness_storage.go
@@ -1,0 +1,124 @@
+package migration
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/eyelock/ynh/internal/config"
+	"github.com/eyelock/ynh/internal/namespace"
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// HarnessStorageMigrator moves flat ~/.ynh/harnesses/<name>/ to the namespaced
+// layout ~/.ynh/harnesses/<org>--<repo>/<name>/.
+//
+// Applies only when:
+//   - The directory's parent is HarnessesDir() directly (flat layout)
+//   - .ynh-plugin/plugin.json exists (HarnessFormatMigrator must have run first)
+//
+// If installed.json is missing or has no source, the harness is left in place
+// under a synthetic "local/unknown" namespace and a warning is printed.
+//
+// Uses write-to-temp-then-rename for atomicity. If interrupted, Applies returns
+// true on retry and the migration re-runs cleanly (idempotent).
+type HarnessStorageMigrator struct{}
+
+func (HarnessStorageMigrator) Description() string {
+	return "harness storage: flat → namespaced layout"
+}
+
+func (HarnessStorageMigrator) Applies(dir string) bool {
+	if filepath.Dir(dir) != config.HarnessesDir() {
+		return false
+	}
+	return plugin.IsPluginDir(dir)
+}
+
+func (HarnessStorageMigrator) Run(dir string) error {
+	name := filepath.Base(dir)
+
+	ns := "local/unknown"
+	ins, err := plugin.LoadInstalledJSON(dir)
+	if err == nil && ins.Source != "" {
+		ns = namespace.DeriveFromURL(ins.Source)
+	} else {
+		fmt.Fprintf(os.Stderr, "warning: harness %q: no provenance found, placing under local/unknown namespace\n", name)
+		fmt.Fprintf(os.Stderr, "  To fix: ynh install %s@org/repo\n", name)
+	}
+
+	fsName := namespace.ToFSName(ns)
+	nsDir := filepath.Join(config.HarnessesDir(), fsName)
+	if err := os.MkdirAll(nsDir, 0o755); err != nil {
+		return fmt.Errorf("creating namespace dir %s: %w", nsDir, err)
+	}
+
+	destDir := filepath.Join(nsDir, name)
+
+	// Update namespace in installed.json before moving
+	if ins != nil {
+		ins.Namespace = ns
+		if err := plugin.SaveInstalledJSON(dir, ins); err != nil {
+			return fmt.Errorf("updating installed.json: %w", err)
+		}
+	}
+
+	// Attempt atomic rename first
+	if err := os.Rename(dir, destDir); err != nil {
+		// Cross-device move: copy then delete
+		if err2 := copyDir(dir, destDir); err2 != nil {
+			return fmt.Errorf("copying harness to %s: %w", destDir, err2)
+		}
+		if err2 := os.RemoveAll(dir); err2 != nil {
+			return fmt.Errorf("removing old harness dir %s: %w", dir, err2)
+		}
+	}
+
+	return nil
+}
+
+// copyDir recursively copies src to dst.
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		return copyFile(path, target, info.Mode())
+	})
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+
+	return os.Rename(tmp, dst)
+}

--- a/internal/migration/harness_storage_test.go
+++ b/internal/migration/harness_storage_test.go
@@ -1,0 +1,106 @@
+package migration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+var storageM = HarnessStorageMigrator{}
+
+// setupHarnessesDir creates a temp YNH_HOME and returns its harnesses subdir.
+func setupHarnessesDir(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	dir := filepath.Join(home, "harnesses")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestHarnessStorageMigrator_Applies(t *testing.T) {
+	harnessesDir := setupHarnessesDir(t)
+
+	t.Run("true for flat dir with plugin.json", func(t *testing.T) {
+		dir := filepath.Join(harnessesDir, "david")
+		writeFile(t, filepath.Join(dir, plugin.PluginDir, plugin.PluginFile), `{"name":"david","version":"0.1.0"}`)
+		if !storageM.Applies(dir) {
+			t.Error("expected Applies=true")
+		}
+	})
+
+	t.Run("false for namespaced dir", func(t *testing.T) {
+		dir := filepath.Join(harnessesDir, "eyelock--assistants", "david")
+		writeFile(t, filepath.Join(dir, plugin.PluginDir, plugin.PluginFile), `{"name":"david","version":"0.1.0"}`)
+		if storageM.Applies(dir) {
+			t.Error("expected Applies=false for already-namespaced dir")
+		}
+	})
+
+	t.Run("false when plugin.json missing", func(t *testing.T) {
+		dir := filepath.Join(harnessesDir, "bare")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if storageM.Applies(dir) {
+			t.Error("expected Applies=false when no plugin.json")
+		}
+	})
+}
+
+func TestHarnessStorageMigrator_Run(t *testing.T) {
+	t.Run("moves to namespaced dir using installed.json", func(t *testing.T) {
+		harnessesDir := setupHarnessesDir(t)
+
+		dir := filepath.Join(harnessesDir, "david")
+		writeFile(t, filepath.Join(dir, plugin.PluginDir, plugin.PluginFile), `{"name":"david","version":"0.1.0"}`)
+		writeFile(t, filepath.Join(dir, plugin.PluginDir, plugin.InstalledFile),
+			`{"source_type":"github","source":"https://github.com/eyelock/assistants","installed_at":"2026-04-22T00:00:00Z"}`)
+		writeFile(t, filepath.Join(dir, "skills", "README.md"), "# skills")
+
+		if err := storageM.Run(dir); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+
+		if _, err := os.Stat(dir); err == nil {
+			t.Error("flat dir should have been removed")
+		}
+
+		dest := filepath.Join(harnessesDir, "eyelock--assistants", "david")
+		if _, err := os.Stat(dest); err != nil {
+			t.Errorf("namespaced dir not found: %v", err)
+		}
+
+		if !plugin.IsPluginDir(dest) {
+			t.Error("plugin.json missing from namespaced dir")
+		}
+
+		ins, err := plugin.LoadInstalledJSON(dest)
+		if err != nil {
+			t.Fatalf("LoadInstalledJSON: %v", err)
+		}
+		if ins.Namespace != "eyelock/assistants" {
+			t.Errorf("Namespace = %q, want %q", ins.Namespace, "eyelock/assistants")
+		}
+	})
+
+	t.Run("falls back to local/unknown when no installed.json", func(t *testing.T) {
+		harnessesDir := setupHarnessesDir(t)
+
+		dir := filepath.Join(harnessesDir, "mystery")
+		writeFile(t, filepath.Join(dir, plugin.PluginDir, plugin.PluginFile), `{"name":"mystery","version":"0.1.0"}`)
+
+		if err := storageM.Run(dir); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+
+		dest := filepath.Join(harnessesDir, "local--unknown", "mystery")
+		if _, err := os.Stat(dest); err != nil {
+			t.Errorf("fallback dir not found: %v", err)
+		}
+	})
+}

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -1,0 +1,47 @@
+// Package migration provides a filter chain for transparent format migrations.
+//
+// Each migration is a single struct implementing Migrator. Loaders call
+// DefaultChain().Run(dir) before reading — they never branch on old formats.
+// Removing support for a legacy format means deleting the migrator file and
+// unregistering the struct from DefaultChain. No other code changes.
+package migration
+
+// Migrator is a single format migration step.
+type Migrator interface {
+	// Applies reports whether this migration should run on dir.
+	Applies(dir string) bool
+	// Run performs the in-place migration on dir.
+	Run(dir string) error
+	// Description returns a short user-facing label for what was migrated.
+	Description() string
+}
+
+// Chain is an ordered list of migrators.
+type Chain []Migrator
+
+// Run applies each migrator whose Applies returns true, in order.
+// Returns descriptions of the migrations that were applied.
+func (c Chain) Run(dir string) ([]string, error) {
+	var applied []string
+	for _, m := range c {
+		if m.Applies(dir) {
+			if err := m.Run(dir); err != nil {
+				return applied, err
+			}
+			applied = append(applied, m.Description())
+		}
+	}
+	return applied, nil
+}
+
+// DefaultChain returns the standard migration chain in dependency order.
+//
+// Order matters: HarnessFormatMigrator must run before HarnessStorageMigrator
+// so that .ynh-plugin/installed.json exists when namespace inference runs.
+func DefaultChain() Chain {
+	return Chain{
+		HarnessFormatMigrator{},
+		RegistryFormatMigrator{},
+		HarnessStorageMigrator{},
+	}
+}

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -34,7 +34,7 @@ func (c Chain) Run(dir string) ([]string, error) {
 	return applied, nil
 }
 
-// DefaultChain returns the standard migration chain in dependency order.
+// DefaultChain returns the full migration chain including storage relocation.
 //
 // Order matters: HarnessFormatMigrator must run before HarnessStorageMigrator
 // so that .ynh-plugin/installed.json exists when namespace inference runs.
@@ -43,5 +43,15 @@ func DefaultChain() Chain {
 		HarnessFormatMigrator{},
 		RegistryFormatMigrator{},
 		HarnessStorageMigrator{},
+	}
+}
+
+// FormatChain returns the format-only migration chain (no storage relocation).
+// Use this when loading harnesses transparently — storage migration should be
+// triggered explicitly so callers holding paths are not surprised by relocation.
+func FormatChain() Chain {
+	return Chain{
+		HarnessFormatMigrator{},
+		RegistryFormatMigrator{},
 	}
 }

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -1,0 +1,98 @@
+package migration
+
+import (
+	"errors"
+	"testing"
+)
+
+type fakeMigrator struct {
+	applies     bool
+	runErr      error
+	ran         bool
+	description string
+}
+
+func (f *fakeMigrator) Applies(dir string) bool { return f.applies }
+func (f *fakeMigrator) Run(dir string) error {
+	f.ran = true
+	return f.runErr
+}
+func (f *fakeMigrator) Description() string { return f.description }
+
+func TestChain_Run_OnlyAppliesMatching(t *testing.T) {
+	m1 := &fakeMigrator{applies: true, description: "m1"}
+	m2 := &fakeMigrator{applies: false, description: "m2"}
+	m3 := &fakeMigrator{applies: true, description: "m3"}
+
+	c := Chain{m1, m2, m3}
+	applied, err := c.Run("/some/dir")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !m1.ran {
+		t.Error("m1 should have run")
+	}
+	if m2.ran {
+		t.Error("m2 should not have run")
+	}
+	if !m3.ran {
+		t.Error("m3 should have run")
+	}
+
+	want := []string{"m1", "m3"}
+	if len(applied) != 2 || applied[0] != want[0] || applied[1] != want[1] {
+		t.Errorf("applied = %v, want %v", applied, want)
+	}
+}
+
+func TestChain_Run_StopsOnError(t *testing.T) {
+	m1 := &fakeMigrator{applies: true, description: "m1"}
+	m2 := &fakeMigrator{applies: true, runErr: errors.New("boom"), description: "m2"}
+	m3 := &fakeMigrator{applies: true, description: "m3"}
+
+	c := Chain{m1, m2, m3}
+	applied, err := c.Run("/some/dir")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if m3.ran {
+		t.Error("m3 should not run after m2 errors")
+	}
+	if len(applied) != 1 || applied[0] != "m1" {
+		t.Errorf("applied = %v, want [m1]", applied)
+	}
+}
+
+func TestDefaultChain_Order(t *testing.T) {
+	c := DefaultChain()
+	// harness_format must precede harness_storage so installed.json is readable
+	// when the storage migrator runs.
+	var sawFormat, sawStorage bool
+	for _, m := range c {
+		switch m.(type) {
+		case HarnessFormatMigrator:
+			sawFormat = true
+			if sawStorage {
+				t.Error("HarnessFormatMigrator must come before HarnessStorageMigrator")
+			}
+		case HarnessStorageMigrator:
+			sawStorage = true
+			if !sawFormat {
+				t.Error("HarnessStorageMigrator must come after HarnessFormatMigrator")
+			}
+		}
+	}
+	if !sawFormat || !sawStorage {
+		t.Error("DefaultChain missing expected migrators")
+	}
+}
+
+func TestFormatChain_ExcludesStorage(t *testing.T) {
+	c := FormatChain()
+	for _, m := range c {
+		if _, ok := m.(HarnessStorageMigrator); ok {
+			t.Error("FormatChain should not include HarnessStorageMigrator")
+		}
+	}
+}

--- a/internal/migration/registry_format.go
+++ b/internal/migration/registry_format.go
@@ -1,0 +1,88 @@
+package migration
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// RegistryFormatMigrator converts registry.json → .ynh-plugin/marketplace.json.
+// Safe to run multiple times — Applies returns false once the new format exists.
+type RegistryFormatMigrator struct{}
+
+func (RegistryFormatMigrator) Description() string {
+	return "registry format: registry.json → .ynh-plugin/marketplace.json"
+}
+
+func (RegistryFormatMigrator) Applies(dir string) bool {
+	_, oldErr := os.Stat(filepath.Join(dir, "registry.json"))
+	_, newErr := os.Stat(filepath.Join(dir, plugin.PluginDir, plugin.MarketplaceFile))
+	return oldErr == nil && newErr != nil
+}
+
+func (RegistryFormatMigrator) Run(dir string) error {
+	data, err := os.ReadFile(filepath.Join(dir, "registry.json"))
+	if err != nil {
+		return fmt.Errorf("reading registry.json: %w", err)
+	}
+
+	var old oldRegistry
+	if err := json.Unmarshal(data, &old); err != nil {
+		return fmt.Errorf("parsing registry.json: %w", err)
+	}
+
+	mj := &plugin.MarketplaceJSON{
+		Name:  old.Name,
+		Owner: &plugin.OwnerInfo{Name: old.Name},
+	}
+	if old.Description != "" {
+		mj.Metadata = &plugin.MarketplaceMeta{Description: old.Description}
+	}
+
+	for i, e := range old.Entries {
+		src := plugin.RemoteSource{
+			Type: "github",
+			Repo: e.Repo,
+			Path: e.Path,
+		}
+		srcData, err := json.Marshal(src)
+		if err != nil {
+			return fmt.Errorf("entry %d: marshaling source: %w", i, err)
+		}
+		mj.Harnesses = append(mj.Harnesses, plugin.HarnessEntry{
+			Name:        e.Name,
+			Source:      json.RawMessage(srcData),
+			Description: e.Description,
+			Version:     e.Version,
+			Keywords:    e.Keywords,
+		})
+	}
+
+	if err := plugin.SaveMarketplaceJSON(dir, mj); err != nil {
+		return fmt.Errorf("writing marketplace.json: %w", err)
+	}
+
+	if err := os.Remove(filepath.Join(dir, "registry.json")); err != nil {
+		return fmt.Errorf("removing registry.json: %w", err)
+	}
+
+	return nil
+}
+
+type oldRegistry struct {
+	Name        string     `json:"name"`
+	Description string     `json:"description,omitempty"`
+	Entries     []oldEntry `json:"entries"`
+}
+
+type oldEntry struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Keywords    []string `json:"keywords,omitempty"`
+	Repo        string   `json:"repo"`
+	Path        string   `json:"path,omitempty"`
+	Version     string   `json:"version,omitempty"`
+}

--- a/internal/migration/registry_format_test.go
+++ b/internal/migration/registry_format_test.go
@@ -1,0 +1,82 @@
+package migration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+var registryFormatM = RegistryFormatMigrator{}
+
+func TestRegistryFormatMigrator_Applies(t *testing.T) {
+	t.Run("true when only registry.json exists", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "registry.json"), `{"name":"r","entries":[]}`)
+		if !registryFormatM.Applies(dir) {
+			t.Error("expected Applies=true")
+		}
+	})
+
+	t.Run("false when marketplace.json already exists", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "registry.json"), `{"name":"r","entries":[]}`)
+		if err := os.MkdirAll(filepath.Join(dir, plugin.PluginDir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(dir, plugin.PluginDir, plugin.MarketplaceFile), `{"name":"r","owner":{"name":"r"},"harnesses":[]}`)
+		if registryFormatM.Applies(dir) {
+			t.Error("expected Applies=false")
+		}
+	})
+}
+
+func TestRegistryFormatMigrator_Run(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "registry.json"), `{
+		"name": "my-registry",
+		"description": "A test registry",
+		"entries": [
+			{"name": "david", "repo": "eyelock/assistants", "path": "ynh/david", "description": "Dev harness", "version": "0.1.0", "keywords": ["dev"]}
+		]
+	}`)
+
+	if err := registryFormatM.Run(dir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "registry.json")); err == nil {
+		t.Error("registry.json should have been removed")
+	}
+
+	mj, err := plugin.LoadMarketplaceJSON(dir)
+	if err != nil {
+		t.Fatalf("LoadMarketplaceJSON: %v", err)
+	}
+	if mj.Name != "my-registry" {
+		t.Errorf("Name = %q, want %q", mj.Name, "my-registry")
+	}
+	if len(mj.Harnesses) != 1 {
+		t.Fatalf("len(Harnesses) = %d, want 1", len(mj.Harnesses))
+	}
+
+	h := mj.Harnesses[0]
+	if h.Name != "david" {
+		t.Errorf("harness Name = %q, want %q", h.Name, "david")
+	}
+
+	src, ok := h.SourceRemote()
+	if !ok {
+		t.Fatal("expected remote source")
+	}
+	if src.Type != "github" {
+		t.Errorf("source.type = %q, want %q", src.Type, "github")
+	}
+	if src.Repo != "eyelock/assistants" {
+		t.Errorf("source.repo = %q, want %q", src.Repo, "eyelock/assistants")
+	}
+	if src.Path != "ynh/david" {
+		t.Errorf("source.path = %q, want %q", src.Path, "ynh/david")
+	}
+}

--- a/internal/namespace/namespace.go
+++ b/internal/namespace/namespace.go
@@ -1,0 +1,99 @@
+package namespace
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseQualified splits "name@org/repo" into name and namespace.
+// If no "@" is present, name is the full ref and namespace is empty.
+func ParseQualified(ref string) (name, ns string, err error) {
+	idx := strings.LastIndex(ref, "@")
+	if idx < 0 {
+		return ref, "", nil
+	}
+	name = ref[:idx]
+	ns = ref[idx+1:]
+	if name == "" {
+		return "", "", fmt.Errorf("qualified ref %q: name must not be empty", ref)
+	}
+	if ns == "" {
+		return "", "", fmt.Errorf("qualified ref %q: namespace must not be empty", ref)
+	}
+	return name, ns, nil
+}
+
+// DeriveFromURL derives "org/repo" from a Git URL or local path.
+// Uses the same URL parsing as internal/resolver.repoDirName but without
+// the hash suffix — namespaces must be ref-agnostic and stable across machines.
+//
+// Examples:
+//
+//	https://github.com/eyelock/assistants     → eyelock/assistants
+//	git@github.com:eyelock/assistants.git     → eyelock/assistants
+//	github.com/eyelock/assistants             → eyelock/assistants
+//	/Users/david/harnesses                    → david/harnesses
+func DeriveFromURL(url string) string {
+	if strings.HasPrefix(url, "/") || strings.HasPrefix(url, ".") {
+		return deriveFromLocalPath(url)
+	}
+
+	cleaned := strings.TrimSuffix(url, ".git")
+
+	// SSH: git@host:org/repo
+	if strings.HasPrefix(cleaned, "git@") {
+		if idx := strings.Index(cleaned, ":"); idx > 0 {
+			cleaned = cleaned[idx+1:]
+		}
+	}
+
+	cleaned = strings.TrimPrefix(cleaned, "https://")
+	cleaned = strings.TrimPrefix(cleaned, "http://")
+
+	parts := splitNonEmpty(cleaned, "/")
+	switch len(parts) {
+	case 0:
+		return "local/unknown"
+	case 1:
+		return "local/" + parts[0]
+	default:
+		// Drop the host segment if it looks like a hostname (contains a dot)
+		if strings.Contains(parts[0], ".") && len(parts) >= 3 {
+			parts = parts[1:]
+		}
+		return parts[len(parts)-2] + "/" + parts[len(parts)-1]
+	}
+}
+
+func deriveFromLocalPath(path string) string {
+	cleaned := strings.TrimLeft(path, "./")
+	parts := splitNonEmpty(cleaned, "/")
+	switch len(parts) {
+	case 0:
+		return "local/unknown"
+	case 1:
+		return "local/" + parts[0]
+	default:
+		return parts[len(parts)-2] + "/" + parts[len(parts)-1]
+	}
+}
+
+// ToFSName converts "org/repo" to "org--repo" for use as a directory name.
+func ToFSName(ns string) string {
+	return strings.ReplaceAll(ns, "/", "--")
+}
+
+// FromFSName converts "org--repo" back to "org/repo".
+func FromFSName(fsName string) string {
+	return strings.ReplaceAll(fsName, "--", "/")
+}
+
+func splitNonEmpty(s, sep string) []string {
+	var out []string
+	for _, p := range strings.Split(s, sep) {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/namespace/namespace_test.go
+++ b/internal/namespace/namespace_test.go
@@ -1,0 +1,76 @@
+package namespace
+
+import "testing"
+
+func TestDeriveFromURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://github.com/eyelock/assistants", "eyelock/assistants"},
+		{"https://github.com/eyelock/assistants.git", "eyelock/assistants"},
+		{"git@github.com:eyelock/assistants.git", "eyelock/assistants"},
+		{"git@github.com:eyelock/assistants", "eyelock/assistants"},
+		{"https://gitlab.com/myorg/tools", "myorg/tools"},
+		{"github.com/eyelock/assistants", "eyelock/assistants"},
+		{"/Users/david/harnesses", "david/harnesses"},
+		{"/harnesses", "local/harnesses"},
+		{"./harnesses", "local/harnesses"},
+	}
+
+	for _, tc := range tests {
+		got := DeriveFromURL(tc.url)
+		if got != tc.want {
+			t.Errorf("DeriveFromURL(%q) = %q, want %q", tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestParseQualified(t *testing.T) {
+	tests := []struct {
+		ref     string
+		name    string
+		ns      string
+		wantErr bool
+	}{
+		{"david@eyelock/assistants", "david", "eyelock/assistants", false},
+		{"david", "david", "", false},
+		{"david@", "", "", true},
+		{"@eyelock/assistants", "", "", true},
+	}
+
+	for _, tc := range tests {
+		name, ns, err := ParseQualified(tc.ref)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("ParseQualified(%q): expected error, got none", tc.ref)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseQualified(%q): unexpected error: %v", tc.ref, err)
+			continue
+		}
+		if name != tc.name {
+			t.Errorf("ParseQualified(%q) name = %q, want %q", tc.ref, name, tc.name)
+		}
+		if ns != tc.ns {
+			t.Errorf("ParseQualified(%q) ns = %q, want %q", tc.ref, ns, tc.ns)
+		}
+	}
+}
+
+func TestToFromFSName(t *testing.T) {
+	tests := []string{
+		"eyelock/assistants",
+		"myorg/tools",
+		"a/b",
+	}
+	for _, ns := range tests {
+		fs := ToFSName(ns)
+		back := FromFSName(fs)
+		if back != ns {
+			t.Errorf("round-trip %q → %q → %q", ns, fs, back)
+		}
+	}
+}

--- a/internal/plugin/marketplace.go
+++ b/internal/plugin/marketplace.go
@@ -1,0 +1,109 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// MarketplaceFile is the registry index filename inside PluginDir.
+const MarketplaceFile = "marketplace.json"
+
+// MarketplaceJSON is the root structure of .ynh-plugin/marketplace.json.
+type MarketplaceJSON struct {
+	Schema    string           `json:"$schema,omitempty"`
+	Name      string           `json:"name"`
+	Owner     *OwnerInfo       `json:"owner"`
+	Metadata  *MarketplaceMeta `json:"metadata,omitempty"`
+	Harnesses []HarnessEntry   `json:"harnesses"`
+}
+
+// OwnerInfo describes the registry owner.
+type OwnerInfo struct {
+	Name  string `json:"name"`
+	Email string `json:"email,omitempty"`
+}
+
+// MarketplaceMeta holds optional registry-level metadata.
+type MarketplaceMeta struct {
+	Description string `json:"description,omitempty"`
+	Version     string `json:"version,omitempty"`
+	HarnessRoot string `json:"harnessRoot,omitempty"`
+}
+
+// HarnessEntry describes one harness in a marketplace index.
+// Source is either a JSON string (relative path) or a RemoteSource object.
+type HarnessEntry struct {
+	Name        string          `json:"name"`
+	Source      json.RawMessage `json:"source"`
+	Description string          `json:"description,omitempty"`
+	Version     string          `json:"version,omitempty"`
+	Author      *AuthorInfo     `json:"author,omitempty"`
+	Keywords    []string        `json:"keywords,omitempty"`
+	Category    string          `json:"category,omitempty"`
+	Tags        []string        `json:"tags,omitempty"`
+}
+
+// SourcePath returns the relative path string if source is a plain string.
+func (e *HarnessEntry) SourcePath() (string, bool) {
+	var s string
+	if err := json.Unmarshal(e.Source, &s); err == nil {
+		return s, true
+	}
+	return "", false
+}
+
+// SourceRemote returns the remote source object if source is an object.
+func (e *HarnessEntry) SourceRemote() (*RemoteSource, bool) {
+	var r RemoteSource
+	if err := json.Unmarshal(e.Source, &r); err == nil && r.Type != "" {
+		return &r, true
+	}
+	return nil, false
+}
+
+// RemoteSource is the object form of a HarnessEntry source.
+// Type is the discriminator: "github", "url", or "git-subdir".
+type RemoteSource struct {
+	Type string `json:"type"`
+	Repo string `json:"repo,omitempty"` // github only
+	URL  string `json:"url,omitempty"`  // url and git-subdir
+	Path string `json:"path,omitempty"`
+	Ref  string `json:"ref,omitempty"`
+	SHA  string `json:"sha,omitempty"`
+}
+
+// LoadMarketplaceJSON reads and parses .ynh-plugin/marketplace.json from dir.
+func LoadMarketplaceJSON(dir string) (*MarketplaceJSON, error) {
+	data, err := os.ReadFile(filepath.Join(dir, PluginDir, MarketplaceFile))
+	if err != nil {
+		return nil, fmt.Errorf("reading marketplace.json: %w", err)
+	}
+
+	var mj MarketplaceJSON
+	if err := json.Unmarshal(data, &mj); err != nil {
+		return nil, fmt.Errorf("invalid marketplace.json: %w", err)
+	}
+
+	return &mj, nil
+}
+
+// SaveMarketplaceJSON writes mj to .ynh-plugin/marketplace.json in dir.
+func SaveMarketplaceJSON(dir string, mj *MarketplaceJSON) error {
+	if err := os.MkdirAll(filepath.Join(dir, PluginDir), 0o755); err != nil {
+		return fmt.Errorf("creating .ynh-plugin dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(mj, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling marketplace.json: %w", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.WriteFile(filepath.Join(dir, PluginDir, MarketplaceFile), data, 0o644); err != nil {
+		return fmt.Errorf("writing marketplace.json: %w", err)
+	}
+
+	return nil
+}

--- a/internal/plugin/marketplace_test.go
+++ b/internal/plugin/marketplace_test.go
@@ -1,0 +1,161 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHarnessEntry_SourcePath(t *testing.T) {
+	e := HarnessEntry{Source: json.RawMessage(`"./ynh/david"`)}
+	path, ok := e.SourcePath()
+	if !ok {
+		t.Fatal("expected string source to parse as path")
+	}
+	if path != "./ynh/david" {
+		t.Errorf("path = %q, want %q", path, "./ynh/david")
+	}
+
+	_, ok = e.SourceRemote()
+	if ok {
+		t.Error("string source should not parse as RemoteSource")
+	}
+}
+
+func TestHarnessEntry_SourceRemote_GitHub(t *testing.T) {
+	e := HarnessEntry{Source: json.RawMessage(`{"type":"github","repo":"eyelock/assistants","path":"ynh/david","ref":"main"}`)}
+	src, ok := e.SourceRemote()
+	if !ok {
+		t.Fatal("expected object source to parse")
+	}
+	if src.Type != "github" {
+		t.Errorf("Type = %q, want github", src.Type)
+	}
+	if src.Repo != "eyelock/assistants" {
+		t.Errorf("Repo = %q", src.Repo)
+	}
+
+	_, ok = e.SourcePath()
+	if ok {
+		t.Error("object source should not parse as string path")
+	}
+}
+
+func TestHarnessEntry_SourceRemote_URL(t *testing.T) {
+	e := HarnessEntry{Source: json.RawMessage(`{"type":"url","url":"https://gitlab.com/myorg/tools.git","ref":"v1.0.0","sha":"abc123"}`)}
+	src, ok := e.SourceRemote()
+	if !ok {
+		t.Fatal("expected object source to parse")
+	}
+	if src.Type != "url" {
+		t.Errorf("Type = %q, want url", src.Type)
+	}
+	if src.URL != "https://gitlab.com/myorg/tools.git" {
+		t.Errorf("URL = %q", src.URL)
+	}
+	if src.SHA != "abc123" {
+		t.Errorf("SHA = %q", src.SHA)
+	}
+}
+
+func TestLoadSaveMarketplaceJSON_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	mj := &MarketplaceJSON{
+		Name:  "test",
+		Owner: &OwnerInfo{Name: "me"},
+		Harnesses: []HarnessEntry{
+			{Name: "a", Source: json.RawMessage(`"./a"`)},
+			{Name: "b", Source: json.RawMessage(`{"type":"github","repo":"o/r"}`)},
+		},
+	}
+
+	if err := SaveMarketplaceJSON(dir, mj); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// File should be at .ynh-plugin/marketplace.json
+	if _, err := os.Stat(filepath.Join(dir, PluginDir, MarketplaceFile)); err != nil {
+		t.Fatalf("marketplace.json not found: %v", err)
+	}
+
+	loaded, err := LoadMarketplaceJSON(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if loaded.Name != "test" {
+		t.Errorf("Name = %q", loaded.Name)
+	}
+	if len(loaded.Harnesses) != 2 {
+		t.Fatalf("len(Harnesses) = %d", len(loaded.Harnesses))
+	}
+
+	if path, ok := loaded.Harnesses[0].SourcePath(); !ok || path != "./a" {
+		t.Errorf("first entry path = %q ok=%v", path, ok)
+	}
+	if src, ok := loaded.Harnesses[1].SourceRemote(); !ok || src.Type != "github" {
+		t.Errorf("second entry remote = %v ok=%v", src, ok)
+	}
+}
+
+func TestLoadSavePluginJSON_StripsInstalledFrom(t *testing.T) {
+	dir := t.TempDir()
+	hj := &HarnessJSON{
+		Name:    "test",
+		Version: "1.0.0",
+		InstalledFrom: &ProvenanceMeta{
+			SourceType:  "github",
+			Source:      "https://github.com/o/r",
+			InstalledAt: "2026-04-22T00:00:00Z",
+		},
+	}
+
+	if err := SavePluginJSON(dir, hj); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := LoadPluginJSON(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.InstalledFrom != nil {
+		t.Error("SavePluginJSON should strip InstalledFrom")
+	}
+
+	// Caller's struct must not be mutated
+	if hj.InstalledFrom == nil {
+		t.Error("SavePluginJSON mutated caller's struct")
+	}
+}
+
+func TestLoadSaveInstalledJSON_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	ins := &InstalledJSON{
+		SourceType:  "github",
+		Source:      "https://github.com/eyelock/assistants",
+		Ref:         "main",
+		SHA:         "abc123",
+		Namespace:   "eyelock/assistants",
+		InstalledAt: "2026-04-22T00:00:00Z",
+	}
+
+	if err := SaveInstalledJSON(dir, ins); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := LoadInstalledJSON(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if loaded.Source != ins.Source {
+		t.Errorf("Source = %q, want %q", loaded.Source, ins.Source)
+	}
+	if loaded.Namespace != ins.Namespace {
+		t.Errorf("Namespace = %q, want %q", loaded.Namespace, ins.Namespace)
+	}
+	if loaded.SHA != ins.SHA {
+		t.Errorf("SHA = %q, want %q", loaded.SHA, ins.SHA)
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -164,10 +164,119 @@ type DelegateMeta struct {
 // HarnessFile is the manifest filename used in harness directories.
 const HarnessFile = ".harness.json"
 
+// PluginDir is the manifest directory for the 0.2+ format.
+const PluginDir = ".ynh-plugin"
+
+// PluginFile is the manifest filename inside PluginDir.
+const PluginFile = "plugin.json"
+
+// InstalledFile holds install-time provenance inside PluginDir.
+// Authors never write this file — ynh install writes it at install time.
+const InstalledFile = "installed.json"
+
+// InstalledJSON records where a harness was installed from.
+// It lives at .ynh-plugin/installed.json, separate from the author-controlled plugin.json.
+type InstalledJSON struct {
+	SourceType   string `json:"source_type"`
+	Source       string `json:"source"`
+	Ref          string `json:"ref,omitempty"`
+	SHA          string `json:"sha,omitempty"`
+	Path         string `json:"path,omitempty"`
+	Namespace    string `json:"namespace,omitempty"`
+	RegistryName string `json:"registry_name,omitempty"`
+	InstalledAt  string `json:"installed_at"`
+}
+
 // IsHarnessDir returns true if the directory contains a .harness.json manifest.
 func IsHarnessDir(dir string) bool {
 	_, err := os.Stat(filepath.Join(dir, HarnessFile))
 	return err == nil
+}
+
+// IsPluginDir returns true if the directory contains a .ynh-plugin/plugin.json manifest.
+func IsPluginDir(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, PluginDir, PluginFile))
+	return err == nil
+}
+
+// LoadPluginJSON reads and parses .ynh-plugin/plugin.json from dir.
+// Unknown fields are rejected. The migration chain must run before this
+// so callers can assume the new format exists.
+func LoadPluginJSON(dir string) (*HarnessJSON, error) {
+	data, err := os.ReadFile(filepath.Join(dir, PluginDir, PluginFile))
+	if err != nil {
+		return nil, fmt.Errorf("reading plugin.json: %w", err)
+	}
+
+	var hj HarnessJSON
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&hj); err != nil {
+		return nil, fmt.Errorf("invalid plugin.json: %w", err)
+	}
+
+	if hj.Name == "" {
+		return nil, fmt.Errorf("plugin.json missing required field: name")
+	}
+
+	return &hj, nil
+}
+
+// SavePluginJSON writes hj to .ynh-plugin/plugin.json in dir.
+// InstalledFrom is stripped — provenance belongs in installed.json.
+func SavePluginJSON(dir string, hj *HarnessJSON) error {
+	if err := os.MkdirAll(filepath.Join(dir, PluginDir), 0o755); err != nil {
+		return fmt.Errorf("creating .ynh-plugin dir: %w", err)
+	}
+
+	clean := *hj
+	clean.InstalledFrom = nil
+
+	data, err := json.MarshalIndent(clean, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling plugin.json: %w", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.WriteFile(filepath.Join(dir, PluginDir, PluginFile), data, 0o644); err != nil {
+		return fmt.Errorf("writing plugin.json: %w", err)
+	}
+
+	return nil
+}
+
+// LoadInstalledJSON reads .ynh-plugin/installed.json from dir.
+func LoadInstalledJSON(dir string) (*InstalledJSON, error) {
+	data, err := os.ReadFile(filepath.Join(dir, PluginDir, InstalledFile))
+	if err != nil {
+		return nil, fmt.Errorf("reading installed.json: %w", err)
+	}
+
+	var ins InstalledJSON
+	if err := json.Unmarshal(data, &ins); err != nil {
+		return nil, fmt.Errorf("invalid installed.json: %w", err)
+	}
+
+	return &ins, nil
+}
+
+// SaveInstalledJSON writes ins to .ynh-plugin/installed.json in dir.
+func SaveInstalledJSON(dir string, ins *InstalledJSON) error {
+	if err := os.MkdirAll(filepath.Join(dir, PluginDir), 0o755); err != nil {
+		return fmt.Errorf("creating .ynh-plugin dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(ins, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling installed.json: %w", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.WriteFile(filepath.Join(dir, PluginDir, InstalledFile), data, 0o644); err != nil {
+		return fmt.Errorf("writing installed.json: %w", err)
+	}
+
+	return nil
 }
 
 // IsLegacyPluginDir returns true if the directory contains a legacy .claude-plugin/plugin.json.


### PR DESCRIPTION
## Summary

Part 1 of 4 in the 0.2 namespacing & format redesign. **Pure additions** — no
existing behavior changes. Nothing is wired in; subsequent PRs adopt these.

- **`internal/migration/`** — Filter chain with `Migrator` interface, `Chain`
  type, `DefaultChain()` (format + storage) and `FormatChain()` (format only).
  Each migrator is one struct in its own file: `harness_format.go`,
  `registry_format.go`, `harness_storage.go`. Adding or removing a migrator
  means adding/removing a file and unregistering the struct — no ripples.
- **`internal/namespace/`** — `ParseQualified` (for `name@org/repo`),
  `DeriveFromURL` (URL → `org/repo`), `ToFSName`/`FromFSName` (the `--`
  separator for filesystem use).
- **`internal/plugin/`** — `PluginDir`/`PluginFile`/`InstalledFile` constants,
  `IsPluginDir`, `LoadPluginJSON`, `SavePluginJSON` (strips `InstalledFrom`),
  `LoadInstalledJSON`/`SaveInstalledJSON`, `InstalledJSON` struct,
  `MarketplaceJSON` struct and loaders (type-discriminator field is `type`).
- **CONTRIBUTING.md** — documents the migration chain pattern.
- **Schemas** — `plugin.schema.json`, `marketplace.schema.json` for editor validation.

Unit tests cover each migrator, chain ordering/idempotency, source-type parsing,
and format round-trips.

## Why this PR exists

This is the foundation for three follow-ups:

- **PR 2/4** — Loaders call the chain and read the new format (transparent
  backward compat).
- **PR 3/4** — `cmd/ynh` and `cmd/ynd` adopt namespaced install + `@` syntax
  + `ynd migrate`.
- **PR 4/4** — Docs and tutorials updated.

## Test plan

- [x] `make check` passes (build, lint, 90%+ coverage on new code)
- [x] `internal/migration`, `internal/namespace`, `internal/plugin` unit tests
- [ ] PR 2 will consume these types