### PR TITLE
feat: 0.2 cmd — namespaced install, @ syntax, ynd migrate (3/4)

### DIFF
--- a/cmd/ynd/create.go
+++ b/cmd/ynd/create.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -154,26 +153,15 @@ func createHarness(name, description, vendor string) error {
 		}
 	}
 
-	type scaffoldJSON struct {
-		Schema        string `json:"$schema"`
-		Name          string `json:"name"`
-		Version       string `json:"version"`
-		Description   string `json:"description,omitempty"`
-		DefaultVendor string `json:"default_vendor"`
-	}
-	scaffold := scaffoldJSON{
-		Schema:        "https://eyelock.github.io/ynh/schema/harness.schema.json",
+	hj := &plugin.HarnessJSON{
+		Schema:        "https://eyelock.github.io/ynh/schema/plugin.schema.json",
 		Name:          name,
 		Version:       "0.1.0",
 		Description:   description,
 		DefaultVendor: resolveVendorDefault(vendor),
 	}
-	data, err := json.MarshalIndent(scaffold, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshalling .harness.json: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(name, plugin.HarnessFile), append(data, '\n'), 0o644); err != nil {
-		return err
+	if err := plugin.SavePluginJSON(name, hj); err != nil {
+		return fmt.Errorf("writing plugin.json: %w", err)
 	}
 
 	instructions := fmt.Sprintf(`# %s
@@ -185,7 +173,7 @@ Project-level instructions that apply to every session with this harness.
 	}
 
 	fmt.Printf("Created harness %q:\n", name)
-	fmt.Printf("  %s/%s\n", name, plugin.HarnessFile)
+	fmt.Printf("  %s/%s/%s\n", name, plugin.PluginDir, plugin.PluginFile)
 	fmt.Printf("  %s/AGENTS.md\n", name)
 	fmt.Printf("  %s/skills/\n", name)
 	fmt.Printf("  %s/agents/\n", name)

--- a/cmd/ynd/create_test.go
+++ b/cmd/ynd/create_test.go
@@ -102,7 +102,7 @@ func TestCreateHarness(t *testing.T) {
 	}
 
 	expectedFiles := []string{
-		"my-team/.harness.json",
+		"my-team/.ynh-plugin/plugin.json",
 		"my-team/AGENTS.md",
 	}
 	for _, f := range expectedFiles {
@@ -127,7 +127,7 @@ func TestCreateHarness(t *testing.T) {
 	}
 
 	// Verify .harness.json content
-	data, err := os.ReadFile(filepath.Join(dir, "my-team/.harness.json"))
+	data, err := os.ReadFile(filepath.Join(dir, "my-team/.ynh-plugin/plugin.json"))
 	if err != nil {
 		t.Fatalf("reading .harness.json: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestCreateHarness_VendorEnvVar(t *testing.T) {
 		t.Fatalf("createHarness failed: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(dir, "vendor-test/.harness.json"))
+	data, err := os.ReadFile(filepath.Join(dir, "vendor-test/.ynh-plugin/plugin.json"))
 	if err != nil {
 		t.Fatalf("reading .harness.json: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestCreateHarness_WithDescription(t *testing.T) {
 		t.Fatalf("cmdCreate: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(dir, "my-harness/.harness.json"))
+	data, err := os.ReadFile(filepath.Join(dir, "my-harness/.ynh-plugin/plugin.json"))
 	if err != nil {
 		t.Fatalf("reading .harness.json: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestCreateHarness_WithVendor(t *testing.T) {
 		t.Fatalf("cmdCreate: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(dir, "my-harness/.harness.json"))
+	data, err := os.ReadFile(filepath.Join(dir, "my-harness/.ynh-plugin/plugin.json"))
 	if err != nil {
 		t.Fatalf("reading .harness.json: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestCreateHarness_WithDescriptionAndVendor(t *testing.T) {
 		t.Fatalf("cmdCreate: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(dir, "my-harness/.harness.json"))
+	data, err := os.ReadFile(filepath.Join(dir, "my-harness/.ynh-plugin/plugin.json"))
 	if err != nil {
 		t.Fatalf("reading .harness.json: %v", err)
 	}
@@ -270,7 +270,7 @@ func TestCreateHarness_NoDescriptionOmitsField(t *testing.T) {
 		t.Fatalf("cmdCreate: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(dir, "my-harness/.harness.json"))
+	data, err := os.ReadFile(filepath.Join(dir, "my-harness/.ynh-plugin/plugin.json"))
 	if err != nil {
 		t.Fatalf("reading .harness.json: %v", err)
 	}
@@ -464,8 +464,8 @@ func TestCmdCreate_Harness(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "test-harness", ".harness.json")); err != nil {
-		t.Error("expected .harness.json to exist")
+	if _, err := os.Stat(filepath.Join(dir, "test-harness", ".ynh-plugin", "plugin.json")); err != nil {
+		t.Error("expected .ynh-plugin/plugin.json to exist")
 	}
 }
 

--- a/cmd/ynd/export.go
+++ b/cmd/ynd/export.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/exporter"
+	"github.com/eyelock/ynh/internal/migration"
 	"github.com/eyelock/ynh/internal/plugin"
 	"github.com/eyelock/ynh/internal/resolver"
 	"github.com/eyelock/ynh/internal/vendor"
@@ -110,17 +111,15 @@ func cmdExport(args []string) error {
 		}
 	}
 
-	// Determine output directory
+	// Determine output directory. Migration chain runs in harness.LoadDir below,
+	// so we convert any legacy source format transparently before reading.
 	if outputDir == "" {
-		var pj *plugin.HarnessJSON
-		var err error
-		if plugin.IsPluginDir(srcDir) {
-			pj, err = plugin.LoadPluginJSON(srcDir)
-		} else {
-			pj, err = plugin.LoadHarnessJSON(srcDir)
+		if _, err := migration.FormatChain().Run(srcDir); err != nil {
+			return fmt.Errorf("migrating source format: %w", err)
 		}
+		pj, err := plugin.LoadPluginJSON(srcDir)
 		if err != nil {
-			return fmt.Errorf("loading manifest for name: %w", err)
+			return fmt.Errorf("loading plugin.json for name: %w", err)
 		}
 		outputDir = filepath.Join(".", "dist", pj.Name)
 	}

--- a/cmd/ynd/export.go
+++ b/cmd/ynd/export.go
@@ -112,9 +112,15 @@ func cmdExport(args []string) error {
 
 	// Determine output directory
 	if outputDir == "" {
-		pj, err := plugin.LoadHarnessJSON(srcDir)
+		var pj *plugin.HarnessJSON
+		var err error
+		if plugin.IsPluginDir(srcDir) {
+			pj, err = plugin.LoadPluginJSON(srcDir)
+		} else {
+			pj, err = plugin.LoadHarnessJSON(srcDir)
+		}
 		if err != nil {
-			return fmt.Errorf("loading .harness.json for name: %w", err)
+			return fmt.Errorf("loading manifest for name: %w", err)
 		}
 		outputDir = filepath.Join(".", "dist", pj.Name)
 	}

--- a/cmd/ynd/lint.go
+++ b/cmd/ynd/lint.go
@@ -50,7 +50,7 @@ func cmdLint(args []string) error {
 
 	files, err := discoverAll(root,
 		[]string{".md", ".sh"},
-		[]string{plugin.HarnessFile, plugin.PluginFile},
+		[]string{plugin.PluginFile},
 	)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func cmdLint(args []string) error {
 			issues = append(issues, lintMarkdown(f)...)
 		case strings.HasSuffix(f, ".sh"):
 			issues = append(issues, lintShell(f)...)
-		case filepath.Base(f) == plugin.HarnessFile, filepath.Base(f) == plugin.PluginFile:
+		case filepath.Base(f) == plugin.PluginFile:
 			issues = append(issues, lintHarnessJSONFile(f)...)
 		}
 	}

--- a/cmd/ynd/lint.go
+++ b/cmd/ynd/lint.go
@@ -50,7 +50,7 @@ func cmdLint(args []string) error {
 
 	files, err := discoverAll(root,
 		[]string{".md", ".sh"},
-		[]string{plugin.HarnessFile},
+		[]string{plugin.HarnessFile, plugin.PluginFile},
 	)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func cmdLint(args []string) error {
 			issues = append(issues, lintMarkdown(f)...)
 		case strings.HasSuffix(f, ".sh"):
 			issues = append(issues, lintShell(f)...)
-		case filepath.Base(f) == plugin.HarnessFile:
+		case filepath.Base(f) == plugin.HarnessFile, filepath.Base(f) == plugin.PluginFile:
 			issues = append(issues, lintHarnessJSONFile(f)...)
 		}
 	}

--- a/cmd/ynd/lint_test.go
+++ b/cmd/ynd/lint_test.go
@@ -470,11 +470,11 @@ func TestCmdLint_IssueWithoutLineNumber(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	writeFile(t, filepath.Join(dir, ".harness.json"), []byte(`{}`))
+	writeFile(t, filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(`{}`))
 
 	err := cmdLint(nil)
 	if err == nil {
-		t.Fatal("expected lint error for .harness.json missing fields")
+		t.Fatal("expected lint error for plugin.json missing fields")
 	}
 }
 

--- a/cmd/ynd/main.go
+++ b/cmd/ynd/main.go
@@ -41,6 +41,8 @@ func main() {
 		err = cmdDiff(os.Args[2:])
 	case "marketplace":
 		err = cmdMarketplace(os.Args[2:])
+	case "migrate":
+		err = cmdMigrate(os.Args[2:])
 	case "version", "--version", "-v":
 		fmt.Println(config.Version)
 	case "help", "--help", "-h":
@@ -77,6 +79,7 @@ Commands:
   preview <source>           Show assembled vendor output without installing
   diff <source> [vendors]    Compare assembled output across vendors
   marketplace build          Build a vendor-native marketplace from marketplace.json
+  migrate <path>             Convert .harness.json → .ynh-plugin/plugin.json in-place
   version                    Print version
   help                       Show this help
 

--- a/cmd/ynd/migrate.go
+++ b/cmd/ynd/migrate.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/eyelock/ynh/internal/migration"
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// cmdMigrate runs the format migration chain against a directory.
+// Idempotent — the chain no-ops when no migrator applies.
+//
+// The command itself knows nothing about specific migrations. Adding or
+// removing a migrator in internal/migration/ changes what this command
+// handles automatically. Storage relocation is intentionally excluded;
+// ynh itself triggers that when installing or relocating harnesses.
+//
+// Supports -r/--recursive to walk a tree and migrate every directory that
+// any registered migrator applies to.
+func cmdMigrate(args []string) error {
+	recursive := false
+	var target string
+
+	for _, a := range args {
+		switch a {
+		case "-r", "--recursive":
+			recursive = true
+		case "-h", "--help":
+			printMigrateUsage()
+			return nil
+		default:
+			if target != "" {
+				return fmt.Errorf("unexpected argument %q", a)
+			}
+			target = a
+		}
+	}
+
+	if target == "" {
+		target = "."
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		return fmt.Errorf("target %q: %w", target, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("target %q is not a directory", target)
+	}
+
+	chain := migration.FormatChain()
+
+	dirs := []string{target}
+	if recursive {
+		dirs = findMigratableDirs(target, chain)
+		if len(dirs) == 0 {
+			fmt.Printf("Nothing to migrate under %s\n", target)
+			return nil
+		}
+	}
+
+	migrated := 0
+	for _, dir := range dirs {
+		applied, err := chain.Run(dir)
+		if err != nil {
+			return fmt.Errorf("migrating %s: %w", dir, err)
+		}
+		if len(applied) > 0 {
+			fmt.Printf("Migrated %s\n", dir)
+			for _, d := range applied {
+				fmt.Printf("  %s\n", d)
+			}
+			migrated++
+		}
+	}
+
+	if migrated == 0 {
+		fmt.Println("Nothing to migrate.")
+	} else {
+		fmt.Printf("Migrated %d director(ies).\n", migrated)
+	}
+	return nil
+}
+
+// findMigratableDirs walks root and returns every directory where at least
+// one migrator in chain applies. The walker never enters .ynh-plugin/ subdirs
+// (migrator targets are the parent harness/registry dir).
+func findMigratableDirs(root string, chain migration.Chain) []string {
+	var dirs []string
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if d.Name() == plugin.PluginDir {
+			return filepath.SkipDir
+		}
+		for _, m := range chain {
+			if m.Applies(path) {
+				dirs = append(dirs, path)
+				return nil
+			}
+		}
+		return nil
+	})
+	return dirs
+}
+
+func printMigrateUsage() {
+	fmt.Println(`ynd migrate - run the format migration chain
+
+Runs every registered format migrator against the target directory.
+Migrators decide whether they apply based on the directory contents,
+so the command works for any format transition handled by the chain.
+
+Usage:
+  ynd migrate [path]              Migrate a single directory (default: .)
+  ynd migrate -r [path]           Recursively migrate all matching dirs under path
+
+Options:
+  -r, --recursive                 Walk the tree and migrate every matching dir
+  -h, --help                      Show this help`)
+}

--- a/cmd/ynd/preview.go
+++ b/cmd/ynd/preview.go
@@ -293,7 +293,7 @@ func loadHarnessForPreview(dir string) (*harness.Harness, string, error) {
 	// Check for bare AGENTS.md or instructions.md
 	hasInstructions := assembler.FindInstructionsFile(dir) != ""
 	if !hasInstructions {
-		return nil, "", fmt.Errorf("directory %q has no .harness.json or AGENTS.md", dir)
+		return nil, "", fmt.Errorf("directory %q has no .ynh-plugin/plugin.json, .harness.json, or AGENTS.md", dir)
 	}
 
 	// Copy to temp dir to avoid mutating source
@@ -314,14 +314,14 @@ func loadHarnessForPreview(dir string) (*harness.Harness, string, error) {
 		return nil, "", fmt.Errorf("copying source: %w", err)
 	}
 
-	// Synthesize minimal harness.json
+	// Synthesize minimal plugin.json
 	name := filepath.Base(dir)
 	hj := &plugin.HarnessJSON{
 		Name:    name,
 		Version: "0.0.0",
 	}
-	if err := plugin.SaveHarnessJSON(tmpDir, hj); err != nil {
-		return nil, "", fmt.Errorf("writing synthesized .harness.json: %w", err)
+	if err := plugin.SavePluginJSON(tmpDir, hj); err != nil {
+		return nil, "", fmt.Errorf("writing synthesized plugin.json: %w", err)
 	}
 
 	h, err := harness.LoadDir(tmpDir)

--- a/cmd/ynd/preview.go
+++ b/cmd/ynd/preview.go
@@ -283,17 +283,16 @@ func writeGeneratedFiles(baseDir string, files map[string][]byte) error {
 // If tempDir is non-empty, the caller must clean it up.
 func loadHarnessForPreview(dir string) (*harness.Harness, string, error) {
 	switch harness.DetectFormat(dir) {
-	case "plugin", "harness":
+	case "plugin":
 		h, err := harness.LoadDir(dir)
 		return h, "", err
 	case "legacy":
 		return nil, "", fmt.Errorf("legacy format detected in %q. Migrate to .ynh-plugin/plugin.json", dir)
 	}
 
-	// Check for bare AGENTS.md or instructions.md
-	hasInstructions := assembler.FindInstructionsFile(dir) != ""
-	if !hasInstructions {
-		return nil, "", fmt.Errorf("directory %q has no .ynh-plugin/plugin.json, .harness.json, or AGENTS.md", dir)
+	// No manifest: synthesize from AGENTS.md / instructions.md if present
+	if assembler.FindInstructionsFile(dir) == "" {
+		return nil, "", fmt.Errorf("directory %q has no harness manifest or AGENTS.md", dir)
 	}
 
 	// Copy to temp dir to avoid mutating source

--- a/cmd/ynd/validate.go
+++ b/cmd/ynd/validate.go
@@ -61,11 +61,11 @@ func cmdValidate(args []string) error {
 		}
 		// Check for legacy format
 		if isLegacyHarnessRoot(root) {
-			fmt.Println("Legacy format detected. Consolidate .claude-plugin/plugin.json and metadata.json into .harness.json.")
+			fmt.Println("Legacy format detected. Migrate .claude-plugin/plugin.json and metadata.json to .ynh-plugin/plugin.json.")
 			return fmt.Errorf("validation failed")
 		}
 		fmt.Println("No harness directories found.")
-		fmt.Println("A harness requires .harness.json")
+		fmt.Println("A harness requires .ynh-plugin/plugin.json (or legacy .harness.json).")
 		return nil
 	}
 
@@ -87,7 +87,7 @@ func validateFile(path string) error {
 	var issues []lintIssue
 
 	switch {
-	case base == plugin.HarnessFile:
+	case base == plugin.PluginFile || base == plugin.HarnessFile:
 		issues = lintHarnessJSON(path)
 	case base == "marketplace.json":
 		issues = lintMarketplaceConfig(path)
@@ -113,8 +113,25 @@ func validateFile(path string) error {
 }
 
 func isHarnessRoot(dir string) bool {
+	if plugin.IsPluginDir(dir) {
+		return true
+	}
 	_, err := os.Stat(filepath.Join(dir, plugin.HarnessFile))
 	return err == nil
+}
+
+// harnessManifestPath returns the path to the manifest file for dir.
+// Prefers .ynh-plugin/plugin.json; falls back to .harness.json. Empty if neither.
+func harnessManifestPath(dir string) string {
+	pluginPath := filepath.Join(dir, plugin.PluginDir, plugin.PluginFile)
+	if _, err := os.Stat(pluginPath); err == nil {
+		return pluginPath
+	}
+	legacyPath := filepath.Join(dir, plugin.HarnessFile)
+	if _, err := os.Stat(legacyPath); err == nil {
+		return legacyPath
+	}
+	return ""
 }
 
 func isLegacyHarnessRoot(dir string) bool {
@@ -157,24 +174,37 @@ func validateHarness(dir string) error {
 
 	// Check for legacy format
 	if isLegacyHarnessRoot(dir) && !isHarnessRoot(dir) {
-		issues = append(issues, "legacy format detected: consolidate .claude-plugin/plugin.json and metadata.json into .harness.json")
+		issues = append(issues, "legacy format detected: migrate .claude-plugin/plugin.json and metadata.json to .ynh-plugin/plugin.json")
 	}
 
-	// Check harness.json exists and is valid
-	harnessPath := filepath.Join(dir, plugin.HarnessFile)
-	data, err := os.ReadFile(harnessPath)
-	if err != nil {
-		issues = append(issues, "missing .harness.json")
+	// Check manifest exists (plugin.json or .harness.json) and is valid
+	manifestPath := harnessManifestPath(dir)
+	manifestLabel := "manifest"
+	if manifestPath == filepath.Join(dir, plugin.PluginDir, plugin.PluginFile) {
+		manifestLabel = ".ynh-plugin/plugin.json"
+	} else if manifestPath == filepath.Join(dir, plugin.HarnessFile) {
+		manifestLabel = ".harness.json"
+	}
+	var data []byte
+	var err error
+	if manifestPath == "" {
+		issues = append(issues, "missing manifest (.ynh-plugin/plugin.json or .harness.json)")
 	} else {
+		data, err = os.ReadFile(manifestPath)
+		if err != nil {
+			issues = append(issues, fmt.Sprintf("missing %s", manifestLabel))
+		}
+	}
+	if err == nil && data != nil {
 		var hj map[string]any
 		if err := json.Unmarshal(data, &hj); err != nil {
-			issues = append(issues, fmt.Sprintf("invalid .harness.json: %v", err))
+			issues = append(issues, fmt.Sprintf("invalid %s: %v", manifestLabel, err))
 		} else {
 			if _, ok := hj["name"]; !ok {
-				issues = append(issues, ".harness.json missing 'name'")
+				issues = append(issues, fmt.Sprintf("%s missing 'name'", manifestLabel))
 			}
 			if _, ok := hj["version"]; !ok {
-				issues = append(issues, ".harness.json missing 'version'")
+				issues = append(issues, fmt.Sprintf("%s missing 'version'", manifestLabel))
 			}
 			// Validate hooks
 			issues = append(issues, validateHarnessHooks(hj)...)

--- a/cmd/ynd/validate.go
+++ b/cmd/ynd/validate.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/eyelock/ynh/internal/marketplace"
+	"github.com/eyelock/ynh/internal/migration"
 	"github.com/eyelock/ynh/internal/plugin"
 )
 
@@ -87,7 +88,7 @@ func validateFile(path string) error {
 	var issues []lintIssue
 
 	switch {
-	case base == plugin.PluginFile || base == plugin.HarnessFile:
+	case base == plugin.PluginFile:
 		issues = lintHarnessJSON(path)
 	case base == "marketplace.json":
 		issues = lintMarketplaceConfig(path)
@@ -113,23 +114,20 @@ func validateFile(path string) error {
 }
 
 func isHarnessRoot(dir string) bool {
-	if plugin.IsPluginDir(dir) {
-		return true
-	}
-	_, err := os.Stat(filepath.Join(dir, plugin.HarnessFile))
-	return err == nil
+	// Run the migration chain first so a legacy .harness.json is converted
+	// transparently before we decide whether this dir is a harness root.
+	_, _ = migration.FormatChain().Run(dir)
+	return plugin.IsPluginDir(dir)
 }
 
-// harnessManifestPath returns the path to the manifest file for dir.
-// Prefers .ynh-plugin/plugin.json; falls back to .harness.json. Empty if neither.
+// harnessManifestPath returns the path to the manifest file for dir,
+// after running the migration chain so the result is always the new format
+// (or empty if no harness manifest exists).
 func harnessManifestPath(dir string) string {
+	_, _ = migration.FormatChain().Run(dir)
 	pluginPath := filepath.Join(dir, plugin.PluginDir, plugin.PluginFile)
 	if _, err := os.Stat(pluginPath); err == nil {
 		return pluginPath
-	}
-	legacyPath := filepath.Join(dir, plugin.HarnessFile)
-	if _, err := os.Stat(legacyPath); err == nil {
-		return legacyPath
 	}
 	return ""
 }
@@ -177,18 +175,14 @@ func validateHarness(dir string) error {
 		issues = append(issues, "legacy format detected: migrate .claude-plugin/plugin.json and metadata.json to .ynh-plugin/plugin.json")
 	}
 
-	// Check manifest exists (plugin.json or .harness.json) and is valid
+	// Migration chain runs inside harnessManifestPath so manifestPath is
+	// always the new format (or empty if no harness manifest exists).
 	manifestPath := harnessManifestPath(dir)
-	manifestLabel := "manifest"
-	if manifestPath == filepath.Join(dir, plugin.PluginDir, plugin.PluginFile) {
-		manifestLabel = ".ynh-plugin/plugin.json"
-	} else if manifestPath == filepath.Join(dir, plugin.HarnessFile) {
-		manifestLabel = ".harness.json"
-	}
+	const manifestLabel = ".ynh-plugin/plugin.json"
 	var data []byte
 	var err error
 	if manifestPath == "" {
-		issues = append(issues, "missing manifest (.ynh-plugin/plugin.json or .harness.json)")
+		issues = append(issues, "missing .ynh-plugin/plugin.json")
 	} else {
 		data, err = os.ReadFile(manifestPath)
 		if err != nil {

--- a/cmd/ynd/validate_test.go
+++ b/cmd/ynd/validate_test.go
@@ -14,7 +14,7 @@ func TestValidateHarness_Valid(t *testing.T) {
 	mkdirAll(t, filepath.Join(hr, "skills", "hello"))
 	mkdirAll(t, filepath.Join(hr, "agents"))
 
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"test-harness","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "skills", "hello", "SKILL.md"),
 		[]byte("---\nname: hello\ndescription: Say hello\n---\n\nHello skill.\n"))
@@ -45,7 +45,7 @@ func TestValidateHarness_MissingSkillMD(t *testing.T) {
 
 	hr := filepath.Join(dir, "bad-harness")
 	mkdirAll(t, filepath.Join(hr, "skills", "empty-skill"))
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"bad-harness","version":"0.1.0"}`))
 
 	err := validateHarness(hr)
@@ -61,7 +61,7 @@ func TestValidateHarness_SkillNameMismatch(t *testing.T) {
 	hr := filepath.Join(dir, "test-harness")
 	mkdirAll(t, filepath.Join(hr, "skills", "hello"))
 
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"test-harness","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "skills", "hello", "SKILL.md"),
 		[]byte("---\nname: wrong-name\ndescription: Say hello\n---\n"))
@@ -79,7 +79,7 @@ func TestValidateHarness_AgentMissingTools(t *testing.T) {
 	hr := filepath.Join(dir, "test-harness")
 	mkdirAll(t, filepath.Join(hr, "agents"))
 
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"test-harness","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "agents", "reviewer.md"),
 		[]byte("---\nname: reviewer\ndescription: Reviews code\n---\n"))
@@ -95,7 +95,7 @@ func TestFindHarnessRoots(t *testing.T) {
 
 	for _, name := range []string{"p1", "p2"} {
 		mkdirAll(t, filepath.Join(dir, name))
-		writeFile(t, filepath.Join(dir, name, ".harness.json"),
+		writeFile(t, filepath.Join(dir, name, ".ynh-plugin", "plugin.json"),
 			[]byte(`{"name":"`+name+`","version":"0.1.0"}`))
 	}
 
@@ -109,7 +109,7 @@ func TestFindHarnessRoots(t *testing.T) {
 
 func TestFindHarnessRoots_SelfIsHarness(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, ".harness.json"),
+	writeFile(t, filepath.Join(dir, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"self","version":"0.1.0"}`))
 
 	roots := findHarnessRoots(dir)
@@ -120,7 +120,7 @@ func TestFindHarnessRoots_SelfIsHarness(t *testing.T) {
 
 func TestIsHarnessRoot(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, ".harness.json"),
+	writeFile(t, filepath.Join(dir, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"test","version":"0.1.0"}`))
 
 	if !isHarnessRoot(dir) {
@@ -138,7 +138,7 @@ func TestCmdValidate_Dir(t *testing.T) {
 	t.Chdir(dir)
 
 	hr := filepath.Join(dir, "my-harness")
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"my-harness","version":"0.1.0"}`))
 
 	err := cmdValidate([]string{dir})
@@ -161,7 +161,7 @@ func TestCmdValidate_InsideHarness(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	writeFile(t, filepath.Join(dir, ".harness.json"),
+	writeFile(t, filepath.Join(dir, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"self","version":"0.1.0"}`))
 
 	err := cmdValidate(nil)
@@ -170,9 +170,9 @@ func TestCmdValidate_InsideHarness(t *testing.T) {
 	}
 }
 
-func TestCmdValidate_SingleFile_HarnessJSON(t *testing.T) {
+func TestCmdValidate_SingleFile_PluginJSON(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, ".harness.json")
+	path := filepath.Join(dir, ".ynh-plugin", "plugin.json")
 	writeFile(t, path, []byte(`{"name":"test","version":"0.1.0"}`))
 
 	err := cmdValidate([]string{path})
@@ -240,7 +240,7 @@ func TestValidateMarketplaceConfig_InvalidRemoteSource(t *testing.T) {
 
 func TestCmdValidate_SingleFile_WithIssues(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, ".harness.json")
+	path := filepath.Join(dir, ".ynh-plugin", "plugin.json")
 	writeFile(t, path, []byte(`{}`))
 
 	err := cmdValidate([]string{path})
@@ -251,7 +251,7 @@ func TestCmdValidate_SingleFile_WithIssues(t *testing.T) {
 
 func TestCmdValidate_HarnessFlag(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, ".harness.json"),
+	writeFile(t, filepath.Join(dir, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"flag-test","version":"0.1.0"}`))
 
 	err := cmdValidate([]string{"--harness", dir})
@@ -262,7 +262,7 @@ func TestCmdValidate_HarnessFlag(t *testing.T) {
 
 func TestCmdValidate_HarnessEnvVar(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, ".harness.json"),
+	writeFile(t, filepath.Join(dir, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"env-test","version":"0.1.0"}`))
 
 	t.Setenv("YNH_HARNESS", dir)
@@ -275,7 +275,7 @@ func TestCmdValidate_HarnessEnvVar(t *testing.T) {
 
 func TestCmdValidate_HarnessFlagOverridesEnv(t *testing.T) {
 	goodDir := t.TempDir()
-	writeFile(t, filepath.Join(goodDir, ".harness.json"),
+	writeFile(t, filepath.Join(goodDir, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"good","version":"0.1.0"}`))
 
 	t.Setenv("YNH_HARNESS", "/nonexistent/path")
@@ -309,7 +309,7 @@ func TestCmdValidate_MultipleHarnesses(t *testing.T) {
 
 	for _, name := range []string{"good", "bad"} {
 		hr := filepath.Join(dir, name)
-		writeFile(t, filepath.Join(hr, ".harness.json"),
+		writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 			[]byte(`{"name":"`+name+`","version":"0.1.0"}`))
 	}
 
@@ -322,9 +322,9 @@ func TestCmdValidate_MultipleHarnesses(t *testing.T) {
 	}
 }
 
-func TestValidateFile_HarnessJSON_Valid(t *testing.T) {
+func TestValidateFile_PluginJSON_Valid(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, ".harness.json")
+	path := filepath.Join(dir, ".ynh-plugin", "plugin.json")
 	writeFile(t, path, []byte(`{"name":"test","version":"0.1.0"}`))
 
 	err := validateFile(path)
@@ -333,9 +333,9 @@ func TestValidateFile_HarnessJSON_Valid(t *testing.T) {
 	}
 }
 
-func TestValidateFile_HarnessJSON_Invalid(t *testing.T) {
+func TestValidateFile_PluginJSON_Invalid(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, ".harness.json")
+	path := filepath.Join(dir, ".ynh-plugin", "plugin.json")
 	writeFile(t, path, []byte(`{}`))
 
 	err := validateFile(path)
@@ -386,7 +386,7 @@ func TestValidateHarness_InvalidHarnessJSON(t *testing.T) {
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"), []byte(`{not json}`))
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"), []byte(`{not json}`))
 
 	err := validateHarness(hr)
 	if err == nil {
@@ -400,7 +400,7 @@ func TestValidateHarness_NonMarkdownInArtifactDir(t *testing.T) {
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, filepath.Join(hr, "agents"))
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"bad","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "agents", "stray.txt"), []byte("not markdown"))
 
@@ -416,7 +416,7 @@ func TestValidateHarness_AgentMissingFrontmatter(t *testing.T) {
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, filepath.Join(hr, "agents"))
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"bad","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "agents", "reviewer.md"), []byte("Just text.\n"))
 
@@ -432,7 +432,7 @@ func TestValidateHarness_AgentNameMismatch(t *testing.T) {
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, filepath.Join(hr, "agents"))
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"bad","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "agents", "reviewer.md"),
 		[]byte("---\nname: wrong\ndescription: Reviews code\ntools: Read\n---\n"))
@@ -449,7 +449,7 @@ func TestValidateHarness_AgentMissingDescription(t *testing.T) {
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, filepath.Join(hr, "agents"))
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"bad","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "agents", "reviewer.md"),
 		[]byte("---\nname: reviewer\ntools: Read\n---\n"))
@@ -466,7 +466,7 @@ func TestValidateHarness_AgentWithDescriptionButNoTools(t *testing.T) {
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, filepath.Join(hr, "agents"))
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"bad","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "agents", "reviewer.md"),
 		[]byte("---\nname: reviewer\ndescription: Reviews\n---\n"))
@@ -483,7 +483,7 @@ func TestValidateHarness_SkillMissingFrontmatter(t *testing.T) {
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, filepath.Join(hr, "skills", "hello"))
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"bad","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "skills", "hello", "SKILL.md"), []byte("No frontmatter.\n"))
 
@@ -499,7 +499,7 @@ func TestValidateHarness_SkillMissingName(t *testing.T) {
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, filepath.Join(hr, "skills", "hello"))
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"bad","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "skills", "hello", "SKILL.md"),
 		[]byte("---\ndescription: A skill\n---\n"))
@@ -516,7 +516,7 @@ func TestValidateHarness_SkillMissingDescription(t *testing.T) {
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, filepath.Join(hr, "skills", "hello"))
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"bad","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "skills", "hello", "SKILL.md"),
 		[]byte("---\nname: hello\n---\n"))
@@ -527,33 +527,33 @@ func TestValidateHarness_SkillMissingDescription(t *testing.T) {
 	}
 }
 
-func TestValidateHarness_HarnessJSONMissingName(t *testing.T) {
+func TestValidateHarness_PluginJSONMissingName(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"version":"0.1.0"}`))
 
 	err := validateHarness(hr)
 	if err == nil {
-		t.Fatal("expected validation error for missing name in .harness.json")
+		t.Fatal("expected validation error for missing name in plugin.json")
 	}
 }
 
-func TestValidateHarness_HarnessJSONMissingVersion(t *testing.T) {
+func TestValidateHarness_PluginJSONMissingVersion(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"bad"}`))
 
 	err := validateHarness(hr)
 	if err == nil {
-		t.Fatal("expected validation error for missing version in .harness.json")
+		t.Fatal("expected validation error for missing version in plugin.json")
 	}
 }
 
@@ -563,7 +563,7 @@ func TestValidateHarness_NonMarkdownInRules(t *testing.T) {
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, filepath.Join(hr, "rules"))
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"bad","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "rules", "stray.txt"), []byte("not markdown"))
 
@@ -579,7 +579,7 @@ func TestValidateHarness_NonMarkdownInCommands(t *testing.T) {
 
 	hr := filepath.Join(dir, "bad")
 	mkdirAll(t, filepath.Join(hr, "commands"))
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"bad","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "commands", "stray.py"), []byte("not markdown"))
 
@@ -595,7 +595,7 @@ func TestValidateHarness_ConflictingInstructions(t *testing.T) {
 
 	hr := filepath.Join(dir, "conflict")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"conflict","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "instructions.md"), []byte("one thing"))
 	writeFile(t, filepath.Join(hr, "AGENTS.md"), []byte("another thing"))
@@ -615,7 +615,7 @@ func TestValidateHarness_IdenticalInstructionsOK(t *testing.T) {
 
 	hr := filepath.Join(dir, "ok")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"ok","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "instructions.md"), []byte("same content"))
 	writeFile(t, filepath.Join(hr, "AGENTS.md"), []byte("same content"))
@@ -631,7 +631,7 @@ func TestValidateHarness_HooksValid(t *testing.T) {
 
 	hr := filepath.Join(dir, "hooks-valid")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"hooks-valid","version":"0.1.0","hooks":{"before_tool":[{"command":"echo hi"}]}}`))
 
 	if err := validateHarness(hr); err != nil {
@@ -645,7 +645,7 @@ func TestValidateHarness_HooksUnknownEvent(t *testing.T) {
 
 	hr := filepath.Join(dir, "hooks-bad-event")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"hooks-bad-event","version":"0.1.0","hooks":{"unknown_event":[{"command":"echo hi"}]}}`))
 
 	err := validateHarness(hr)
@@ -660,7 +660,7 @@ func TestValidateHarness_HooksEmptyCommand(t *testing.T) {
 
 	hr := filepath.Join(dir, "hooks-empty-cmd")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"hooks-empty-cmd","version":"0.1.0","hooks":{"before_tool":[{"command":""}]}}`))
 
 	err := validateHarness(hr)
@@ -675,7 +675,7 @@ func TestValidateHarness_MCPServersValid(t *testing.T) {
 
 	hr := filepath.Join(dir, "mcp-valid")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"mcp-valid","version":"0.1.0","mcp_servers":{"github":{"command":"npx","args":["-y","server"]}}}`))
 
 	if err := validateHarness(hr); err != nil {
@@ -689,7 +689,7 @@ func TestValidateHarness_MCPServersURLOnly(t *testing.T) {
 
 	hr := filepath.Join(dir, "mcp-url")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"mcp-url","version":"0.1.0","mcp_servers":{"api":{"url":"https://api.example.com/mcp"}}}`))
 
 	if err := validateHarness(hr); err != nil {
@@ -703,7 +703,7 @@ func TestValidateHarness_MCPServersNeitherCommandNorURL(t *testing.T) {
 
 	hr := filepath.Join(dir, "mcp-neither")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"mcp-neither","version":"0.1.0","mcp_servers":{"bad":{}}}`))
 
 	err := validateHarness(hr)
@@ -718,7 +718,7 @@ func TestValidateHarness_MCPServersBothCommandAndURL(t *testing.T) {
 
 	hr := filepath.Join(dir, "mcp-both")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"mcp-both","version":"0.1.0","mcp_servers":{"bad":{"command":"npx","url":"https://example.com"}}}`))
 
 	err := validateHarness(hr)
@@ -733,7 +733,7 @@ func TestValidateHarness_MCPServersNotObject(t *testing.T) {
 
 	hr := filepath.Join(dir, "mcp-bad-type")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"mcp-bad-type","version":"0.1.0","mcp_servers":"not-an-object"}`))
 
 	err := validateHarness(hr)
@@ -748,7 +748,7 @@ func TestValidateHarness_ProfilesValid(t *testing.T) {
 
 	hr := filepath.Join(dir, "prof-valid")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"prof-valid","version":"0.1.0","profiles":{"ci":{"hooks":{"before_tool":[{"command":"echo ci"}]}}}}`))
 
 	if err := validateHarness(hr); err != nil {
@@ -762,7 +762,7 @@ func TestValidateHarness_ProfilesInvalidHookEvent(t *testing.T) {
 
 	hr := filepath.Join(dir, "prof-bad")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"prof-bad","version":"0.1.0","profiles":{"ci":{"hooks":{"bad_event":[{"command":"echo"}]}}}}`))
 
 	err := validateHarness(hr)
@@ -777,7 +777,7 @@ func TestValidateHarness_ProfilesMCPServerInvalid(t *testing.T) {
 
 	hr := filepath.Join(dir, "prof-mcp-bad")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"prof-mcp-bad","version":"0.1.0","profiles":{"ci":{"mcp_servers":{"bad":{}}}}}`))
 
 	err := validateHarness(hr)
@@ -792,7 +792,7 @@ func TestValidateHarness_ProfileNullMCPServerValid(t *testing.T) {
 
 	hr := filepath.Join(dir, "null-mcp")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"null-mcp","version":"0.1.0","mcp_servers":{"pg":{"command":"pg-mcp"}},"profiles":{"ci":{"mcp_servers":{"pg":null}}}}`))
 
 	if err := validateHarness(hr); err != nil {
@@ -806,7 +806,7 @@ func TestValidateHarness_FocusValid(t *testing.T) {
 
 	hr := filepath.Join(dir, "focus-valid")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"focus-valid","version":"0.1.0","profiles":{"ci":{}},"focus":{"review":{"profile":"ci","prompt":"Review code"}}}`))
 
 	if err := validateHarness(hr); err != nil {
@@ -820,7 +820,7 @@ func TestValidateHarness_FocusMissingPrompt(t *testing.T) {
 
 	hr := filepath.Join(dir, "focus-no-prompt")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"focus-no-prompt","version":"0.1.0","focus":{"review":{"profile":"ci"}}}`))
 
 	err := validateHarness(hr)
@@ -835,7 +835,7 @@ func TestValidateHarness_FocusUnknownProfile(t *testing.T) {
 
 	hr := filepath.Join(dir, "focus-bad-profile")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"focus-bad-profile","version":"0.1.0","focus":{"review":{"profile":"nonexistent","prompt":"Review code"}}}`))
 
 	err := validateHarness(hr)
@@ -850,7 +850,7 @@ func TestValidateHarness_FocusNoProfile(t *testing.T) {
 
 	hr := filepath.Join(dir, "focus-no-profile")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"focus-no-profile","version":"0.1.0","focus":{"docs":{"prompt":"Generate docs"}}}`))
 
 	if err := validateHarness(hr); err != nil {
@@ -864,7 +864,7 @@ func TestValidateHarness_AgentsMDOnly(t *testing.T) {
 
 	hr := filepath.Join(dir, "agents-only")
 	mkdirAll(t, hr)
-	writeFile(t, filepath.Join(hr, ".harness.json"),
+	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
 		[]byte(`{"name":"agents-only","version":"0.1.0"}`))
 	writeFile(t, filepath.Join(hr, "AGENTS.md"), []byte("just agents"))
 

--- a/cmd/ynh/include_test.go
+++ b/cmd/ynh/include_test.go
@@ -2,31 +2,26 @@ package main
 
 import (
 	"bytes"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/eyelock/ynh/internal/plugin"
 )
 
-// writeIncludeTestHarness creates a minimal .harness.json in dir.
+// writeIncludeTestHarness creates a minimal plugin.json in dir.
 func writeIncludeTestHarness(t *testing.T, dir, name string) {
 	t.Helper()
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	content := `{"name":"` + name + `","version":"0.1.0"}`
-	if err := os.WriteFile(filepath.Join(dir, ".harness.json"), []byte(content), 0o644); err != nil {
+	hj := &plugin.HarnessJSON{Name: name, Version: "0.1.0"}
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func loadTestIncludes(t *testing.T, dir string) []plugin.IncludeMeta {
 	t.Helper()
-	hj, err := plugin.LoadHarnessJSON(dir)
+	hj, err := plugin.LoadPluginJSON(dir)
 	if err != nil {
-		t.Fatalf("LoadHarnessJSON: %v", err)
+		t.Fatalf("LoadPluginJSON: %v", err)
 	}
 	return hj.Includes
 }

--- a/cmd/ynh/info.go
+++ b/cmd/ynh/info.go
@@ -243,12 +243,10 @@ func printInfoJSON(stdout, stderr io.Writer, name string) error {
 		return cliError(stderr, true, code, err.Error())
 	}
 
-	// Read the raw manifest (plugin.json for 0.2+, .harness.json for 0.1)
+	// Migration chain has run (harness.Load was called above), so the manifest
+	// is always at the new path.
 	installDir := harness.InstalledDir(name)
 	manifestPath := filepath.Join(installDir, plugin.PluginDir, plugin.PluginFile)
-	if _, err := os.Stat(manifestPath); err != nil {
-		manifestPath = filepath.Join(installDir, plugin.HarnessFile)
-	}
 	raw, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return cliError(stderr, true, errCodeIOError,

--- a/cmd/ynh/info.go
+++ b/cmd/ynh/info.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/eyelock/ynh/internal/harness"
@@ -221,7 +222,13 @@ func printInfoText(w io.Writer, name string) error {
 	if len(p.Focuses) == 0 {
 		_, _ = fmt.Fprintln(w, "  (none)")
 	} else {
-		for fname, focus := range p.Focuses {
+		focusNames := make([]string, 0, len(p.Focuses))
+		for fname := range p.Focuses {
+			focusNames = append(focusNames, fname)
+		}
+		sort.Strings(focusNames)
+		for _, fname := range focusNames {
+			focus := p.Focuses[fname]
 			profileLabel := "(default)"
 			if focus.Profile != "" {
 				profileLabel = "profile=" + focus.Profile

--- a/cmd/ynh/install_helpers.go
+++ b/cmd/ynh/install_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/eyelock/ynh/internal/assembler"
 	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/migration"
 	"github.com/eyelock/ynh/internal/plugin"
 )
 
@@ -22,26 +23,24 @@ func isLocalPath(source string) bool {
 	return false
 }
 
-// loadOrSynthesizeHarness loads a harness from a directory. If the directory
-// has .harness.json, it loads normally. If the directory has AGENTS.md (or
-// instructions.md) but no .harness.json, it synthesizes minimal .harness.json
-// on disk so that the rest of the install flow works unchanged.
+// loadOrSynthesizeHarness loads a harness from a directory. The migration
+// chain runs first to convert any legacy format transparently. If no manifest
+// exists but AGENTS.md or instructions.md does, a minimal plugin.json is
+// synthesized so the install flow works unchanged.
 func loadOrSynthesizeHarness(dir string) (*harness.Harness, error) {
-	// Try known harness formats (plugin = 0.2+, harness = 0.1)
-	switch harness.DetectFormat(dir) {
-	case "plugin", "harness":
+	if _, err := migration.FormatChain().Run(dir); err != nil {
+		return nil, fmt.Errorf("migrating harness format: %w", err)
+	}
+
+	if plugin.IsPluginDir(dir) {
 		return harness.LoadDir(dir)
-	case "legacy":
-		return nil, fmt.Errorf("legacy format detected in %q. Migrate to .ynh-plugin/plugin.json", dir)
 	}
 
-	// Check for bare AGENTS.md or instructions.md
-	hasInstructions := assembler.FindInstructionsFile(dir) != ""
-	if !hasInstructions {
-		return nil, fmt.Errorf("directory %q has no .ynh-plugin/plugin.json, .harness.json, or AGENTS.md", dir)
+	// No manifest: try to synthesize from AGENTS.md or instructions.md
+	if assembler.FindInstructionsFile(dir) == "" {
+		return nil, fmt.Errorf("directory %q has no harness manifest or AGENTS.md", dir)
 	}
 
-	// Synthesize minimal plugin.json in the source directory
 	name := filepath.Base(dir)
 	hj := &plugin.HarnessJSON{
 		Name:    name,

--- a/cmd/ynh/install_helpers.go
+++ b/cmd/ynh/install_helpers.go
@@ -38,17 +38,17 @@ func loadOrSynthesizeHarness(dir string) (*harness.Harness, error) {
 	// Check for bare AGENTS.md or instructions.md
 	hasInstructions := assembler.FindInstructionsFile(dir) != ""
 	if !hasInstructions {
-		return nil, fmt.Errorf("directory %q has no .harness.json or AGENTS.md", dir)
+		return nil, fmt.Errorf("directory %q has no .ynh-plugin/plugin.json, .harness.json, or AGENTS.md", dir)
 	}
 
-	// Synthesize minimal .harness.json in the source directory
+	// Synthesize minimal plugin.json in the source directory
 	name := filepath.Base(dir)
 	hj := &plugin.HarnessJSON{
 		Name:    name,
 		Version: "0.0.0",
 	}
-	if err := plugin.SaveHarnessJSON(dir, hj); err != nil {
-		return nil, fmt.Errorf("writing synthesized .harness.json: %w", err)
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
+		return nil, fmt.Errorf("writing synthesized plugin.json: %w", err)
 	}
 
 	return harness.LoadDir(dir)

--- a/cmd/ynh/install_helpers_test.go
+++ b/cmd/ynh/install_helpers_test.go
@@ -63,9 +63,9 @@ func TestLoadOrSynthesizeHarness_BareAgentsMD(t *testing.T) {
 		t.Errorf("Name = %q, want %q", h.Name, "my-project")
 	}
 
-	// Verify .harness.json was synthesized
-	if _, err := os.Stat(filepath.Join(dir, ".harness.json")); err != nil {
-		t.Error("synthesized .harness.json should exist")
+	// Verify manifest was synthesized (new format)
+	if _, err := os.Stat(filepath.Join(dir, ".ynh-plugin", "plugin.json")); err != nil {
+		t.Error("synthesized plugin.json should exist")
 	}
 }
 

--- a/cmd/ynh/install_resolve.go
+++ b/cmd/ynh/install_resolve.go
@@ -17,7 +17,8 @@ type resolvedSource struct {
 	path         string // monorepo subdir (from registry entry)
 	localPath    string // absolute path when resolved from a configured source
 	sourceType   string // "local", "git", "registry", "source"
-	registryName string // non-empty for registry lookups
+	registryName string // non-empty for registry lookups (user-declared label)
+	namespace    string // non-empty for registry lookups (URL-derived "org/repo")
 	sourceName   string // non-empty for source lookups (config source name)
 }
 
@@ -40,12 +41,12 @@ func resolveInstallSource(source, existingPath string, cfg *config.Config) (reso
 		return resolvedSource{sourceType: "git"}, nil
 	}
 
-	// Rule 4: Contains @ → registry lookup as name@registry-name
+	// Rule 4: Contains @ → registry lookup as name@<namespace-or-label>.
+	// Passes the full qualified ref through to LookupExact, which matches
+	// against the registry's URL-derived namespace (e.g. "eyelock/assistants")
+	// or its user-declared name (e.g. "eyelock-assistants").
 	if strings.Contains(source, "@") {
-		parts := strings.SplitN(source, "@", 2)
-		name := parts[0]
-		regName := parts[1]
-		return lookupFromRegistry(name, regName, cfg)
+		return lookupFromRegistry(source, cfg)
 	}
 
 	// Rule 5: Contains / → Git URL shorthand
@@ -62,7 +63,7 @@ func resolveInstallSource(source, existingPath string, cfg *config.Config) (reso
 	return searchFromRegistry(source, cfg)
 }
 
-func lookupFromRegistry(name, regName string, cfg *config.Config) (resolvedSource, error) {
+func lookupFromRegistry(qualified string, cfg *config.Config) (resolvedSource, error) {
 	if len(cfg.Registries) == 0 {
 		return resolvedSource{}, fmt.Errorf("no registries configured. Add one with: ynh registry add <url>")
 	}
@@ -72,9 +73,9 @@ func lookupFromRegistry(name, regName string, cfg *config.Config) (resolvedSourc
 		return resolvedSource{}, fmt.Errorf("fetching registries: %w", err)
 	}
 
-	results := registry.LookupExact(regs, name, regName)
+	results := registry.LookupExact(regs, qualified, "")
 	if len(results) == 0 {
-		return resolvedSource{}, fmt.Errorf("%q not found in registry %q", name, regName)
+		return resolvedSource{}, fmt.Errorf("%q not found in any registry", qualified)
 	}
 
 	entry := results[0].Entry
@@ -82,7 +83,8 @@ func lookupFromRegistry(name, regName string, cfg *config.Config) (resolvedSourc
 		gitURL:       entry.Repo,
 		path:         entry.Path,
 		sourceType:   "registry",
-		registryName: regName,
+		registryName: results[0].RegistryName,
+		namespace:    entry.Namespace,
 	}, nil
 }
 
@@ -107,6 +109,7 @@ func searchFromRegistry(name string, cfg *config.Config) (resolvedSource, error)
 			path:         entry.Path,
 			sourceType:   "registry",
 			registryName: results[0].RegistryName,
+			namespace:    entry.Namespace,
 		}, nil
 	}
 
@@ -115,7 +118,7 @@ func searchFromRegistry(name string, cfg *config.Config) (resolvedSource, error)
 		for _, r := range results {
 			msg += fmt.Sprintf("  %s (from %s)\n", r.Entry.Name, r.RegistryName)
 		}
-		msg += fmt.Sprintf("Use: ynh install %s@<registry-name>", name)
+		msg += fmt.Sprintf("Use: ynh install %s@<namespace>", name)
 		return resolvedSource{}, fmt.Errorf("%s", msg)
 	}
 

--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -93,12 +93,12 @@ func cmdListTo(args []string, stdout, stderr io.Writer) error {
 }
 
 func printListText(w io.Writer) error {
-	names, err := harness.List()
+	entries, err := harness.ListAll()
 	if err != nil {
 		return err
 	}
 
-	if len(names) == 0 {
+	if len(entries) == 0 {
 		_, _ = fmt.Fprintln(w, "No harnesses installed.")
 		_, _ = fmt.Fprintln(w, "Install one with: ynh install <git-url|path>")
 		return nil
@@ -107,10 +107,10 @@ func printListText(w io.Writer) error {
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(tw, "NAME\tVENDOR\tSOURCE\tARTIFACTS\tINCLUDES\tDELEGATES TO")
 
-	for _, name := range names {
-		p, err := harness.Load(name)
+	for _, e := range entries {
+		p, err := harness.LoadDir(e.Dir)
 		if err != nil {
-			_, _ = fmt.Fprintf(tw, "%s\t(error: %v)\t\t\t\t\n", name, err)
+			_, _ = fmt.Fprintf(tw, "%s\t(error: %v)\t\t\t\t\n", e.Name, err)
 			continue
 		}
 
@@ -120,7 +120,7 @@ func printListText(w io.Writer) error {
 		}
 
 		source := formatProvenance(p.InstalledFrom)
-		artifacts := formatArtifactSummary(name)
+		artifacts := formatArtifactSummaryDir(e.Dir)
 		includes := formatIncludes(p.Includes)
 		delegates := formatDelegates(p.DelegatesTo)
 
@@ -216,7 +216,12 @@ func buildDelegates(delegates []harness.Delegate) []listDelegate {
 // formatArtifactSummary formats the ARTIFACTS column for ynh ls.
 // Shows a compact summary like "1s 2a 1r 1c" (skills, agents, rules, commands).
 func formatArtifactSummary(name string) string {
-	arts, _ := harness.ScanArtifacts(name)
+	return formatArtifactSummaryDir(harness.InstalledDir(name))
+}
+
+// formatArtifactSummaryDir formats the ARTIFACTS column from an explicit directory.
+func formatArtifactSummaryDir(dir string) string {
+	arts, _ := harness.ScanArtifactsDir(dir)
 	if arts.Total() == 0 {
 		return "0"
 	}

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/eyelock/ynh/internal/assembler"
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/migration"
 	"github.com/eyelock/ynh/internal/plugin"
 	"github.com/eyelock/ynh/internal/resolver"
 	"github.com/eyelock/ynh/internal/symlink"
@@ -279,27 +280,26 @@ func cmdInstall(args []string) error {
 		}
 	}
 
-	// Inject install provenance into the copied .harness.json
+	// Migrate format if needed (converts .harness.json → .ynh-plugin/plugin.json)
+	if _, err := migration.FormatChain().Run(installDir); err != nil {
+		return fmt.Errorf("migrating installed harness format: %w", err)
+	}
+
+	// Write install provenance to .ynh-plugin/installed.json (separate from plugin.json)
 	provSource := source
 	if resolved.sourceType == "local" {
 		provSource = originalSource
 	} else if resolved.localPath != "" {
 		provSource = resolved.localPath
 	}
-	prov := &plugin.ProvenanceMeta{
+	ins := &plugin.InstalledJSON{
 		SourceType:   resolved.sourceType,
 		Source:       provSource,
 		Path:         pathFlag,
 		RegistryName: resolved.registryName,
 		InstalledAt:  time.Now().UTC().Format(time.RFC3339),
 	}
-	// Load existing .harness.json from the copied file (preserves includes, delegates, etc.)
-	hj, err := plugin.LoadHarnessJSON(installDir)
-	if err != nil {
-		return fmt.Errorf("loading installed .harness.json: %w", err)
-	}
-	hj.InstalledFrom = prov
-	if err := plugin.SaveHarnessJSON(installDir, hj); err != nil {
+	if err := plugin.SaveInstalledJSON(installDir, ins); err != nil {
 		return fmt.Errorf("saving provenance: %w", err)
 	}
 
@@ -1114,7 +1114,7 @@ func cmdPrune() error {
 			if name == "ynh" || name == "ynd" {
 				continue
 			}
-			if harness.DetectFormat(harness.InstalledDir(name)) == "harness" {
+			if f := harness.DetectFormat(harness.InstalledDir(name)); f == "plugin" || f == "harness" {
 				continue
 			}
 			launcherPath := filepath.Join(binDir, name)
@@ -1138,7 +1138,7 @@ func cmdPrune() error {
 	if err == nil {
 		for _, entry := range runEntries {
 			name := entry.Name()
-			if harness.DetectFormat(harness.InstalledDir(name)) == "harness" {
+			if f := harness.DetectFormat(harness.InstalledDir(name)); f == "plugin" || f == "harness" {
 				continue
 			}
 			staleRun := filepath.Join(runDir, name)

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -515,25 +515,27 @@ func cmdRun(args []string) error {
 		harnessDir = filepath.Dir(ra.HarnessFile)
 
 	default:
-		// Auto-discover .harness.json in cwd
+		// Auto-discover a harness in cwd. The migration chain converts any
+		// legacy format transparently so we only need to load the new format.
 		cwd, wdErr := os.Getwd()
 		if wdErr != nil {
 			return wdErr
 		}
-		localFile := filepath.Join(cwd, plugin.HarnessFile)
-		if _, statErr := os.Stat(localFile); statErr == nil {
-			p, err = harness.LoadFile(localFile)
-			if err != nil {
-				return err
-			}
-			name = p.Name
-			if name == "" {
-				name = "(inline)"
-			}
-			harnessDir = cwd
-		} else {
+		if _, err := migration.FormatChain().Run(cwd); err != nil {
+			return fmt.Errorf("migrating harness in cwd: %w", err)
+		}
+		if !plugin.IsPluginDir(cwd) {
 			return fmt.Errorf("usage: ynh run <harness-name> [-v vendor] [--focus name] [--harness-file path] [-- prompt]")
 		}
+		p, err = harness.LoadDir(cwd)
+		if err != nil {
+			return err
+		}
+		name = p.Name
+		if name == "" {
+			name = "(inline)"
+		}
+		harnessDir = cwd
 	}
 
 	// Resolve focus → profile + prompt
@@ -1114,7 +1116,7 @@ func cmdPrune() error {
 			if name == "ynh" || name == "ynd" {
 				continue
 			}
-			if f := harness.DetectFormat(harness.InstalledDir(name)); f == "plugin" || f == "harness" {
+			if harness.DetectFormat(harness.InstalledDir(name)) == "plugin" {
 				continue
 			}
 			launcherPath := filepath.Join(binDir, name)
@@ -1138,7 +1140,7 @@ func cmdPrune() error {
 	if err == nil {
 		for _, entry := range runEntries {
 			name := entry.Name()
-			if f := harness.DetectFormat(harness.InstalledDir(name)); f == "plugin" || f == "harness" {
+			if harness.DetectFormat(harness.InstalledDir(name)) == "plugin" {
 				continue
 			}
 			staleRun := filepath.Join(runDir, name)

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -260,8 +260,13 @@ func cmdInstall(args []string) error {
 	// Users invoke it with: ynh run ynh
 	reservedName := p.Name == "ynh"
 
-	// Copy harness to installed directory (clean first to remove stale artifacts)
-	installDir := harness.InstalledDir(p.Name)
+	// Install dir: namespaced when a registry namespace was resolved, else flat.
+	var installDir string
+	if resolved.namespace != "" {
+		installDir = harness.InstalledDirNS(resolved.namespace, p.Name)
+	} else {
+		installDir = harness.InstalledDir(p.Name)
+	}
 
 	// If source == install dir, skip the clean+copy (already in place).
 	// Otherwise remove stale artifacts and copy fresh.
@@ -296,6 +301,7 @@ func cmdInstall(args []string) error {
 		SourceType:   resolved.sourceType,
 		Source:       provSource,
 		Path:         pathFlag,
+		Namespace:    resolved.namespace,
 		RegistryName: resolved.registryName,
 		InstalledAt:  time.Now().UTC().Format(time.RFC3339),
 	}

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -765,9 +765,9 @@ func TestCmdInstall_PathFlag(t *testing.T) {
 		t.Fatalf("cmdInstall with --path failed: %v", err)
 	}
 
-	// Verify harness was installed
+	// Verify harness was installed (format migrated to .ynh-plugin/plugin.json)
 	installDir := harness.InstalledDir("alice")
-	if _, err := os.Stat(filepath.Join(installDir, ".harness.json")); err != nil {
+	if harness.DetectFormat(installDir) == "" {
 		t.Fatal("harness not found after install")
 	}
 }
@@ -819,9 +819,9 @@ func TestCmdInstall_SourceInsideHarnessesDir(t *testing.T) {
 		t.Fatalf("install from already-installed location should succeed, got: %v", err)
 	}
 
-	// Harness file must still be present after install
-	if _, statErr := os.Stat(filepath.Join(srcDir, ".harness.json")); statErr != nil {
-		t.Error("harness file missing after install from already-installed location")
+	// Harness must still be loadable after install from already-installed location
+	if harness.DetectFormat(srcDir) == "" {
+		t.Error("harness missing after install from already-installed location")
 	}
 }
 

--- a/cmd/ynh/search.go
+++ b/cmd/ynh/search.go
@@ -69,7 +69,6 @@ type searchResultEntry struct {
 	Keywords    []string   `json:"keywords,omitempty"`
 	Repo        string     `json:"repo,omitempty"`
 	Path        string     `json:"path,omitempty"`
-	Vendors     []string   `json:"vendors,omitempty"`
 	Version     string     `json:"version,omitempty"`
 	From        searchFrom `json:"from"`
 }
@@ -119,9 +118,6 @@ func unifiedSearch(cfg *config.Config, query string) ([]searchResultEntry, error
 					Version:     h.Version,
 					From:        searchFrom{Type: "source", Name: s.Name},
 				}
-				if h.DefaultVendor != "" {
-					entry.Vendors = []string{h.DefaultVendor}
-				}
 				if len(h.Keywords) > 0 {
 					entry.Keywords = h.Keywords
 				}
@@ -161,19 +157,15 @@ func printSearchText(w io.Writer, query string, results []searchResultEntry) err
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "NAME\tDESCRIPTION\tREPO\tVENDORS\tFROM")
+	_, _ = fmt.Fprintln(tw, "NAME\tDESCRIPTION\tREPO\tFROM")
 	for _, r := range results {
-		vendors := strings.Join(r.Vendors, ",")
-		if vendors == "" {
-			vendors = "-"
-		}
 		repo := r.Repo
 		if r.Path != "" {
 			repo += " (" + r.Path + ")"
 		}
 		from := r.From.Name + " (" + r.From.Type + ")"
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
-			r.Name, r.Description, repo, vendors, from)
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			r.Name, r.Description, repo, from)
 	}
 	return tw.Flush()
 }

--- a/cmd/ynh/search.go
+++ b/cmd/ynh/search.go
@@ -96,7 +96,6 @@ func unifiedSearch(cfg *config.Config, query string) ([]searchResultEntry, error
 				Keywords:    r.Entry.Keywords,
 				Repo:        r.Entry.Repo,
 				Path:        r.Entry.Path,
-				Vendors:     r.Entry.Vendors,
 				Version:     r.Entry.Version,
 				From:        searchFrom{Type: "registry", Name: r.RegistryName},
 			}

--- a/docs/tutorial/07-registry-and-discovery.md
+++ b/docs/tutorial/07-registry-and-discovery.md
@@ -93,8 +93,8 @@ ynh search "go"
 
 Expected:
 ```
-NAME   DESCRIPTION                                       REPO                                       VENDORS              FROM
-david  Full-stack development harness with Go expertise  github.com/eyelock/assistants (ynh/david)  claude,codex,cursor  tutorial-registry (registry)
+NAME   DESCRIPTION                                       REPO                                       FROM
+david  Full-stack development harness with Go expertise  github.com/eyelock/assistants (ynh/david)  tutorial-registry (registry)
 ```
 
 ```bash
@@ -103,8 +103,8 @@ ynh search "planning"
 
 Expected:
 ```
-NAME     DESCRIPTION                                REPO                                         VENDORS  FROM
-planner  Project planning and architecture harness  github.com/eyelock/assistants (ynh/planner)  claude   tutorial-registry (registry)
+NAME     DESCRIPTION                                REPO                                         FROM
+planner  Project planning and architecture harness  github.com/eyelock/assistants (ynh/planner)  tutorial-registry (registry)
 ```
 
 ```bash
@@ -113,8 +113,8 @@ ynh search "music"
 
 Expected:
 ```
-NAME              DESCRIPTION                                      REPO                                                      VENDORS  FROM
-media-management  Music library processing and Apple Music import  github.com/eyelock/assistants (plugins/media-management)  claude   tutorial-registry (registry)
+NAME              DESCRIPTION                                      REPO                                                      FROM
+media-management  Music library processing and Apple Music import  github.com/eyelock/assistants (plugins/media-management)  tutorial-registry (registry)
 ```
 
 ```bash

--- a/docs/tutorial/08-developer-tools.md
+++ b/docs/tutorial/08-developer-tools.md
@@ -22,7 +22,7 @@ Expected: a `my-team/` directory with the full harness structure:
 ```bash
 find my-team -type f | sort
 # Expected:
-#   my-team/.harness.json
+#   my-team/.ynh-plugin/plugin.json
 #   my-team/AGENTS.md
 ```
 

--- a/docs/tutorial/13-profiles.md
+++ b/docs/tutorial/13-profiles.md
@@ -154,7 +154,7 @@ ynd preview /tmp/ynh-tutorial/profile-harness -v claude --profile nonexistent
 
 Expected error:
 ```
-Error: profile "nonexistent" not defined in .harness.json
+Error: profile "nonexistent" not defined in harness manifest
 ```
 
 ## T13.6: Use YNH_PROFILE env var

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -85,9 +85,10 @@ func Export(opts ExportOptions) ([]ExportResult, error) {
 		}
 	}
 
-	hj, err := plugin.LoadHarnessJSON(opts.SourceDir)
+	// harness.LoadDir above ran the migration chain, so the manifest is at the new path.
+	hj, err := plugin.LoadPluginJSON(opts.SourceDir)
 	if err != nil {
-		return nil, fmt.Errorf("loading .harness.json: %w", err)
+		return nil, fmt.Errorf("loading plugin.json: %w", err)
 	}
 
 	// Check remote sources for all delegates

--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -5,12 +5,21 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/eyelock/ynh/internal/migration"
 	"github.com/eyelock/ynh/internal/plugin"
 )
 
+// loadManifest runs the migration chain and loads the manifest from the new path.
+func loadManifest(dir string) (*plugin.HarnessJSON, error) {
+	if _, err := migration.FormatChain().Run(dir); err != nil {
+		return nil, fmt.Errorf("migrating harness manifest: %w", err)
+	}
+	return plugin.LoadPluginJSON(dir)
+}
+
 // ResolveEditTarget resolves a harness reference to a directory.
 // If ref contains a path separator or starts with '.', it is treated as a
-// filesystem path and must contain .harness.json. Otherwise it is looked up
+// filesystem path and must contain a harness manifest. Otherwise it is looked up
 // as an installed harness name. Returns the directory and whether the harness
 // is installed (i.e. lives under the ynh harnesses directory).
 func ResolveEditTarget(ref string) (dir string, installed bool, err error) {
@@ -26,7 +35,7 @@ func ResolveEditTarget(ref string) (dir string, installed bool, err error) {
 	}
 
 	installDir := InstalledDir(ref)
-	if f := DetectFormat(installDir); f == "plugin" || f == "harness" {
+	if DetectFormat(installDir) == "plugin" {
 		return installDir, true, nil
 	}
 	return "", false, fmt.Errorf("harness %q: %w", ref, ErrNotFound)
@@ -58,7 +67,7 @@ type UpdateOptions struct {
 // If the URL+path already exists and Replace is false, it returns an error.
 // Network operations (pre-fetch, pick validation) are the caller's responsibility.
 func AddInclude(dir, url string, opts AddOptions) error {
-	hj, err := plugin.LoadHarnessJSON(dir)
+	hj, err := loadManifest(dir)
 	if err != nil {
 		return err
 	}
@@ -77,14 +86,14 @@ func AddInclude(dir, url string, opts AddOptions) error {
 		hj.Includes = append(hj.Includes, plugin.IncludeMeta{Git: url, Ref: opts.Ref, Path: opts.Path, Pick: opts.Pick})
 	}
 
-	return plugin.SaveHarnessJSON(dir, hj)
+	return plugin.SavePluginJSON(dir, hj)
 }
 
 // RemoveInclude removes an include identified by URL and optional path.
 // If the URL matches multiple includes and no path is given, an error is
 // returned listing the paths that would disambiguate.
 func RemoveInclude(dir, url string, opts RemoveOptions) error {
-	hj, err := plugin.LoadHarnessJSON(dir)
+	hj, err := loadManifest(dir)
 	if err != nil {
 		return err
 	}
@@ -111,7 +120,7 @@ func RemoveInclude(dir, url string, opts RemoveOptions) error {
 	}
 
 	hj.Includes = keep
-	return plugin.SaveHarnessJSON(dir, hj)
+	return plugin.SavePluginJSON(dir, hj)
 }
 
 // UpdateInclude updates fields on an existing include.
@@ -120,7 +129,7 @@ func RemoveInclude(dir, url string, opts RemoveOptions) error {
 // are updated; omitted fields are left unchanged.
 // Network operations (pre-fetch, pick validation) are the caller's responsibility.
 func UpdateInclude(dir, url string, opts UpdateOptions) error {
-	hj, err := plugin.LoadHarnessJSON(dir)
+	hj, err := loadManifest(dir)
 	if err != nil {
 		return err
 	}
@@ -141,14 +150,14 @@ func UpdateInclude(dir, url string, opts UpdateOptions) error {
 		inc.Ref = *opts.Ref
 	}
 
-	return plugin.SaveHarnessJSON(dir, hj)
+	return plugin.SavePluginJSON(dir, hj)
 }
 
 // FindUpdateTarget loads the harness from dir and returns the include that
 // would be updated by UpdateOptions. Used by callers that need to inspect the
 // final state before writing (e.g. to pre-fetch the right ref/path).
 func FindUpdateTarget(dir, url string, opts UpdateOptions) (plugin.IncludeMeta, error) {
-	hj, err := plugin.LoadHarnessJSON(dir)
+	hj, err := loadManifest(dir)
 	if err != nil {
 		return plugin.IncludeMeta{}, err
 	}

--- a/internal/harness/editor_test.go
+++ b/internal/harness/editor_test.go
@@ -29,9 +29,9 @@ func overrideHarnessesDir(t *testing.T) {
 // loadIncludes is a test helper that reads the includes from a harness dir.
 func loadIncludes(t *testing.T, dir string) []plugin.IncludeMeta {
 	t.Helper()
-	hj, err := plugin.LoadHarnessJSON(dir)
+	hj, err := plugin.LoadPluginJSON(dir)
 	if err != nil {
-		t.Fatalf("LoadHarnessJSON: %v", err)
+		t.Fatalf("LoadPluginJSON: %v", err)
 	}
 	return hj.Includes
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -69,14 +69,20 @@ type ListEntry struct {
 	Dir       string // absolute path to the harness directory
 }
 
-// DetectFormat returns the format of a harness directory.
-// Returns "plugin" (0.2+), "harness" (0.1), "legacy" (pre-0.1), or "".
+// DetectFormat reports what manifest format a directory holds, after
+// running the migration chain. Returns "plugin" (new format present),
+// "legacy" (unsupported pre-0.1 .claude-plugin format), or "" (nothing).
+//
+// The migration chain converts any supported legacy format to the new
+// format before detection, so callers only ever see "plugin" or "" for
+// valid harnesses. Legacy detection is the one exception — it signals a
+// format that predates ynh and has no migration path.
 func DetectFormat(dir string) string {
+	if _, err := migration.FormatChain().Run(dir); err != nil {
+		return ""
+	}
 	if plugin.IsPluginDir(dir) {
 		return "plugin"
-	}
-	if plugin.IsHarnessDir(dir) {
-		return "harness"
 	}
 	if plugin.IsLegacyPluginDir(dir) {
 		return "legacy"
@@ -87,21 +93,14 @@ func DetectFormat(dir string) string {
 // ErrNotFound is returned when a harness is not installed.
 var ErrNotFound = errors.New("harness not found")
 
-// Load finds and loads an installed harness by name. It runs the migration
-// chain transparently — if the flat-layout dir is migrated to a namespaced
-// path, Load follows and returns the harness from its new location.
+// Load finds and loads an installed harness by name. The migration chain
+// runs inside LoadDir so no legacy handling is needed here. If the flat
+// layout has the harness, use that; otherwise scan the namespaced layout.
 func Load(name string) (*Harness, error) {
 	flatDir := InstalledDir(name)
-
 	if _, err := os.Stat(flatDir); err == nil {
-		// Run format migration only — storage migration is triggered explicitly
-		// to avoid surprising callers that hold the flat path.
-		if _, err := migration.FormatChain().Run(flatDir); err != nil {
-			return nil, fmt.Errorf("migrating harness %q: %w", name, err)
-		}
 		return LoadDir(flatDir)
 	}
-
 	return findInNamespacedDirs(name)
 }
 
@@ -223,27 +222,24 @@ func InstalledDir(name string) string {
 	return filepath.Join(config.HarnessesDir(), name)
 }
 
-// LoadDir loads a harness from a directory. It handles both the 0.2
-// (.ynh-plugin/plugin.json) and 0.1 (.harness.json) formats. The migration
-// chain should be run before calling this for installed harnesses.
+// LoadDir loads a harness from a directory. The migration chain runs
+// transparently, so callers never need to handle legacy formats themselves.
 func LoadDir(dir string) (*Harness, error) {
-	var hj *plugin.HarnessJSON
-	var err error
+	if _, err := migration.FormatChain().Run(dir); err != nil {
+		return nil, fmt.Errorf("migrating harness manifest: %w", err)
+	}
 
-	switch DetectFormat(dir) {
-	case "plugin":
-		hj, err = plugin.LoadPluginJSON(dir)
-	case "harness":
-		hj, err = plugin.LoadHarnessJSON(dir)
-	case "legacy":
+	if plugin.IsLegacyPluginDir(dir) && !plugin.IsPluginDir(dir) {
 		return nil, fmt.Errorf("legacy .claude-plugin format is not supported; migrate to .ynh-plugin/plugin.json")
-	default:
+	}
+	if !plugin.IsPluginDir(dir) {
 		return nil, fmt.Errorf("no harness manifest found in %s", dir)
 	}
+
+	hj, err := plugin.LoadPluginJSON(dir)
 	if err != nil {
 		return nil, err
 	}
-	_ = hj // used below
 
 	if !validName.MatchString(hj.Name) {
 		return nil, fmt.Errorf("invalid harness name %q: must match %s", hj.Name, validName.String())
@@ -329,7 +325,7 @@ func ResolveProfile(h *Harness, profileName string) (*Harness, error) {
 
 	profile, ok := h.Profiles[profileName]
 	if !ok {
-		return nil, fmt.Errorf("profile %q not defined in .harness.json", profileName)
+		return nil, fmt.Errorf("profile %q not defined in harness manifest", profileName)
 	}
 
 	resolved := *h

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/eyelock/ynh/internal/plugin"
 )
 
-func TestDetectFormat_Harness(t *testing.T) {
+func TestDetectFormat_Plugin(t *testing.T) {
+	// Migration chain converts legacy .harness.json transparently.
+	// DetectFormat always returns "plugin" for any supported format.
 	dir := t.TempDir()
 	writeTestHarness(t, dir, "x")
-	if got := DetectFormat(dir); got != "harness" {
-		t.Errorf("DetectFormat = %q, want %q", got, "harness")
+	if got := DetectFormat(dir); got != "plugin" {
+		t.Errorf("DetectFormat = %q, want %q", got, "plugin")
 	}
 }
 
@@ -692,26 +694,20 @@ func TestScanArtifacts_SkillWithoutManifest(t *testing.T) {
 	}
 }
 
-// writeTestHarness creates a minimal harness.json with default_vendor in dir.
+// writeTestHarness creates a minimal plugin.json with default_vendor in dir.
 func writeTestHarness(t *testing.T, dir, name string) {
 	t.Helper()
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	hj := fmt.Sprintf(`{"name":%q,"version":"0.1.0","default_vendor":"claude"}`, name)
-	if err := os.WriteFile(filepath.Join(dir, ".harness.json"), []byte(hj), 0o644); err != nil {
+	hj := &plugin.HarnessJSON{Name: name, Version: "0.1.0", DefaultVendor: "claude"}
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
 		t.Fatal(err)
 	}
 }
 
-// writeTestHarnessMinimal creates a minimal harness.json without default_vendor.
+// writeTestHarnessMinimal creates a minimal plugin.json without default_vendor.
 func writeTestHarnessMinimal(t *testing.T, dir, name string) {
 	t.Helper()
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	hj := fmt.Sprintf(`{"name":%q,"version":"0.1.0"}`, name)
-	if err := os.WriteFile(filepath.Join(dir, ".harness.json"), []byte(hj), 0o644); err != nil {
+	hj := &plugin.HarnessJSON{Name: name, Version: "0.1.0"}
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/marketplace/marketplace.go
+++ b/internal/marketplace/marketplace.go
@@ -11,6 +11,7 @@ import (
 	"github.com/eyelock/ynh/internal/assembler"
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/exporter"
+	"github.com/eyelock/ynh/internal/migration"
 	"github.com/eyelock/ynh/internal/plugin"
 	"github.com/eyelock/ynh/internal/resolver"
 	"github.com/eyelock/ynh/internal/vendor"
@@ -189,7 +190,10 @@ func Build(cfg *MarketplaceConfig, opts BuildOptions) error {
 
 		switch entry.Type {
 		case "harness":
-			hj, err := plugin.LoadHarnessJSON(srcDir)
+			if _, err := migration.FormatChain().Run(srcDir); err != nil {
+				return fmt.Errorf("entry %q: %w", entry.Source, err)
+			}
+			hj, err := plugin.LoadPluginJSON(srcDir)
 			if err != nil {
 				return fmt.Errorf("entry %q: %w", entry.Source, err)
 			}
@@ -262,19 +266,30 @@ func buildPluginEntry(srcDir, outputDir string, vendors []string) error {
 		return fmt.Errorf("copying plugin: %w", err)
 	}
 
-	// Load metadata for manifest generation — try harness.json first,
-	// fall back to .claude-plugin/plugin.json (vendor-native plugin format).
-	hj, err := plugin.LoadHarnessJSON(outputDir)
-	if err != nil {
+	// Load metadata for manifest generation — run migration chain first so any
+	// legacy .harness.json becomes the new plugin.json, then fall back to the
+	// vendor-native .claude-plugin/plugin.json format for standalone plugins.
+	if _, err := migration.FormatChain().Run(outputDir); err != nil {
+		return fmt.Errorf("migrating source format: %w", err)
+	}
+	var hj *plugin.HarnessJSON
+	var err error
+	if plugin.IsPluginDir(outputDir) {
+		hj, err = plugin.LoadPluginJSON(outputDir)
+	}
+	if hj == nil {
 		pi, piErr := loadPluginManifest(outputDir)
 		if piErr != nil {
-			return fmt.Errorf("no .harness.json or .claude-plugin/plugin.json found: %w", err)
+			return fmt.Errorf("no .ynh-plugin/plugin.json or .claude-plugin/plugin.json found: %w", piErr)
 		}
 		hj = &plugin.HarnessJSON{
 			Name:        pi.Name,
 			Description: pi.Description,
 			Version:     pi.Version,
 		}
+	}
+	if err != nil {
+		return err
 	}
 
 	// Generate missing vendor manifests

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -69,10 +69,15 @@ func Fetch(src config.RegistrySource) (Registry, error) {
 		return Registry{}, err
 	}
 
-	// Derive and set namespace from the registry URL
+	// Derive namespace from the registry URL; resolve relative-path entries
+	// against the registry URL so Entry.Repo is always set.
 	reg.Namespace = namespace.DeriveFromURL(src.URL)
 	for i := range reg.Entries {
 		reg.Entries[i].Namespace = reg.Namespace
+		if reg.Entries[i].Repo == "" && reg.Entries[i].Path != "" {
+			reg.Entries[i].Repo = src.URL
+			reg.Entries[i].Path = strings.TrimPrefix(reg.Entries[i].Path, "./")
+		}
 	}
 	return reg, nil
 }
@@ -153,16 +158,19 @@ func Search(registries []Registry, query string) []SearchResult {
 }
 
 // LookupExact finds an entry by exact name, optionally scoped to a registry.
-// Accepts plain "name" or qualified "name@org/repo".
+// Accepts plain "name" or qualified "name@<label>". The label after @ matches
+// the registry's URL-derived Namespace first, then the user-declared Name
+// (legacy form), so both `david@eyelock/assistants` and `david@eyelock-assistants`
+// resolve the same entry.
 func LookupExact(registries []Registry, ref string, registryName string) []SearchResult {
-	name, ns, _ := namespace.ParseQualified(ref)
+	name, label, _ := namespace.ParseQualified(ref)
 
 	var results []SearchResult
 	for _, reg := range registries {
 		if registryName != "" && reg.Name != registryName {
 			continue
 		}
-		if ns != "" && reg.Namespace != ns {
+		if label != "" && reg.Namespace != label && reg.Name != label {
 			continue
 		}
 		for _, entry := range reg.Entries {

--- a/internal/sources/sources.go
+++ b/internal/sources/sources.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/eyelock/ynh/internal/migration"
 	"github.com/eyelock/ynh/internal/plugin"
 )
 
@@ -69,22 +70,14 @@ func walkDiscover(dir string, remainingDepth int, results *[]DiscoveredHarness) 
 }
 
 // loadMinimalHarness reads just the identity fields from a harness manifest.
-// It checks .ynh-plugin/plugin.json first (0.2+), then .harness.json (0.1).
+// Migration chain runs first so any legacy format is converted before we read.
 // Uses a loose struct (no DisallowUnknownFields) so discovery tolerates newer fields.
 func loadMinimalHarness(dir string) (DiscoveredHarness, bool) {
-	var manifestPath string
-	pluginPath := filepath.Join(dir, plugin.PluginDir, plugin.PluginFile)
-	legacyPath := filepath.Join(dir, plugin.HarnessFile)
-
-	switch {
-	case fileExists(pluginPath):
-		manifestPath = pluginPath
-	case fileExists(legacyPath):
-		manifestPath = legacyPath
-	default:
+	if _, err := migration.FormatChain().Run(dir); err != nil {
 		return DiscoveredHarness{}, false
 	}
 
+	manifestPath := filepath.Join(dir, plugin.PluginDir, plugin.PluginFile)
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return DiscoveredHarness{}, false
@@ -113,9 +106,4 @@ func loadMinimalHarness(dir string) (DiscoveredHarness, bool) {
 		Keywords:      manifest.Keywords,
 		Path:          dir,
 	}, true
-}
-
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
 }

--- a/testdata/export-harness/.ynh-plugin/plugin.json
+++ b/testdata/export-harness/.ynh-plugin/plugin.json
@@ -5,6 +5,9 @@
   "author": {
     "name": "test"
   },
-  "keywords": ["test", "export"],
+  "keywords": [
+    "test",
+    "export"
+  ],
   "default_vendor": "claude"
 }


### PR DESCRIPTION
## Summary

Part 3 of 4. The user-visible 0.2 surface. Every legacy branch outside
`internal/migration/` is removed — callers just use the loaders from PR 2
and trust the chain.

- **`cmd/ynh install`** — writes `.ynh-plugin/installed.json` for provenance;
  installs to `~/.ynh/harnesses/<org>--<repo>/<name>/` when a namespace
  resolved from the registry.
- **`cmd/ynh install name@org/repo`** — the `@`-suffix matches the registry's
  URL-derived namespace first, then its user-declared name (legacy form).
  Relative-path marketplace entries resolve against the registry URL so
  `Entry.Repo` is always populated.
- **`cmd/ynh ls`** — walks `ListAll()` + `LoadDir(entry.Dir)` so same-named
  harnesses from different namespaces render as distinct rows.
- **`cmd/ynh info`** — reads manifest from the new path; focus entries sorted.
- **`cmd/ynd migrate`** — new command that runs `FormatChain()` generically.
  Adding/removing a migrator in `internal/migration/` automatically changes
  what this command handles; no hardcoded migrator names.
- **Legacy isolation refactor** — `LoadDir`, `DetectFormat`, editor helpers,
  `install_helpers`, run auto-discover, prune, validate, lint, export,
  preview, sources, marketplace, exporter — all go through the chain. The
  `"harness"` case in `DetectFormat` switches is gone.

Real bugs caught by evals and fixed here: `@` dispatch, relative-path
registry entries, `LookupExact` namespace matching, namespaced install dir,
`ls` walking nested structure, deterministic focus ordering.

## Depends on

- [#80](https://github.com/eyelock/ynh/pull/80) types
- [#81](https://github.com/eyelock/ynh/pull/81) loaders

## Test plan

- [x] `make check` passes
- [x] `/evals` PASS against merged stack (17 tutorials, 22 error cases, 0 failures)
- [x] Manual: same-name harnesses from two registries install under
      distinct namespaces and both appear in `ynh ls`