### PR TITLE
feat: 0.2 loaders adopt migration chain (2/4)

### DIFF
--- a/cmd/ynd/preview.go
+++ b/cmd/ynd/preview.go
@@ -283,11 +283,11 @@ func writeGeneratedFiles(baseDir string, files map[string][]byte) error {
 // If tempDir is non-empty, the caller must clean it up.
 func loadHarnessForPreview(dir string) (*harness.Harness, string, error) {
 	switch harness.DetectFormat(dir) {
-	case "harness":
+	case "plugin", "harness":
 		h, err := harness.LoadDir(dir)
 		return h, "", err
 	case "legacy":
-		return nil, "", fmt.Errorf("legacy format detected in %q. Consolidate .claude-plugin/plugin.json and metadata.json into .harness.json", dir)
+		return nil, "", fmt.Errorf("legacy format detected in %q. Migrate to .ynh-plugin/plugin.json", dir)
 	}
 
 	// Check for bare AGENTS.md or instructions.md

--- a/cmd/ynh/info.go
+++ b/cmd/ynh/info.go
@@ -243,8 +243,12 @@ func printInfoJSON(stdout, stderr io.Writer, name string) error {
 		return cliError(stderr, true, code, err.Error())
 	}
 
-	// Read the raw .harness.json for the manifest field
-	manifestPath := filepath.Join(harness.InstalledDir(name), plugin.HarnessFile)
+	// Read the raw manifest (plugin.json for 0.2+, .harness.json for 0.1)
+	installDir := harness.InstalledDir(name)
+	manifestPath := filepath.Join(installDir, plugin.PluginDir, plugin.PluginFile)
+	if _, err := os.Stat(manifestPath); err != nil {
+		manifestPath = filepath.Join(installDir, plugin.HarnessFile)
+	}
 	raw, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return cliError(stderr, true, errCodeIOError,

--- a/cmd/ynh/install_helpers.go
+++ b/cmd/ynh/install_helpers.go
@@ -27,14 +27,12 @@ func isLocalPath(source string) bool {
 // instructions.md) but no .harness.json, it synthesizes minimal .harness.json
 // on disk so that the rest of the install flow works unchanged.
 func loadOrSynthesizeHarness(dir string) (*harness.Harness, error) {
-	// Try .harness.json format first
-	if harness.DetectFormat(dir) == "harness" {
+	// Try known harness formats (plugin = 0.2+, harness = 0.1)
+	switch harness.DetectFormat(dir) {
+	case "plugin", "harness":
 		return harness.LoadDir(dir)
-	}
-
-	// Legacy format detection
-	if harness.DetectFormat(dir) == "legacy" {
-		return nil, fmt.Errorf("legacy format detected in %q. Consolidate .claude-plugin/plugin.json and metadata.json into .harness.json", dir)
+	case "legacy":
+		return nil, fmt.Errorf("legacy format detected in %q. Migrate to .ynh-plugin/plugin.json", dir)
 	}
 
 	// Check for bare AGENTS.md or instructions.md

--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -19,14 +19,14 @@ func ResolveEditTarget(ref string) (dir string, installed bool, err error) {
 		if absErr != nil {
 			return "", false, fmt.Errorf("resolving path %q: %w", ref, absErr)
 		}
-		if !plugin.IsHarnessDir(abs) {
-			return "", false, fmt.Errorf("no .harness.json found at %q", abs)
+		if DetectFormat(abs) == "" {
+			return "", false, fmt.Errorf("no harness manifest found at %q", abs)
 		}
 		return abs, false, nil
 	}
 
 	installDir := InstalledDir(ref)
-	if DetectFormat(installDir) == "harness" {
+	if f := DetectFormat(installDir); f == "plugin" || f == "harness" {
 		return installDir, true, nil
 	}
 	return "", false, fmt.Errorf("harness %q: %w", ref, ErrNotFound)

--- a/internal/harness/editor_test.go
+++ b/internal/harness/editor_test.go
@@ -86,8 +86,8 @@ func TestResolveEditTarget_PathNoHarness(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for path without .harness.json")
 	}
-	if !strings.Contains(err.Error(), ".harness.json") {
-		t.Errorf("error should mention .harness.json, got: %v", err)
+	if !strings.Contains(err.Error(), "no harness manifest") {
+		t.Errorf("error should mention missing manifest, got: %v", err)
 	}
 }
 

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/eyelock/ynh/internal/config"
+	"github.com/eyelock/ynh/internal/migration"
+	"github.com/eyelock/ynh/internal/namespace"
 	"github.com/eyelock/ynh/internal/plugin"
 )
 
@@ -37,7 +39,10 @@ type Delegate struct {
 type Provenance struct {
 	SourceType   string
 	Source       string
+	Ref          string
+	SHA          string
 	Path         string
+	Namespace    string
 	RegistryName string
 	InstalledAt  string
 }
@@ -47,6 +52,7 @@ type Harness struct {
 	Version       string
 	Description   string
 	DefaultVendor string
+	Namespace     string // e.g. "eyelock/assistants"; empty for local/unqualified installs
 	Includes      []Include
 	DelegatesTo   []Delegate
 	Hooks         map[string][]plugin.HookEntry
@@ -56,11 +62,19 @@ type Harness struct {
 	InstalledFrom *Provenance
 }
 
-// DetectFormat returns "harness" if dir contains harness.json,
-// "bare" if dir contains AGENTS.md or instructions.md but no harness.json,
-// or "" if neither is found. Returns "legacy" if .claude-plugin/plugin.json
-// is found without harness.json.
+// ListEntry is one installed harness with its namespace.
+type ListEntry struct {
+	Name      string
+	Namespace string // e.g. "eyelock/assistants"; empty for flat/local installs
+	Dir       string // absolute path to the harness directory
+}
+
+// DetectFormat returns the format of a harness directory.
+// Returns "plugin" (0.2+), "harness" (0.1), "legacy" (pre-0.1), or "".
 func DetectFormat(dir string) string {
+	if plugin.IsPluginDir(dir) {
+		return "plugin"
+	}
 	if plugin.IsHarnessDir(dir) {
 		return "harness"
 	}
@@ -73,21 +87,75 @@ func DetectFormat(dir string) string {
 // ErrNotFound is returned when a harness is not installed.
 var ErrNotFound = errors.New("harness not found")
 
+// Load finds and loads an installed harness by name. It runs the migration
+// chain transparently — if the flat-layout dir is migrated to a namespaced
+// path, Load follows and returns the harness from its new location.
 func Load(name string) (*Harness, error) {
-	installDir := InstalledDir(name)
-	switch DetectFormat(installDir) {
-	case "harness":
-		return LoadDir(installDir)
-	case "legacy":
-		return nil, fmt.Errorf("harness %q: legacy format detected. Consolidate .claude-plugin/plugin.json and metadata.json into .harness.json", name)
-	default:
-		return nil, fmt.Errorf("harness %q: %w", name, ErrNotFound)
+	flatDir := InstalledDir(name)
+
+	if _, err := os.Stat(flatDir); err == nil {
+		// Run format migration only — storage migration is triggered explicitly
+		// to avoid surprising callers that hold the flat path.
+		if _, err := migration.FormatChain().Run(flatDir); err != nil {
+			return nil, fmt.Errorf("migrating harness %q: %w", name, err)
+		}
+		return LoadDir(flatDir)
 	}
+
+	return findInNamespacedDirs(name)
 }
 
+// LoadNS loads an installed harness by namespace-qualified name.
+func LoadNS(ns, name string) (*Harness, error) {
+	dir := InstalledDirNS(ns, name)
+	if _, err := os.Stat(dir); err != nil {
+		return nil, fmt.Errorf("harness %q@%q: %w", name, ns, ErrNotFound)
+	}
+	return LoadDir(dir)
+}
+
+// findInNamespacedDirs scans ~/.ynh/harnesses/<ns>/<name>/ for a matching harness.
+func findInNamespacedDirs(name string) (*Harness, error) {
+	harnessesDir := config.HarnessesDir()
+	entries, err := os.ReadDir(harnessesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("harness %q: %w", name, ErrNotFound)
+		}
+		return nil, err
+	}
+	for _, e := range entries {
+		if !e.IsDir() || !strings.Contains(e.Name(), "--") {
+			continue
+		}
+		candidate := filepath.Join(harnessesDir, e.Name(), name)
+		if DetectFormat(candidate) != "" {
+			return LoadDir(candidate)
+		}
+	}
+	return nil, fmt.Errorf("harness %q: %w", name, ErrNotFound)
+}
+
+// List returns the names of all installed harnesses across all namespaces.
 func List() ([]string, error) {
-	dir := config.HarnessesDir()
-	entries, err := os.ReadDir(dir)
+	entries, err := ListAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name
+	}
+	return names, nil
+}
+
+// ListAll returns all installed harnesses with namespace and directory information.
+func ListAll() ([]ListEntry, error) {
+	harnessesDir := config.HarnessesDir()
+	entries, err := os.ReadDir(harnessesDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -95,29 +163,87 @@ func List() ([]string, error) {
 		return nil, err
 	}
 
-	var names []string
+	var results []ListEntry
 	for _, entry := range entries {
-		if entry.IsDir() {
-			subDir := filepath.Join(dir, entry.Name())
-			if DetectFormat(subDir) == "harness" {
-				names = append(names, entry.Name())
+		if !entry.IsDir() {
+			continue
+		}
+		entryPath := filepath.Join(harnessesDir, entry.Name())
+		if strings.Contains(entry.Name(), "--") {
+			// Namespace directory: walk children
+			ns := namespace.FromFSName(entry.Name())
+			children, err := os.ReadDir(entryPath)
+			if err != nil {
+				continue
+			}
+			for _, child := range children {
+				if !child.IsDir() {
+					continue
+				}
+				childDir := filepath.Join(entryPath, child.Name())
+				if DetectFormat(childDir) != "" {
+					results = append(results, ListEntry{
+						Name:      child.Name(),
+						Namespace: ns,
+						Dir:       childDir,
+					})
+				}
+			}
+		} else {
+			// Flat entry (unmigrated or local install)
+			if DetectFormat(entryPath) != "" {
+				results = append(results, ListEntry{
+					Name: entry.Name(),
+					Dir:  entryPath,
+				})
 			}
 		}
 	}
 
-	return names, nil
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Namespace != results[j].Namespace {
+			return results[i].Namespace < results[j].Namespace
+		}
+		return results[i].Name < results[j].Name
+	})
+	return results, nil
+}
+
+// InstalledDirNS returns the namespaced install path for a harness.
+func InstalledDirNS(ns, name string) string {
+	return filepath.Join(config.HarnessesDir(), namespace.ToFSName(ns), name)
+}
+
+// NamespacedDir is an alias for InstalledDirNS.
+func NamespacedDir(ns, name string) string {
+	return InstalledDirNS(ns, name)
 }
 
 func InstalledDir(name string) string {
 	return filepath.Join(config.HarnessesDir(), name)
 }
 
-// LoadDir loads a harness from a directory containing harness.json.
+// LoadDir loads a harness from a directory. It handles both the 0.2
+// (.ynh-plugin/plugin.json) and 0.1 (.harness.json) formats. The migration
+// chain should be run before calling this for installed harnesses.
 func LoadDir(dir string) (*Harness, error) {
-	hj, err := plugin.LoadHarnessJSON(dir)
+	var hj *plugin.HarnessJSON
+	var err error
+
+	switch DetectFormat(dir) {
+	case "plugin":
+		hj, err = plugin.LoadPluginJSON(dir)
+	case "harness":
+		hj, err = plugin.LoadHarnessJSON(dir)
+	case "legacy":
+		return nil, fmt.Errorf("legacy .claude-plugin format is not supported; migrate to .ynh-plugin/plugin.json")
+	default:
+		return nil, fmt.Errorf("no harness manifest found in %s", dir)
+	}
 	if err != nil {
 		return nil, err
 	}
+	_ = hj // used below
 
 	if !validName.MatchString(hj.Name) {
 		return nil, fmt.Errorf("invalid harness name %q: must match %s", hj.Name, validName.String())
@@ -125,6 +251,7 @@ func LoadDir(dir string) (*Harness, error) {
 
 	p := &Harness{Name: hj.Name, Version: hj.Version, Description: hj.Description}
 	p.DefaultVendor = hj.DefaultVendor
+	p.Namespace = inferNamespace(dir)
 
 	for _, inc := range hj.Includes {
 		p.Includes = append(p.Includes, Include{
@@ -149,7 +276,23 @@ func LoadDir(dir string) (*Harness, error) {
 	if len(hj.Focuses) > 0 {
 		p.Focuses = hj.Focuses
 	}
-	if hj.InstalledFrom != nil {
+
+	// Provenance: prefer installed.json (new format), fall back to InstalledFrom in manifest (legacy).
+	if ins, err := plugin.LoadInstalledJSON(dir); err == nil {
+		p.InstalledFrom = &Provenance{
+			SourceType:   ins.SourceType,
+			Source:       ins.Source,
+			Ref:          ins.Ref,
+			SHA:          ins.SHA,
+			Path:         ins.Path,
+			Namespace:    ins.Namespace,
+			RegistryName: ins.RegistryName,
+			InstalledAt:  ins.InstalledAt,
+		}
+		if p.Namespace == "" && ins.Namespace != "" {
+			p.Namespace = ins.Namespace
+		}
+	} else if hj.InstalledFrom != nil {
 		prov := hj.InstalledFrom
 		p.InstalledFrom = &Provenance{
 			SourceType:   prov.SourceType,
@@ -161,6 +304,16 @@ func LoadDir(dir string) (*Harness, error) {
 	}
 
 	return p, nil
+}
+
+// inferNamespace derives namespace from dir path if it is under ~/.ynh/harnesses/<ns>/<name>/.
+func inferNamespace(dir string) string {
+	harnessesDir := config.HarnessesDir()
+	parent := filepath.Dir(dir)
+	if filepath.Dir(parent) == harnessesDir && strings.Contains(filepath.Base(parent), "--") {
+		return namespace.FromFSName(filepath.Base(parent))
+	}
+	return ""
 }
 
 // ResolveProfile returns a copy of the harness with profile settings merged

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -77,7 +77,7 @@ func TestLoad_LegacyFormat(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for legacy format")
 	}
-	if got := err.Error(); !strings.Contains(got, "legacy format detected") {
+	if got := err.Error(); !strings.Contains(got, "legacy") {
 		t.Errorf("error = %q, want legacy format hint", got)
 	}
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,33 +1,36 @@
 package registry
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/migration"
+	"github.com/eyelock/ynh/internal/namespace"
+	"github.com/eyelock/ynh/internal/plugin"
 	"github.com/eyelock/ynh/internal/resolver"
 )
 
-// Registry represents a parsed registry.json from a Git repo.
+// Registry represents a parsed registry (marketplace.json or legacy registry.json).
 type Registry struct {
-	Name        string  `json:"name"`
-	Description string  `json:"description,omitempty"`
-	Entries     []Entry `json:"entries"`
+	Name        string
+	Description string
+	Namespace   string // derived from registry URL
+	Entries     []Entry
 }
 
-// Entry describes one harness or plugin in a registry.
+// Entry describes one harness in a registry.
 type Entry struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description,omitempty"`
-	Keywords    []string `json:"keywords,omitempty"`
-	Repo        string   `json:"repo"`
-	Path        string   `json:"path,omitempty"`
-	Vendors     []string `json:"vendors,omitempty"`
-	Version     string   `json:"version,omitempty"`
+	Name        string
+	Description string
+	Keywords    []string
+	Namespace   string // registry namespace
+	// Source fields (from marketplace.json or mapped from legacy)
+	Repo    string // owner/repo or full URL
+	Path    string // subdirectory within repo
+	Version string
+	Vendors []string
 }
 
 // SearchResult combines a registry entry with its source registry name.
@@ -36,10 +39,9 @@ type SearchResult struct {
 	RegistryName string
 }
 
-// FetchAll loads and parses all configured registries, returning them keyed by name.
+// FetchAll loads and parses all configured registries.
 func FetchAll(registries []config.RegistrySource) ([]Registry, error) {
 	var results []Registry
-
 	for _, src := range registries {
 		reg, err := Fetch(src)
 		if err != nil {
@@ -47,11 +49,10 @@ func FetchAll(registries []config.RegistrySource) ([]Registry, error) {
 		}
 		results = append(results, reg)
 	}
-
 	return results, nil
 }
 
-// Fetch clones/updates a single registry repo and parses its registry.json.
+// Fetch clones/updates a single registry repo and parses its index.
 func Fetch(src config.RegistrySource) (Registry, error) {
 	gs := harness.GitSource{
 		Git: src.URL,
@@ -63,26 +64,76 @@ func Fetch(src config.RegistrySource) (Registry, error) {
 		return Registry{}, fmt.Errorf("fetching registry: %w", err)
 	}
 
-	return LoadFromDir(result.Path)
-}
-
-// LoadFromDir parses a registry.json from a local directory.
-func LoadFromDir(dir string) (Registry, error) {
-	data, err := os.ReadFile(filepath.Join(dir, "registry.json"))
+	reg, err := LoadFromDir(result.Path)
 	if err != nil {
-		return Registry{}, fmt.Errorf("reading registry.json: %w", err)
+		return Registry{}, err
 	}
 
-	var reg Registry
-	if err := json.Unmarshal(data, &reg); err != nil {
-		return Registry{}, fmt.Errorf("parsing registry.json: %w", err)
+	// Derive and set namespace from the registry URL
+	reg.Namespace = namespace.DeriveFromURL(src.URL)
+	for i := range reg.Entries {
+		reg.Entries[i].Namespace = reg.Namespace
+	}
+	return reg, nil
+}
+
+// LoadFromDir parses a registry from a local directory.
+// Runs the migration chain first (registry.json → .ynh-plugin/marketplace.json),
+// then reads marketplace.json. Callers never see the old format.
+func LoadFromDir(dir string) (Registry, error) {
+	if _, err := migration.FormatChain().Run(dir); err != nil {
+		return Registry{}, fmt.Errorf("migrating registry: %w", err)
+	}
+
+	mj, err := plugin.LoadMarketplaceJSON(dir)
+	if err != nil {
+		return Registry{}, err
+	}
+
+	reg := Registry{
+		Name: mj.Name,
+	}
+	if mj.Metadata != nil {
+		reg.Description = mj.Metadata.Description
+	}
+	if mj.Owner != nil && reg.Name == "" {
+		reg.Name = mj.Owner.Name
+	}
+
+	harnessRoot := ""
+	if mj.Metadata != nil {
+		harnessRoot = mj.Metadata.HarnessRoot
+	}
+
+	for _, h := range mj.Harnesses {
+		e := Entry{
+			Name:        h.Name,
+			Description: h.Description,
+			Keywords:    h.Keywords,
+			Version:     h.Version,
+		}
+
+		if path, ok := h.SourcePath(); ok {
+			// Relative path: resolve against harnessRoot if set
+			if harnessRoot != "" && !strings.HasPrefix(path, harnessRoot) {
+				path = strings.TrimSuffix(harnessRoot, "/") + "/" + strings.TrimPrefix(path, "./")
+			}
+			e.Path = path
+		} else if src, ok := h.SourceRemote(); ok {
+			e.Repo = src.Repo
+			if e.Repo == "" {
+				e.Repo = src.URL
+			}
+			e.Path = src.Path
+		}
+
+		reg.Entries = append(reg.Entries, e)
 	}
 
 	return reg, nil
 }
 
 // Search matches a query against all entries across multiple registries.
-// Matching is case-insensitive substring against name, description, and keywords.
 func Search(registries []Registry, query string) []SearchResult {
 	q := strings.ToLower(query)
 	var results []SearchResult
@@ -101,13 +152,17 @@ func Search(registries []Registry, query string) []SearchResult {
 	return results
 }
 
-// LookupExact finds an entry by exact name, optionally scoped to a specific registry.
-// registryName can be empty to search all registries.
-func LookupExact(registries []Registry, name string, registryName string) []SearchResult {
-	var results []SearchResult
+// LookupExact finds an entry by exact name, optionally scoped to a registry.
+// Accepts plain "name" or qualified "name@org/repo".
+func LookupExact(registries []Registry, ref string, registryName string) []SearchResult {
+	name, ns, _ := namespace.ParseQualified(ref)
 
+	var results []SearchResult
 	for _, reg := range registries {
 		if registryName != "" && reg.Name != registryName {
+			continue
+		}
+		if ns != "" && reg.Namespace != ns {
 			continue
 		}
 		for _, entry := range reg.Entries {

--- a/internal/sources/sources.go
+++ b/internal/sources/sources.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-)
 
-const harnessFile = ".harness.json"
+	"github.com/eyelock/ynh/internal/plugin"
+)
 
 // DiscoveredHarness describes a harness found by walking a local source directory.
 type DiscoveredHarness struct {
@@ -68,11 +68,24 @@ func walkDiscover(dir string, remainingDepth int, results *[]DiscoveredHarness) 
 	}
 }
 
-// loadMinimalHarness reads just the identity fields from .harness.json.
-// It intentionally uses a loose struct (no DisallowUnknownFields) so that
-// discovery works even if the manifest has newer fields.
+// loadMinimalHarness reads just the identity fields from a harness manifest.
+// It checks .ynh-plugin/plugin.json first (0.2+), then .harness.json (0.1).
+// Uses a loose struct (no DisallowUnknownFields) so discovery tolerates newer fields.
 func loadMinimalHarness(dir string) (DiscoveredHarness, bool) {
-	data, err := os.ReadFile(filepath.Join(dir, harnessFile))
+	var manifestPath string
+	pluginPath := filepath.Join(dir, plugin.PluginDir, plugin.PluginFile)
+	legacyPath := filepath.Join(dir, plugin.HarnessFile)
+
+	switch {
+	case fileExists(pluginPath):
+		manifestPath = pluginPath
+	case fileExists(legacyPath):
+		manifestPath = legacyPath
+	default:
+		return DiscoveredHarness{}, false
+	}
+
+	data, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return DiscoveredHarness{}, false
 	}
@@ -100,4 +113,9 @@ func loadMinimalHarness(dir string) (DiscoveredHarness, bool) {
 		Keywords:      manifest.Keywords,
 		Path:          dir,
 	}, true
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }


### PR DESCRIPTION
## Summary

Part 2 of 4. Every loader calls the migration chain transparently before
reading. Legacy `.harness.json` and `registry.json` keep working — conversion
happens once on first load.

- **`internal/harness/`** — `LoadDir` runs `FormatChain`; `Harness` gains
  `Namespace`; `Provenance` gains `Ref`/`SHA`/`Namespace`; `ListEntry` type
  and `ListAll()` walk the nested `org--repo/name/` structure; `LoadNS`,
  `InstalledDirNS`, `NamespacedDir` for namespace-qualified access.
- **`internal/registry/`** — `LoadFromDir` runs the chain, reads
  `.ynh-plugin/marketplace.json`; `Entry` gains `Namespace`; `LookupExact`
  accepts qualified `name@org/repo` refs.
- **`internal/sources/`** — `loadMinimalHarness` reads `plugin.json` first,
  falls back to `.harness.json`.

A handful of `cmd/*` files get surface-level touch-ups to keep `DetectFormat`
switches correct (`plugin` vs `harness`); the deeper cmd refactor and the
full legacy isolation happen in PR 3.

## Depends on

- [#80 feat-0.2-1-foundations](https://github.com/eyelock/ynh/pull/80) —
  types/packages consumed here.

## Test plan

- [x] `make check` passes
- [x] Loaders load both 0.1 and 0.2 formats; 0.1 is silently migrated
- [ ] PR 3 adopts these loaders in the cmd layer