### PR TITLE
docs: 0.2 tutorials and reference sweep (4/4)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -77,7 +77,7 @@ Inside the session, use `/ynh-create-harness` to build your own. Or do it manual
 ```bash
 # Create a harness
 mkdir david
-echo '{"name":"david","version":"0.1.0","default_vendor":"claude"}' > david/.harness.json
+echo '{"name":"david","version":"0.1.0","default_vendor":"claude"}' > david/.ynh-plugin/plugin.json
 
 # Install it
 ynh install ./david

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -48,6 +48,7 @@
   * [14. Marketplace](tutorial/06-marketplace.md)
   * [15. Registry & Discovery](tutorial/07-registry-and-discovery.md)
   * [16. Docker Images](tutorial/09-docker-image.md)
+  * [17. Namespacing & Migration](tutorial/18-namespacing-and-migration.md)
 
 * **Project**
   * [Migrating to 0.2](migration.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -12,6 +12,7 @@
   * [Hooks](hooks.md)
   * [MCP Servers](mcp.md)
   * [Profiles](profiles.md)
+  * [Namespacing](namespacing.md)
   * [Vendor Support](vendors.md)
 
 * **Tools**
@@ -49,5 +50,6 @@
   * [16. Docker Images](tutorial/09-docker-image.md)
 
 * **Project**
+  * [Migrating to 0.2](migration.md)
   * [Manual Test Plan](tutorial/manual-test-plan.md)
   * [Contributing](https://github.com/eyelock/ynh/blob/main/.github/CONTRIBUTING.md)

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -139,7 +139,7 @@ A harness can include an `AGENTS.md` file with project-level instructions. Most 
 
 ```
 my-harness/
-├── .harness.json
+├── .ynh-plugin/plugin.json
 └── AGENTS.md             <- read natively by Codex/Cursor; shimmed for Claude
 ```
 
@@ -168,14 +168,14 @@ Files in the harness's own directory:
 
 ```
 my-harness/
-├── .harness.json
+├── .ynh-plugin/plugin.json
 ├── skills/review/SKILL.md     <- embedded
 └── rules/concise.md           <- embedded
 ```
 
 ### 2. External Git repos
 
-Referenced in `.harness.json`:
+Referenced in `.ynh-plugin/plugin.json`:
 
 ```json
 {

--- a/docs/cli-structured.md
+++ b/docs/cli-structured.md
@@ -17,7 +17,7 @@ Structured output exists to serve those consumers without breaking the humans-fi
 
 **JSON.** One format, everywhere. No YAML, no TOML, no per-command bespoke shapes.
 
-- Fields use `snake_case` — matching `.harness.json` and `config.json`.
+- Fields use `snake_case` — matching `.ynh-plugin/plugin.json` and `config.json`.
 - Output is written to `stdout` as a single top-level value (object or array), terminated by a newline. No banners, no prompts, no progress chatter on `stdout`.
 - Progress or informational messages, when emitted by a structured-output command, go to `stderr` and are advisory only. Consumers parse `stdout`.
 - Arrays are emitted even when empty (`[]`, not omitted). Required object fields are always present.
@@ -78,13 +78,13 @@ Pre-1.0 caveat: breaking changes remain possible across minor versions, but will
 - Paths are absolute, fully resolved — no `~`, no relative fragments. Consumers receive exactly what they can pass to `os.Open` or its equivalent.
 - Timestamps are ISO 8601 in UTC (`2026-04-15T12:34:56Z`). No Unix epochs.
 - Booleans are `true` / `false`, never `0` / `1` or `"yes"` / `"no"`.
-- Vendor and adapter IDs use the canonical short form (`claude`, `codex`, `cursor`) — the same identifiers used in `.harness.json` and on the `-v` flag.
+- Vendor and adapter IDs use the canonical short form (`claude`, `codex`, `cursor`) — the same identifiers used in `.ynh-plugin/plugin.json` and on the `-v` flag.
 
 ## Scope
 
 This document governs *output* shape and stability. It does not govern:
 
-- On-disk file formats (`.harness.json`, `config.json`, `symlinks.json`) — those have their own schemas under `docs/schema/`.
+- On-disk file formats (`.ynh-plugin/plugin.json`, `config.json`, `symlinks.json`) — those have their own schemas under `docs/schema/`.
 - Command-line argument shape — flags and positional args are part of each command's own contract.
 - Log or diagnostic output from long-running operations (e.g. Git clones) — that remains human-oriented text on `stderr`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,9 +35,9 @@ This gives you an AI session with skills that teach you ynh — including `/ynh-
 
 ## Create a Harness
 
-A harness is a directory with a `.harness.json` and your artifacts:
+A harness is a directory with a `.ynh-plugin/plugin.json` and your artifacts:
 
-`.harness.json`:
+`.ynh-plugin/plugin.json`:
 ```json
 {
   "$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json",
@@ -51,7 +51,7 @@ Add whatever you need - skills, agents, rules, commands:
 
 ```
 david/
-├── .harness.json
+├── .ynh-plugin/plugin.json
 ├── skills/greet/SKILL.md
 ├── agents/reviewer.md
 └── rules/concise.md
@@ -82,7 +82,7 @@ Or set a global default in `~/.ynh/config.json`:
 
 Point your harness at any Git repo. Skills are used as-is - no wrapping, no build step:
 
-`.harness.json`:
+`.ynh-plugin/plugin.json`:
 ```json
 {
   "$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json",

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -37,7 +37,7 @@ YNH does **not** include sensors (linters, test runners, CI/CD). These are well-
 
 ### Hooks: Bridge to Feedback Sensors
 
-While ynh focuses on the guide layer, [hooks](hooks.md) provide the bridge to feedback sensors. A harness declares canonical hook events (`before_tool`, `after_tool`, `before_prompt`, `on_stop`) in `.harness.json`, and ynh translates them into vendor-native hook config at assembly time. The hook scripts themselves — linters, validators, safety checks — live outside the harness. This keeps the boundary clean: ynh declares *when* to check, existing tools provide *what* to check.
+While ynh focuses on the guide layer, [hooks](hooks.md) provide the bridge to feedback sensors. A harness declares canonical hook events (`before_tool`, `after_tool`, `before_prompt`, `on_stop`) in `.ynh-plugin/plugin.json`, and ynh translates them into vendor-native hook config at assembly time. The hook scripts themselves — linters, validators, safety checks — live outside the harness. This keeps the boundary clean: ynh declares *when* to check, existing tools provide *what* to check.
 
 ### MCP Servers: Tool Registry
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -2,15 +2,15 @@
 
 A harness is a portable template that assembles the guide layer of a coding harness — skills, rules, agents, commands, and instructions — for any supported vendor. See [Harness Engineering](harness-engineering.md) for the broader context.
 
-A harness is defined by a `.harness.json` manifest and artifact directories.
+A harness is defined by a `.ynh-plugin/plugin.json` manifest and artifact directories.
 
-> **Migration note:** Legacy format (`.claude-plugin/plugin.json` + `metadata.json`) is no longer supported. Consolidate into `.harness.json`.
+> **Migration note:** Legacy format (`.claude-plugin/plugin.json` + `metadata.json`) is no longer supported. Consolidate into `.ynh-plugin/plugin.json`.
 
 ## Directory Structure
 
 ```
 david/
-├── .harness.json              # required - name, version, vendor, includes, hooks, etc.
+├── .ynh-plugin/plugin.json              # required - name, version, vendor, includes, hooks, etc.
 ├── AGENTS.md                 # optional - project-level instructions (read natively by most vendors; ynh shims Claude via @-import)
 ├── skills/                   # optional - embedded skills
 │   └── review/
@@ -23,9 +23,9 @@ david/
     └── check.md
 ```
 
-## Harness Manifest (`.harness.json`)
+## Harness Manifest (`.ynh-plugin/plugin.json`)
 
-All harness configuration lives in a single `.harness.json` file. Add `"$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json"` for editor autocompletion and validation.
+All harness configuration lives in a single `.ynh-plugin/plugin.json` file. Add `"$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json"` for editor autocompletion and validation.
 
 ### Annotated Example
 
@@ -179,7 +179,7 @@ When running as `david`, you can ask it to delegate a task to `team-dev`. The de
 
 At runtime, ynh generates a vendor-native agent file for each delegate containing:
 
-- **Description** from the delegate's `.harness.json` (helps the AI route to the right delegate)
+- **Description** from the delegate's `.ynh-plugin/plugin.json` (helps the AI route to the right delegate)
 - **Instructions** from the delegate's `AGENTS.md` (gives the delegate its identity)
 - **Rules** inlined from the delegate's `rules/` directory
 - **Skills** listed from the delegate's `skills/` directory
@@ -214,7 +214,7 @@ Profiles let a single harness carry multiple configurations — e.g. a `strict` 
 |----------|--------|---------|
 | 1 (highest) | `--profile` flag | `david --profile strict` |
 | 2 | `YNH_PROFILE` env var | `export YNH_PROFILE=strict` |
-| 3 (lowest) | Top-level config | Fields in `.harness.json` root |
+| 3 (lowest) | Top-level config | Fields in `.ynh-plugin/plugin.json` root |
 
 When a profile is selected, its `hooks` and `mcp_servers` **fully replace** the corresponding top-level values. No merge, no inheritance. If a profile defines `hooks`, the top-level hooks are discarded entirely.
 
@@ -285,7 +285,7 @@ Only the flags you supply are changed; others are left unchanged. `--from-path` 
 
 ### Pick validation
 
-When `--pick` is supplied, `ynh include add` and `ynh include update` validate that every named artifact exists in the fetched source before writing the `.harness.json`. An error lists both the unknown names and what's available.
+When `--pick` is supplied, `ynh include add` and `ynh include update` validate that every named artifact exists in the fetched source before writing the `.ynh-plugin/plugin.json`. An error lists both the unknown names and what's available.
 
 ### Disambiguation rules
 
@@ -304,7 +304,7 @@ See [Tutorial 17: Include Editing](tutorial/17-include-editing.md) for a full wa
 
 ### Minimal
 
-`.harness.json`:
+`.ynh-plugin/plugin.json`:
 ```json
 {
   "$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json",
@@ -318,7 +318,7 @@ Just a named launcher. Useful as a starting point.
 
 ### Harness with external skills
 
-`.harness.json`:
+`.ynh-plugin/plugin.json`:
 ```json
 {
   "$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json",
@@ -337,7 +337,7 @@ Just a named launcher. Useful as a starting point.
 
 ### Team with private repos
 
-`.harness.json`:
+`.ynh-plugin/plugin.json`:
 ```json
 {
   "$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json",
@@ -359,7 +359,7 @@ Just a named launcher. Useful as a starting point.
 
 ### Multi-source composition
 
-`.harness.json`:
+`.ynh-plugin/plugin.json`:
 ```json
 {
   "$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json",

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -2,7 +2,7 @@
 
 Hooks are shell commands that vendors execute at specific lifecycle events during an agent session. They bridge the **guide layer** (what ynh manages) to the **sensor layer** (linters, tests, validators) by declaring *when* a command should run, without embedding the tool itself.
 
-A harness declares hooks in `.harness.json` at the top level. At assembly time, ynh translates them into the vendor-native config format. The hook scripts themselves live outside the harness — they are regular shell commands or scripts on the host machine.
+A harness declares hooks in `.ynh-plugin/plugin.json` at the top level. At assembly time, ynh translates them into the vendor-native config format. The hook scripts themselves live outside the harness — they are regular shell commands or scripts on the host machine.
 
 > **Note:** Hooks can vary by [profile](harnesses.md#profiles). When a profile is selected, its `hooks` field replaces the top-level hooks entirely.
 
@@ -23,9 +23,9 @@ ynh defines four canonical hook events. Each vendor translates these to its nati
 | `before_prompt` | Runs before a user prompt is submitted to the model. |
 | `on_stop` | Runs when the agent session ends. |
 
-## .harness.json Format
+## Manifest Format
 
-Hooks are declared under the top-level `hooks` key in `.harness.json`. Each event maps to an array of hook entries:
+Hooks are declared under the top-level `hooks` key in `.ynh-plugin/plugin.json`. Each event maps to an array of hook entries:
 
 ```json
 {
@@ -84,7 +84,7 @@ Each vendor uses different event names and config file formats:
 
 Claude Code's `--plugin-dir` flag (used by `ynh run` for Claude) only auto-activates **skills and commands** from plugins. Hooks and MCP servers in `--plugin-dir` plugins are **not activated** at runtime — they require the plugin to be formally installed via `/plugin install`. See [Claude Code plugin docs](https://code.claude.com/docs/en/plugins).
 
-This means hooks and MCP servers defined in `.harness.json` are correctly **assembled and exported** by ynh, but are **not active during `ynh run` sessions** with Claude. They work correctly with Codex and Cursor (which use symlink-based installation into the project directory).
+This means hooks and MCP servers defined in `.ynh-plugin/plugin.json` are correctly **assembled and exported** by ynh, but are **not active during `ynh run` sessions** with Claude. They work correctly with Codex and Cursor (which use symlink-based installation into the project directory).
 
 Hooks and MCP servers in exported plugins (`ynd export`) work as expected when the plugin is installed via Claude Code's `/plugin install` command.
 
@@ -165,7 +165,7 @@ The blocking message should be **agent-legible**: tell the agent what to do inst
 
 Hooks declared in **included harnesses** (via `includes`) are dropped during assembly. Only the root harness's hooks are used. This prevents composed harnesses from silently injecting lifecycle behavior that the harness author didn't explicitly declare.
 
-If an included harness needs hooks, copy its hook declarations into the root harness's `.harness.json`.
+If an included harness needs hooks, copy its hook declarations into the root harness's `.ynh-plugin/plugin.json`.
 
 ## Portable Hook Script Advice
 

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -311,7 +311,7 @@ ynh's `marketplace.json` is a build config — it describes *what* to include in
 ### Entry Types
 
 - **`plugin`** — a self-contained plugin directory (already has `.claude-plugin/plugin.json`). Copied as-is with missing vendor manifests generated.
-- **`harness`** — a ynh harness (has `.harness.json` with includes). Fully exported: remote includes resolved, pick filtering applied, delegates generated, dual manifests written.
+- **`harness`** — a ynh harness (has `.ynh-plugin/plugin.json` with includes). Fully exported: remote includes resolved, pick filtering applied, delegates generated, dual manifests written.
 
 ### Output Structure
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -10,9 +10,9 @@ ynh treats MCP server declarations as part of the harness template. At assembly 
 
 Without harness-level MCP declarations, each developer must manually configure MCP servers per vendor per project. A harness that requires a database query tool or a documentation server can declare those dependencies once, and ynh handles vendor translation.
 
-## .harness.json Format
+## Manifest Format
 
-MCP servers are declared under the top-level `mcp_servers` key in `.harness.json`. Each key is the server name, and the value defines either a stdio server (with `command` + `args`) or an HTTP server (with `url`).
+MCP servers are declared under the top-level `mcp_servers` key in `.ynh-plugin/plugin.json`. Each key is the server name, and the value defines either a stdio server (with `command` + `args`) or an HTTP server (with `url`).
 
 ### Stdio Server
 
@@ -137,7 +137,7 @@ Codex uses `.mcp.json` at the plugin root with the same JSON format as Claude:
 
 MCP server declarations in **included harnesses** (via `includes`) are dropped during assembly. Only the root harness's MCP servers are configured. This prevents composed harnesses from silently adding tool dependencies.
 
-If an included harness requires an MCP server, add the server declaration to the root harness's `.harness.json`.
+If an included harness requires an MCP server, add the server declaration to the root harness's `.ynh-plugin/plugin.json`.
 
 ## Future
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,110 @@
+# Migrating from 0.1 to 0.2
+
+ynh 0.2 is a breaking release that changes three things:
+
+1. **Manifest format** — `.harness.json` → `.ynh-plugin/plugin.json`
+2. **Registry format** — `registry.json` → `.ynh-plugin/marketplace.json`
+3. **Storage layout** — flat `~/.ynh/harnesses/<name>/` → namespaced `~/.ynh/harnesses/<org>--<repo>/<name>/`
+
+Most migration is transparent. This doc describes what happens automatically,
+what requires a one-time manual step, and what differs in the new format.
+
+## The migration chain
+
+All 0.1 → 0.2 conversions are handled by a filter chain in
+`internal/migration/`. Loaders call the chain before reading; callers never
+branch on old formats themselves. You rarely need to run migration
+commands directly — ynh handles it on first access.
+
+Three migrators:
+
+| Migrator | Triggered by | Converts |
+|---|---|---|
+| `harness_format` | Any harness load or install | `.harness.json` → `.ynh-plugin/plugin.json` + `.ynh-plugin/installed.json` |
+| `registry_format` | Any registry fetch | `registry.json` → `.ynh-plugin/marketplace.json` |
+| `harness_storage` | Explicit (install, relocate) | Flat `~/.ynh/harnesses/<name>/` → namespaced `<org>--<repo>/<name>/` |
+
+Format migrations run transparently. Storage relocation is triggered
+explicitly on install to avoid surprising callers that hold the flat path.
+
+## For harness authors (source repos)
+
+If you author harnesses, convert your source trees:
+
+```bash
+cd my-harnesses
+ynd migrate -r .
+```
+
+`ynd migrate` runs the full migration chain against every matching directory.
+It handles any registered migrator — adding more migrators in future
+releases does not require a new command.
+
+Idempotent: safe to run twice. No-op if the target already uses the new format.
+
+### What changes
+
+| Before | After |
+|---|---|
+| `my-harness/.harness.json` | `my-harness/.ynh-plugin/plugin.json` |
+| `installed_from` field inside manifest | separate `.ynh-plugin/installed.json` |
+
+The `installed_from` field no longer lives in the author-controlled manifest.
+It moves to `.ynh-plugin/installed.json`, written by `ynh install` at install
+time. Authors never write `installed.json`; add `.ynh-plugin/installed.json`
+to `.gitignore` if you install your own harness locally for testing.
+
+## For registry maintainers
+
+Convert `registry.json` in place:
+
+```bash
+cd my-registry
+ynd migrate .
+```
+
+### What changes
+
+| Before (`registry.json`) | After (`.ynh-plugin/marketplace.json`) |
+|---|---|
+| `entries: [...]` | `harnesses: [...]` |
+| Entry fields: `name`, `repo`, `path`, `keywords`, `version` | Entry fields: `name`, `source`, `keywords`, `version`, `description`, `author`, `category`, `tags` |
+| `repo: "owner/repo"` | `source: {type: "github", repo: "owner/repo"}` |
+
+The new `source` field supports four shapes: relative path string, GitHub
+object (`type: github`), generic Git URL (`type: url`), and sparse-clone
+monorepo entry (`type: git-subdir`). See `docs/marketplace.md` for the full
+spec.
+
+## For end users (installed harnesses)
+
+You do not need to do anything. On first use of any 0.1-installed harness,
+ynh runs the format migration transparently:
+
+```bash
+ynh run david    # format migration runs once, then loads normally
+```
+
+### Storage relocation (optional)
+
+Installed harnesses remain in the flat layout until you reinstall or
+explicitly relocate them. To move them to the namespaced layout:
+
+```bash
+ynh install david@eyelock/assistants   # reinstall under the namespace
+```
+
+You can also keep them flat — ynh loads both layouts. Flat installs get a
+synthetic `local/unknown` namespace if provenance is missing.
+
+## Backward compatibility timeline
+
+- **0.2.x** — `.harness.json` and `registry.json` continue to work via the
+  migration chain. Old files are converted transparently on first read.
+- **0.3.x** — Legacy migrators are removed. `.harness.json` and
+  `registry.json` are no longer recognized. Run `ynd migrate -r` before
+  upgrading to 0.3.
+
+Dropping support in 0.3 means removing the migrator files and unregistering
+them from `DefaultChain()`. No other code changes — the pattern is designed
+for surgical removal.

--- a/docs/namespacing.md
+++ b/docs/namespacing.md
@@ -1,0 +1,97 @@
+# Namespacing
+
+> **Version:** 0.2+. For pre-0.2 single-name installs, see `docs/migration.md`.
+
+ynh 0.2 introduces namespaced harness storage and an `@` syntax for unambiguous
+references across registries.
+
+## Why namespaces
+
+A registry publishes harnesses by name. Two registries can each publish a
+harness called `david` — they are different harnesses with different authors,
+different content, different update streams. Before 0.2, `ynh install david`
+would silently pick the first match. After 0.2, `ynh install david@eyelock/assistants`
+resolves the exact one.
+
+## Namespace format
+
+A namespace is derived from the Git URL of the registry that publishes a
+harness. It is always `<owner>/<repo>`:
+
+| Registry URL | Namespace |
+|---|---|
+| `https://github.com/eyelock/assistants` | `eyelock/assistants` |
+| `git@github.com:eyelock/assistants.git` | `eyelock/assistants` |
+| `https://gitlab.com/myorg/tools` | `myorg/tools` |
+| Local path `/Users/david/harnesses` | `david/harnesses` (last two segments) |
+
+Derivation is URL-based (not registry-name-based) so the namespace is stable
+across machines and across registry renames.
+
+## `@` syntax
+
+Every command that accepts a harness name also accepts `name@org/repo`:
+
+```bash
+ynh install david@eyelock/assistants
+ynh run david@eyelock/assistants
+ynh run david@eyelock/assistants --profile staging
+ynh info david@eyelock/assistants
+ynh uninstall david@eyelock/assistants
+ynh update david@eyelock/assistants
+```
+
+### Disambiguation rules (install)
+
+Applied in order:
+
+1. Local filesystem path (`./foo` or `/abs/path`) → install from local dir
+2. Git SSH URL (`git@...`) → install directly
+3. Git HTTPS URL (`https://...`) → install directly
+4. `name@org/repo` → look up `name` in the registry with matching namespace
+5. Git shorthand (`github.com/owner/repo`) → install as Git URL
+6. Plain `name` → search registries; error if ambiguous
+
+### Unambiguous short names
+
+If only one installed harness has a given name across all namespaces, the
+short name still works for `run`, `info`, `uninstall`, and `update`:
+
+```bash
+ynh run david                     # works when david is unambiguous
+ynh run david@eyelock/assistants  # always unambiguous
+```
+
+If two registries both have `david` installed, the short form errors with a
+list of candidates.
+
+## Storage layout
+
+Installed harnesses live at `~/.ynh/harnesses/<org>--<repo>/<name>/`:
+
+```
+~/.ynh/harnesses/
+  eyelock--assistants/
+    david/
+      .ynh-plugin/
+        plugin.json
+        installed.json
+      skills/
+    researcher/
+      .ynh-plugin/
+        plugin.json
+  myorg--tools/
+    formatter/
+      .ynh-plugin/
+        plugin.json
+```
+
+The `--` separator is the filesystem-safe encoding of the `/` in the
+namespace. Namespace plus name is a globally unique install key.
+
+### Launchers
+
+`~/.ynh/bin/<org>--<repo>--<name>` is always created for a namespaced install.
+`~/.ynh/bin/<name>` (the short launcher) is created only when `<name>` is
+unambiguous across all installed harnesses. Installing a second harness with
+the same short name from a different namespace removes the short launcher.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,14 +1,14 @@
 # Profiles
 
-Profiles are named configuration variants that allow the same harness to serve different execution contexts — CI, developer, security audit — with different hooks and MCP servers. A single `.harness.json` carries one set of top-level defaults plus any number of profiles that can be selected at run time.
+Profiles are named configuration variants that allow the same harness to serve different execution contexts — CI, developer, security audit — with different hooks and MCP servers. A single `.ynh-plugin/plugin.json` carries one set of top-level defaults plus any number of profiles that can be selected at run time.
 
 ## Why Profiles Matter
 
 A harness that works well for interactive development may need different controls for CI (stricter linting, no interactive MCP servers) or for a security audit (audit logging, SAST tooling). Without profiles, you would need separate harnesses for each context or manual post-install editing. Profiles let the harness author declare all variants in one file, and the operator selects the right one at run time.
 
-## .harness.json Format
+## Manifest Format
 
-Profiles live under the `profiles` key in `.harness.json`. Each profile name maps to an object containing `hooks` and/or `mcp_servers`:
+Profiles live under the `profiles` key in `.ynh-plugin/plugin.json`. Each profile name maps to an object containing `hooks` and/or `mcp_servers`:
 
 ```json
 {
@@ -75,10 +75,10 @@ When both the flag and the environment variable are set, the flag wins. When nei
 
 ## Missing Profile Behavior
 
-Selecting a profile that does not exist in `.harness.json` is a hard error:
+Selecting a profile that does not exist in `.ynh-plugin/plugin.json` is a hard error:
 
 ```
-Error: profile "staging" not defined in .harness.json
+Error: profile "staging" not defined in harness manifest
 ```
 
 This is intentional — a typo in a CI pipeline should fail loudly rather than silently falling back to defaults.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -79,7 +79,7 @@ Commands that take `--format json` emit machine-readable output conforming to [S
 | Command | Structured fields |
 |---------|-------------------|
 | `ynd compose` | Composed harness: `name`, `version`, `description`, `default_vendor`, `artifacts` (with source), `includes`, `delegates_to`, `hooks`, `mcp_servers`, `profiles`, `focuses`, `counts` |
-| `ynh info <name>` | Single harness object: `name`, `version`, `description`, `default_vendor`, `path`, `installed_from`, `manifest` (raw `.harness.json` body) |
+| `ynh info <name>` | Single harness object: `name`, `version`, `description`, `default_vendor`, `path`, `installed_from`, `manifest` (raw `.ynh-plugin/plugin.json` body) |
 | `ynh ls` | Array of harness objects: `name`, `version`, `description`, `default_vendor`, `path`, `installed_from`, `artifacts`, `includes`, `delegates_to` |
 | `ynh paths` | `home`, `config`, `harnesses`, `symlinks`, `cache`, `run`, `bin` — all absolute paths resolved for the current `$YNH_HOME` |
 | `ynh search [query]` | Array of result objects: `name`, `description`, `keywords`, `repo`, `path`, `vendors`, `version`, `from` (`type`, `name`) |

--- a/docs/tutorial/01-first-harness.md
+++ b/docs/tutorial/01-first-harness.md
@@ -22,12 +22,12 @@ ynh init
 
 ## T1.1: Create the harness structure
 
-A harness needs one file at minimum: `.harness.json` (identity and config).
+A harness needs one file at minimum: `.ynh-plugin/plugin.json` (identity and config).
 
 ```bash
-mkdir -p /tmp/ynh-tutorial/my-harness
+mkdir -p /tmp/ynh-tutorial/my-harness/.ynh-plugin
 
-cat > /tmp/ynh-tutorial/my-harness/.harness.json << 'EOF'
+cat > /tmp/ynh-tutorial/my-harness/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "my-harness",
   "version": "0.1.0",
@@ -107,7 +107,7 @@ find /tmp/ynh-tutorial/my-harness -type f | sort
 
 Expected:
 ```
-/tmp/ynh-tutorial/my-harness/.harness.json
+/tmp/ynh-tutorial/my-harness/.ynh-plugin/plugin.json
 /tmp/ynh-tutorial/my-harness/agents/nitpicker.md
 /tmp/ynh-tutorial/my-harness/commands/hello.md
 /tmp/ynh-tutorial/my-harness/instructions.md
@@ -255,7 +255,7 @@ The `remove` alias also works: `ynh remove my-harness`.
 
 ## What you learned
 
-- A harness is a directory with `.harness.json`
+- A harness is a directory with `.ynh-plugin/plugin.json`
 - Four artifact types: skills, agents, rules, commands
 - `instructions.md` becomes vendor-specific project instructions
 - `ynh install` copies the harness and generates a launcher script

--- a/docs/tutorial/02-vendors-and-symlinks.md
+++ b/docs/tutorial/02-vendors-and-symlinks.md
@@ -19,7 +19,8 @@ mkdir -p /tmp/ynh-tutorial
 ```bash
 mkdir -p /tmp/ynh-tutorial/my-harness/skills/ping
 
-cat > /tmp/ynh-tutorial/my-harness/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/my-harness/.ynh-plugin
+cat > /tmp/ynh-tutorial/my-harness/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "my-harness",
   "version": "0.1.0",
@@ -58,7 +59,7 @@ cursor  Cursor        agent   .cursor     true
 
 ynh picks the vendor in this order:
 1. CLI flag `-v` (highest priority)
-2. Harness's `default_vendor` in `.harness.json`
+2. Harness's `default_vendor` in `.ynh-plugin/plugin.json`
 3. Global `~/.ynh/config.json` default (fallback: "claude")
 
 ## T2.3: Switch vendors

--- a/docs/tutorial/03-composition.md
+++ b/docs/tutorial/03-composition.md
@@ -21,7 +21,8 @@ Create a harness that cherry-picks specific skills from it:
 ```bash
 mkdir -p /tmp/ynh-tutorial/my-dev
 
-cat > /tmp/ynh-tutorial/my-dev/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/my-dev/.ynh-plugin
+cat > /tmp/ynh-tutorial/my-dev/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "my-dev",
   "version": "0.1.0",
@@ -82,7 +83,8 @@ ls ~/.ynh/run/my-dev/.claude/skills/
 If you have the assistants repo checked out locally, you can use a local path instead of a Git URL. This is faster (no clone) and useful during development:
 
 ```bash
-cat > /tmp/ynh-tutorial/my-dev/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/my-dev/.ynh-plugin
+cat > /tmp/ynh-tutorial/my-dev/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "my-dev",
   "version": "0.1.0",
@@ -110,7 +112,8 @@ Any GitHub repo that follows the [Agent Skills](https://agentskills.io) standard
 ```bash
 mkdir -p /tmp/ynh-tutorial/with-anthropic
 
-cat > /tmp/ynh-tutorial/with-anthropic/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/with-anthropic/.ynh-plugin
+cat > /tmp/ynh-tutorial/with-anthropic/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "with-anthropic",
   "version": "0.1.0",
@@ -141,7 +144,8 @@ with-anthropic "what skills do you have?"
 ```bash
 mkdir -p /tmp/ynh-tutorial/with-vercel
 
-cat > /tmp/ynh-tutorial/with-vercel/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/with-vercel/.ynh-plugin
+cat > /tmp/ynh-tutorial/with-vercel/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "with-vercel",
   "version": "0.1.0",
@@ -172,7 +176,8 @@ Combine skills from your own repos and third-party repos into one harness:
 ```bash
 mkdir -p /tmp/ynh-tutorial/full-stack
 
-cat > /tmp/ynh-tutorial/full-stack/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/full-stack/.ynh-plugin
+cat > /tmp/ynh-tutorial/full-stack/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "full-stack",
   "version": "0.1.0",
@@ -228,7 +233,8 @@ This skill lives directly in the harness directory.
 It is not pulled from Git. It exists nowhere else.
 EOF
 
-cat > /tmp/ynh-tutorial/mixed/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/mixed/.ynh-plugin
+cat > /tmp/ynh-tutorial/mixed/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "mixed",
   "version": "0.1.0",
@@ -286,7 +292,8 @@ git -C /tmp/ynh-tutorial/local-lib commit -m "init"
 
 # Reference it in a harness
 mkdir -p /tmp/ynh-tutorial/local-ref
-cat > /tmp/ynh-tutorial/local-ref/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/local-ref/.ynh-plugin
+cat > /tmp/ynh-tutorial/local-ref/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "local-ref",
   "version": "0.1.0",
@@ -318,7 +325,8 @@ ls ~/.ynh/run/local-ref/.claude/skills/
 ```bash
 mkdir -p /tmp/ynh-tutorial/pinned
 
-cat > /tmp/ynh-tutorial/pinned/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/pinned/.ynh-plugin
+cat > /tmp/ynh-tutorial/pinned/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "pinned",
   "version": "0.1.0",

--- a/docs/tutorial/04-delegation.md
+++ b/docs/tutorial/04-delegation.md
@@ -19,7 +19,8 @@ Delegates must be Git repos (local or remote). Create a specialist harness and t
 ```bash
 mkdir -p /tmp/ynh-tutorial/specialist/skills/analyze
 
-cat > /tmp/ynh-tutorial/specialist/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/specialist/.ynh-plugin
+cat > /tmp/ynh-tutorial/specialist/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "specialist",
   "version": "0.1.0",
@@ -56,7 +57,8 @@ git -C /tmp/ynh-tutorial/specialist commit -m "init"
 ```bash
 mkdir -p /tmp/ynh-tutorial/team-lead
 
-cat > /tmp/ynh-tutorial/team-lead/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/team-lead/.ynh-plugin
+cat > /tmp/ynh-tutorial/team-lead/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "team-lead",
   "version": "0.1.0",
@@ -143,7 +145,7 @@ ynh uninstall team-lead
 
 ## What you learned
 
-- `delegates_to` in .harness.json references other harnesses as subagents
+- `delegates_to` in .ynh-plugin/plugin.json references other harnesses as subagents
 - Delegates must be Git repos (local or remote)
 - ynh generates vendor-native agent files from delegate harnesses at runtime
 - Agent files inline the delegate's instructions, rules, and skill list

--- a/docs/tutorial/05-export.md
+++ b/docs/tutorial/05-export.md
@@ -42,7 +42,8 @@ cat > /tmp/ynh-tutorial/exportable/instructions.md << 'EOF'
 You are a code quality harness. Focus on correctness and security.
 EOF
 
-cat > /tmp/ynh-tutorial/exportable/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/exportable/.ynh-plugin
+cat > /tmp/ynh-tutorial/exportable/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "exportable",
   "version": "1.0.0",
@@ -82,7 +83,7 @@ ls -Ra /tmp/ynh-tutorial/export-output/claude/
 Expected:
 ```
 .claude-plugin/               # plugin manifest directory
-  plugin.json                 # generated from .harness.json
+  plugin.json                 # generated from .ynh-plugin/plugin.json
 agents/
   checker.md                  # local agent
 skills/
@@ -249,7 +250,8 @@ Clones the repo, applies `--path` scoping, exports. Same as exporting a local di
 
 ```bash
 mkdir -p /tmp/ynh-tutorial/no-instructions
-cat > /tmp/ynh-tutorial/no-instructions/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/no-instructions/.ynh-plugin
+cat > /tmp/ynh-tutorial/no-instructions/.ynh-plugin/plugin.json << 'EOF'
 {"name": "no-instructions", "version": "0.1.0"}
 EOF
 
@@ -257,7 +259,7 @@ ynd export /tmp/ynh-tutorial/no-instructions -o /tmp/ynh-tutorial/no-inst-out -v
 # Expected: succeeds (no warning)
 
 ls -a /tmp/ynh-tutorial/no-inst-out/claude/
-# Expected: .claude-plugin/ only (generated from .harness.json, no AGENTS.md)
+# Expected: .claude-plugin/ only (generated from .ynh-plugin/plugin.json, no AGENTS.md)
 ```
 
 ## Clean up

--- a/docs/tutorial/06-marketplace.md
+++ b/docs/tutorial/06-marketplace.md
@@ -15,7 +15,7 @@ mkdir -p /tmp/ynh-tutorial
 
 Create a small marketplace with one harness and one standalone plugin:
 
-### Standalone plugin (no .harness.json)
+### Standalone plugin (vendor-native format)
 
 ```bash
 mkdir -p /tmp/ynh-tutorial/marketplace-src/plugins/formatter/.claude-plugin
@@ -40,12 +40,13 @@ configured formatter (prettier, gofmt, black, etc.).
 EOF
 ```
 
-### Harness (has .harness.json with includes)
+### Harness (has .ynh-plugin/plugin.json with includes)
 
 ```bash
 mkdir -p /tmp/ynh-tutorial/marketplace-src/harnesses/reviewer
 
-cat > /tmp/ynh-tutorial/marketplace-src/harnesses/reviewer/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/marketplace-src/harnesses/reviewer/.ynh-plugin
+cat > /tmp/ynh-tutorial/marketplace-src/harnesses/reviewer/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "reviewer",
   "version": "1.0.0",
@@ -90,7 +91,7 @@ EOF
 
 Two entry types:
 - **`plugin`** — already a valid plugin directory. Copied as-is, missing vendor manifests generated.
-- **`harness`** — has `.harness.json` with includes. Fully exported (includes resolved, pick applied, delegates generated).
+- **`harness`** — has `.ynh-plugin/plugin.json` with includes. Fully exported (includes resolved, pick applied, delegates generated).
 
 ## T6.3: Build the marketplace
 

--- a/docs/tutorial/09-docker-image.md
+++ b/docs/tutorial/09-docker-image.md
@@ -39,7 +39,8 @@ Create a harness to use throughout this tutorial:
 mkdir -p /tmp/ynh-tutorial/docker-harness/skills/greet
 mkdir -p /tmp/ynh-tutorial/docker-harness/rules
 
-cat > /tmp/ynh-tutorial/docker-harness/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/docker-harness/.ynh-plugin
+cat > /tmp/ynh-tutorial/docker-harness/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "docker-demo",
   "version": "0.1.0",

--- a/docs/tutorial/10-hooks.md
+++ b/docs/tutorial/10-hooks.md
@@ -11,12 +11,13 @@ rm -rf /tmp/ynh-tutorial
 
 ## T10.1: Add hooks to a harness
 
-Create a harness with hook declarations in `.harness.json`:
+Create a harness with hook declarations in `.ynh-plugin/plugin.json`:
 
 ```bash
 mkdir -p /tmp/ynh-tutorial/hook-harness/rules
 
-cat > /tmp/ynh-tutorial/hook-harness/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/hook-harness/.ynh-plugin
+cat > /tmp/ynh-tutorial/hook-harness/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "hook-demo",
   "version": "0.1.0",
@@ -60,7 +61,7 @@ Verify the structure:
 
 ```bash
 ls -R /tmp/ynh-tutorial/hook-harness/
-# Expected: .harness.json, instructions.md, rules/safety.md
+# Expected: .ynh-plugin/, instructions.md, rules/safety.md
 ```
 
 ## T10.2: Preview for Claude
@@ -218,7 +219,7 @@ Expected output shows:
 - `.codex/hooks.json` is only in Codex
 - Shared files (like `CLAUDE.md`, `.cursorrules`, `codex.md`) may be listed as identical or different depending on instructions content
 
-The key difference: the same three hooks declared once in `.harness.json` produce three structurally different config files, each native to the vendor.
+The key difference: the same three hooks declared once in `.ynh-plugin/plugin.json` produce three structurally different config files, each native to the vendor.
 
 ## Clean up
 
@@ -228,7 +229,7 @@ rm -rf /tmp/ynh-tutorial
 
 ## What You Learned
 
-- Hooks are declared in `.harness.json` under `hooks` using canonical event names
+- Hooks are declared in `.ynh-plugin/plugin.json` under `hooks` using canonical event names
 - `ynd preview` shows the assembled vendor-native output without installing
 - Claude, Cursor, and Codex each use different event names and nesting structures
 - Hook scripts should exit with code 2 to block actions and include remediation instructions

--- a/docs/tutorial/10-hooks.md
+++ b/docs/tutorial/10-hooks.md
@@ -60,8 +60,8 @@ EOF
 Verify the structure:
 
 ```bash
-ls -R /tmp/ynh-tutorial/hook-harness/
-# Expected: .ynh-plugin/, instructions.md, rules/safety.md
+ls -aR /tmp/ynh-tutorial/hook-harness/ | grep -v '^\.\{1,2\}$\|^\.:'
+# Expected lines include: .ynh-plugin, instructions.md, rules, safety.md
 ```
 
 ## T10.2: Preview for Claude

--- a/docs/tutorial/11-mcp-servers.md
+++ b/docs/tutorial/11-mcp-servers.md
@@ -16,7 +16,8 @@ Create a harness with an MCP server declaration:
 ```bash
 mkdir -p /tmp/ynh-tutorial/mcp-harness
 
-cat > /tmp/ynh-tutorial/mcp-harness/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/mcp-harness/.ynh-plugin
+cat > /tmp/ynh-tutorial/mcp-harness/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "mcp-demo",
   "version": "0.1.0",
@@ -115,7 +116,8 @@ Codex uses the same JSON format as Claude with a `mcpServers` key, placed at the
 Add a second server using HTTP transport:
 
 ```bash
-cat > /tmp/ynh-tutorial/mcp-harness/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/mcp-harness/.ynh-plugin
+cat > /tmp/ynh-tutorial/mcp-harness/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "mcp-demo",
   "version": "0.1.0",
@@ -215,7 +217,7 @@ rm -rf /tmp/ynh-tutorial
 
 ## What You Learned
 
-- MCP servers are declared in `.harness.json` under `mcp_servers`
+- MCP servers are declared in `.ynh-plugin/plugin.json` under `mcp_servers`
 - Servers can use stdio transport (`command` + `args`) or HTTP transport (`url`)
 - All three vendors use JSON with a `mcpServers` key, but in different file locations
 - Claude places MCP config at `.claude/.mcp.json`, Cursor at `.cursor/mcp.json`, and Codex at `.mcp.json` (plugin root)

--- a/docs/tutorial/12-developer-preview.md
+++ b/docs/tutorial/12-developer-preview.md
@@ -39,7 +39,8 @@ Never deploy to production without running the test suite first.
 Always create a rollback plan before deploying.
 EOF
 
-cat > /tmp/ynh-tutorial/preview-harness/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/preview-harness/.ynh-plugin
+cat > /tmp/ynh-tutorial/preview-harness/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "preview-demo",
   "version": "0.1.0",

--- a/docs/tutorial/13-profiles.md
+++ b/docs/tutorial/13-profiles.md
@@ -12,7 +12,7 @@ ynh uninstall profile-demo 2>/dev/null
 mkdir -p /tmp/ynh-tutorial
 ```
 
-## T13.1: Add profiles to .harness.json
+## T13.1: Add profiles to the plugin manifest
 
 Create a harness with a `ci` profile that adds stricter rules and a lint hook:
 
@@ -20,7 +20,8 @@ Create a harness with a `ci` profile that adds stricter rules and a lint hook:
 mkdir -p /tmp/ynh-tutorial/profile-harness/skills/deploy
 mkdir -p /tmp/ynh-tutorial/profile-harness/rules
 
-cat > /tmp/ynh-tutorial/profile-harness/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/profile-harness/.ynh-plugin
+cat > /tmp/ynh-tutorial/profile-harness/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "profile-demo",
   "version": "0.1.0",
@@ -78,7 +79,7 @@ EOF
 ```
 
 Key points:
-- `profiles` is a top-level field in `.harness.json`
+- `profiles` is a top-level field in `.ynh-plugin/plugin.json`
 - Each profile can contain `hooks` and `mcp_servers`
 - Profiles declare only what they change — absent fields inherit from top-level defaults
 - MCP servers are deep-merged (profile keys win on collision); hooks use per-event replace
@@ -214,7 +215,7 @@ rm -rf /tmp/ynh-tutorial
 
 ## What You Learned
 
-- Profiles are declared in `.harness.json` under `profiles` as named config objects
+- Profiles are declared in `.ynh-plugin/plugin.json` under `profiles` as named config objects
 - Each profile can override `hooks` and `mcp_servers`
 - Profiles use merge semantics: MCP servers are deep-merged (profile keys win), hooks use per-event replace (absent events inherited)
 - Set an MCP server to `null` in a profile to remove an inherited server

--- a/docs/tutorial/14-focus.md
+++ b/docs/tutorial/14-focus.md
@@ -19,7 +19,8 @@ Create a harness with profiles and focus entries that reference them:
 ```bash
 mkdir -p /tmp/ynh-tutorial/focus-harness/skills/deploy
 
-cat > /tmp/ynh-tutorial/focus-harness/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/focus-harness/.ynh-plugin
+cat > /tmp/ynh-tutorial/focus-harness/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "focus-demo",
   "version": "0.1.0",
@@ -185,4 +186,4 @@ rm -rf /tmp/ynh-tutorial
 
 ## Next
 
-[Tutorial 15: Project-Local Config](15-project-local-config.md) — use `.harness.json` in your project root for zero-install AI configuration.
+[Tutorial 15: Project-Local Config](15-project-local-config.md) — use `.ynh-plugin/plugin.json` in your project root for zero-install AI configuration.

--- a/docs/tutorial/15-project-local-config.md
+++ b/docs/tutorial/15-project-local-config.md
@@ -1,6 +1,6 @@
 # Tutorial 15: Project-Local Config
 
-Use a `.harness.json` file in your project root for zero-install AI configuration. No `ynh install` needed — just drop the file and run.
+Use a `.ynh-plugin/plugin.json` file in your project root for zero-install AI configuration. No `ynh install` needed — just drop the file and run.
 
 ## Prerequisites
 
@@ -11,14 +11,15 @@ rm -rf /tmp/ynh-tutorial
 mkdir -p /tmp/ynh-tutorial
 ```
 
-## T15.1: Create a project with .harness.json
+## T15.1: Create a project with .ynh-plugin/plugin.json
 
-Create a project directory with a `.harness.json` file:
+Create a project directory with a `.ynh-plugin/plugin.json` file:
 
 ```bash
 mkdir -p /tmp/ynh-tutorial/my-project/rules
 
-cat > /tmp/ynh-tutorial/my-project/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/my-project/.ynh-plugin
+cat > /tmp/ynh-tutorial/my-project/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "my-project",
   "version": "0.1.0",
@@ -42,9 +43,9 @@ EOF
 ```
 
 Key points:
-- `.harness.json` in the project root — same format as an installed harness
+- `.ynh-plugin/plugin.json` in the project root — same format as an installed harness
 - No `ynh install` needed — ynh can discover and use this file directly
-- Rules, skills, agents, and commands sit alongside `.harness.json` as usual
+- Rules, skills, agents, and commands sit alongside `.ynh-plugin/plugin.json` as usual
 
 ## T15.2: Validate the project config
 
@@ -84,10 +85,10 @@ rm -rf /tmp/ynh-tutorial
 
 ## What You Learned
 
-- `.harness.json` in a project root provides zero-install AI configuration
-- `ynd validate`, `ynd preview`, and `ynd diff` work with project directories containing `.harness.json`
-- `ynh run` auto-discovers `.harness.json` in the current working directory
-- `ynh run --harness-file <path>` points to a specific `.harness.json` file
+- `.ynh-plugin/plugin.json` in a project root provides zero-install AI configuration
+- `ynd validate`, `ynd preview`, and `ynd diff` work with project directories containing `.ynh-plugin/plugin.json`
+- `ynh run` auto-discovers `.ynh-plugin/plugin.json` in the current working directory
+- `ynh run --harness-file <path>` points to a specific `.ynh-plugin/plugin.json` file
 - The file format is identical to installed harnesses — same hooks, MCP servers, profiles, and focus entries
 
 ## Next

--- a/docs/tutorial/16-structured-output.md
+++ b/docs/tutorial/16-structured-output.md
@@ -173,7 +173,8 @@ Always use `--format json` (with a space).
 rm -rf /tmp/ynh-tutorial
 mkdir -p /tmp/ynh-tutorial/my-harness/skills/greet
 
-cat > /tmp/ynh-tutorial/my-harness/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/my-harness/.ynh-plugin
+cat > /tmp/ynh-tutorial/my-harness/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "my-harness",
   "version": "0.1.0",

--- a/docs/tutorial/17-include-editing.md
+++ b/docs/tutorial/17-include-editing.md
@@ -17,7 +17,8 @@ Start with a bare harness and add a Git include to it:
 ```bash
 mkdir -p /tmp/ynh-tutorial-includes/my-harness
 
-cat > /tmp/ynh-tutorial-includes/my-harness/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial-includes/my-harness/.ynh-plugin
+cat > /tmp/ynh-tutorial-includes/my-harness/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "my-harness",
   "version": "0.1.0",
@@ -33,10 +34,10 @@ Expected:
 Added include "github.com/anthropics/skills"
 ```
 
-The include is written to `.harness.json` immediately:
+The include is written to `.ynh-plugin/plugin.json` immediately:
 
 ```bash
-cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+cat /tmp/ynh-tutorial-includes/my-harness/.ynh-plugin/plugin.json
 ```
 
 Expected:
@@ -70,7 +71,7 @@ Added include "github.com/eyelock/assistants" (path: "skills/dev")
 ```
 
 ```bash
-cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+cat /tmp/ynh-tutorial-includes/my-harness/.ynh-plugin/plugin.json
 ```
 
 Expected:
@@ -134,7 +135,7 @@ Replaced include "github.com/anthropics/skills"
 ```
 
 ```bash
-cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+cat /tmp/ynh-tutorial-includes/my-harness/.ynh-plugin/plugin.json
 ```
 
 Expected:
@@ -182,7 +183,7 @@ Updated include "github.com/eyelock/assistants"
 The path and pick are unchanged:
 
 ```bash
-cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+cat /tmp/ynh-tutorial-includes/my-harness/.ynh-plugin/plugin.json
 ```
 
 Expected:
@@ -226,7 +227,7 @@ Updated include "github.com/eyelock/assistants"
 ```
 
 ```bash
-cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+cat /tmp/ynh-tutorial-includes/my-harness/.ynh-plugin/plugin.json
 ```
 
 Expected:
@@ -267,7 +268,7 @@ Removed include "github.com/anthropics/skills"
 ```
 
 ```bash
-cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+cat /tmp/ynh-tutorial-includes/my-harness/.ynh-plugin/plugin.json
 ```
 
 Expected:
@@ -297,7 +298,8 @@ A harness can include the same repo at two different paths. When a URL matches m
 Set up two includes from the same repo at different paths:
 
 ```bash
-cat > /tmp/ynh-tutorial-includes/my-harness/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial-includes/my-harness/.ynh-plugin
+cat > /tmp/ynh-tutorial-includes/my-harness/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "my-harness",
   "version": "0.1.0",
@@ -368,7 +370,7 @@ Updated include "github.com/eyelock/assistants"
 Only the `skills/dev` include is changed; `skills/tech` is untouched:
 
 ```bash
-cat /tmp/ynh-tutorial-includes/my-harness/.harness.json
+cat /tmp/ynh-tutorial-includes/my-harness/.ynh-plugin/plugin.json
 ```
 
 Expected:
@@ -400,7 +402,8 @@ For installed harnesses, use the harness name instead of a path:
 ```bash
 # Install a harness first
 mkdir -p /tmp/ynh-tutorial-includes/base
-cat > /tmp/ynh-tutorial-includes/base/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial-includes/base/.ynh-plugin
+cat > /tmp/ynh-tutorial-includes/base/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "base",
   "version": "0.1.0",
@@ -426,7 +429,7 @@ When targeting an installed harness by name, ynh pre-fetches the new include imm
 ynh info base
 ```
 
-The installed harness's `.harness.json` at `~/.ynh/harnesses/base/.harness.json` now contains the added include.
+The installed harness's `.ynh-plugin/plugin.json` at `~/.ynh/harnesses/base/.ynh-plugin/plugin.json` now contains the added include.
 
 ```bash
 # Clean up
@@ -461,7 +464,7 @@ rm -rf /tmp/ynh-tutorial-includes
 - `<harness>` is a **name** (installed harness) or a **path** (local directory); paths take a `/` or `.` prefix
 - Installed harnesses are pre-fetched after `add` or `update` so `ynh run` works immediately — no separate `ynh update` needed
 - `--pick` names are validated against the fetched repo — unknown names produce a clear error with the available list
-- Mutations never happen if validation fails — the `.harness.json` is only written after all checks pass
+- Mutations never happen if validation fails — the `.ynh-plugin/plugin.json` is only written after all checks pass
 
 ## Next
 

--- a/docs/tutorial/18-namespacing-and-migration.md
+++ b/docs/tutorial/18-namespacing-and-migration.md
@@ -1,0 +1,247 @@
+# Tutorial 18: Namespacing & Migration
+
+Install the same-named harness from multiple registries using `@` syntax, and
+migrate legacy `.harness.json` / `registry.json` files to the 0.2 format.
+
+## Prerequisites
+
+```bash
+# Clean up from any previous run
+rm -rf /tmp/ynh-ns-tutorial
+mkdir -p /tmp/ynh-ns-tutorial
+ynh registry remove /tmp/ynh-ns-tutorial/reg-a 2>/dev/null
+ynh registry remove /tmp/ynh-ns-tutorial/reg-b 2>/dev/null
+ynh uninstall david 2>/dev/null
+ynh uninstall david@acme/tools 2>/dev/null
+ynh uninstall david@eyelock/assistants 2>/dev/null
+```
+
+## T18.1: Create two registries with overlapping names
+
+Two different authors both publish a harness called `david`. In 0.1 this would
+silently conflict. In 0.2 each harness lives under its own namespace.
+
+```bash
+# Registry A — eyelock/assistants
+mkdir -p /tmp/ynh-ns-tutorial/reg-a/harnesses/david/.ynh-plugin
+cat > /tmp/ynh-ns-tutorial/reg-a/harnesses/david/.ynh-plugin/plugin.json << 'EOF'
+{
+  "name": "david",
+  "version": "0.1.0",
+  "description": "Eyelock's development harness"
+}
+EOF
+
+mkdir -p /tmp/ynh-ns-tutorial/reg-a/.ynh-plugin
+cat > /tmp/ynh-ns-tutorial/reg-a/.ynh-plugin/marketplace.json << 'EOF'
+{
+  "name": "eyelock-assistants",
+  "owner": {"name": "eyelock"},
+  "harnesses": [
+    {"name": "david", "source": "./harnesses/david"}
+  ]
+}
+EOF
+
+(cd /tmp/ynh-ns-tutorial/reg-a && git init -q && git add . && git commit -q -m init)
+
+# Registry B — acme/tools
+mkdir -p /tmp/ynh-ns-tutorial/reg-b/harnesses/david/.ynh-plugin
+cat > /tmp/ynh-ns-tutorial/reg-b/harnesses/david/.ynh-plugin/plugin.json << 'EOF'
+{
+  "name": "david",
+  "version": "2.0.0",
+  "description": "Acme's David harness (different author)"
+}
+EOF
+
+mkdir -p /tmp/ynh-ns-tutorial/reg-b/.ynh-plugin
+cat > /tmp/ynh-ns-tutorial/reg-b/.ynh-plugin/marketplace.json << 'EOF'
+{
+  "name": "acme-tools",
+  "owner": {"name": "acme"},
+  "harnesses": [
+    {"name": "david", "source": "./harnesses/david"}
+  ]
+}
+EOF
+
+(cd /tmp/ynh-ns-tutorial/reg-b && git init -q && git add . && git commit -q -m init)
+```
+
+## T18.2: Register both
+
+```bash
+ynh registry add /tmp/ynh-ns-tutorial/reg-a
+ynh registry add /tmp/ynh-ns-tutorial/reg-b
+```
+
+Expected:
+```
+Added registry: /tmp/ynh-ns-tutorial/reg-a
+Added registry: /tmp/ynh-ns-tutorial/reg-b
+```
+
+## T18.3: Understand namespaces
+
+The namespace comes from the registry URL, not the user-chosen name. For local
+paths like these, it's the last two path segments of the source URL. Real GitHub
+registries would derive namespaces like `eyelock/assistants` and `acme/tools`.
+
+Run a search to see both `david` entries, each from its own registry:
+
+```bash
+ynh search david
+```
+
+Expected (two rows): one from each registry.
+
+## T18.4: Disambiguate install with @ syntax
+
+Attempting plain install is ambiguous:
+
+```bash
+ynh install david 2>&1 | head -3
+```
+
+Expected: an error listing both candidates.
+
+Install from a specific registry using `name@org/repo`:
+
+```bash
+ynh install "david@ynh-ns-tutorial/reg-a"
+ynh install "david@ynh-ns-tutorial/reg-b"
+```
+
+> **Note:** For GitHub-hosted registries, the @ syntax is `name@owner/repo`
+> (for example `david@eyelock/assistants`). Local-path registries use the last
+> two path segments as the namespace.
+
+## T18.5: List both — namespaces shown
+
+```bash
+ynh ls
+```
+
+Both harnesses appear, each under its namespace. The `ynh/bin/david` short
+launcher is only created when the name is unambiguous — installing a second
+`david` removes the short launcher and requires the namespaced launcher
+(`ynh-ns-tutorial--reg-a--david`) or `ynh run david@<namespace>`.
+
+## T18.6: Migrate a legacy harness with ynd migrate
+
+Create a harness in the legacy 0.1 format:
+
+```bash
+mkdir -p /tmp/ynh-ns-tutorial/legacy
+cat > /tmp/ynh-ns-tutorial/legacy/.harness.json << 'EOF'
+{
+  "name": "legacy-demo",
+  "version": "0.1.0",
+  "description": "Legacy format harness"
+}
+EOF
+```
+
+Migrate it in place:
+
+```bash
+ynd migrate /tmp/ynh-ns-tutorial/legacy
+```
+
+Expected:
+```
+Migrated /tmp/ynh-ns-tutorial/legacy
+  harness format: .harness.json → .ynh-plugin/plugin.json
+Migrated 1 director(ies).
+```
+
+Verify the result:
+
+```bash
+find /tmp/ynh-ns-tutorial/legacy -type f | sort
+```
+
+Expected:
+```
+/tmp/ynh-ns-tutorial/legacy/.ynh-plugin/plugin.json
+```
+
+`ynd migrate` runs the migration filter chain — it handles any registered
+migrator. Adding a new format migrator in future releases does not require a
+new command.
+
+## T18.7: Recursive migration
+
+Create multiple legacy harnesses at once, then migrate the whole tree:
+
+```bash
+mkdir -p /tmp/ynh-ns-tutorial/bulk/h1 /tmp/ynh-ns-tutorial/bulk/h2
+cat > /tmp/ynh-ns-tutorial/bulk/h1/.harness.json << 'EOF'
+{"name":"h1","version":"0.1.0"}
+EOF
+cat > /tmp/ynh-ns-tutorial/bulk/h2/.harness.json << 'EOF'
+{"name":"h2","version":"0.1.0"}
+EOF
+
+ynd migrate -r /tmp/ynh-ns-tutorial/bulk
+```
+
+Expected:
+```
+Migrated /tmp/ynh-ns-tutorial/bulk/h1
+  harness format: .harness.json → .ynh-plugin/plugin.json
+Migrated /tmp/ynh-ns-tutorial/bulk/h2
+  harness format: .harness.json → .ynh-plugin/plugin.json
+Migrated 2 director(ies).
+```
+
+## T18.8: Transparent migration on use
+
+Legacy harnesses do not strictly require `ynd migrate`. ynh runs the migration
+chain automatically whenever a harness is loaded or installed, so an
+unmigrated 0.1 harness still works:
+
+```bash
+mkdir -p /tmp/ynh-ns-tutorial/transparent
+cat > /tmp/ynh-ns-tutorial/transparent/.harness.json << 'EOF'
+{"name":"transparent","version":"0.1.0"}
+EOF
+
+ynh install /tmp/ynh-ns-tutorial/transparent
+```
+
+The install succeeds and the installed copy uses the 0.2 format. The source
+directory is also migrated in place (the chain runs before the copy).
+
+`ynd migrate` is still useful when you want to convert a whole tree
+intentionally — for example when cleaning up a source repo before publishing.
+
+## Clean up
+
+```bash
+ynh uninstall david@ynh-ns-tutorial/reg-a 2>/dev/null
+ynh uninstall david@ynh-ns-tutorial/reg-b 2>/dev/null
+ynh uninstall legacy-demo transparent h1 h2 2>/dev/null
+ynh registry remove /tmp/ynh-ns-tutorial/reg-a 2>/dev/null
+ynh registry remove /tmp/ynh-ns-tutorial/reg-b 2>/dev/null
+rm -rf /tmp/ynh-ns-tutorial
+```
+
+## What You Learned
+
+- Namespaces are derived from the registry URL and are stable across machines
+- `name@org/repo` syntax disambiguates between same-named harnesses
+- `ynh ls` shows namespace information alongside each installed harness
+- Short launchers (`~/.ynh/bin/<name>`) exist only when the short name is
+  unambiguous; namespaced launchers always exist
+- `ynd migrate` converts `.harness.json` → `.ynh-plugin/plugin.json` and
+  `registry.json` → `.ynh-plugin/marketplace.json` in place
+- Migration runs transparently on install and load; `ynd migrate` is the
+  explicit tool for bulk conversion and source-repo cleanup
+
+## Next
+
+See [docs/namespacing.md](../namespacing.md) for the full @ syntax reference
+and [docs/migration.md](../migration.md) for a complete 0.1 → 0.2 migration
+guide.

--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -164,7 +164,7 @@ Requires Docker installed and running.
 
 | ID | Test | Tutorial step |
 |---|---|---|
-| T10.1 | Add hooks to .harness.json | [T10.1](tutorial/10-hooks.md#t101-add-hooks-to-a-harness) |
+| T10.1 | Add hooks to .ynh-plugin/plugin.json | [T10.1](tutorial/10-hooks.md#t101-add-hooks-to-a-harness) |
 | T10.2 | Preview for Claude — verify hooks.json | [T10.2](tutorial/10-hooks.md#t102-preview-for-claude) |
 | T10.3 | Preview for Cursor — verify hooks.json | [T10.3](tutorial/10-hooks.md#t103-preview-for-cursor) |
 | T10.4 | Preview for Codex — verify hooks.json | [T10.4](tutorial/10-hooks.md#t104-preview-for-codex) |
@@ -196,7 +196,7 @@ Requires Docker installed and running.
 
 | ID | Test | Tutorial step |
 |---|---|---|
-| T13.1 | Add profiles to .harness.json | [T13.1](tutorial/13-profiles.md#t131-add-profiles-to-harnessjson) |
+| T13.1 | Add profiles to the plugin manifest | [T13.1](tutorial/13-profiles.md#t131-add-profiles-to-the-plugin-manifest) |
 | T13.2 | Validate profiles | [T13.2](tutorial/13-profiles.md#t132-validate-profiles) |
 | T13.3 | Preview with --profile ci | [T13.3](tutorial/13-profiles.md#t133-preview-with---profile-ci) |
 | T13.4 | Run with --profile ci | [T13.4](tutorial/13-profiles.md#t134-run-with---profile-ci) |
@@ -250,7 +250,7 @@ ynd --help         # Expected: same
 
 ```bash
 mkdir -p /tmp/ynh-edge/repo
-echo '{"name":"edge","version":"0.1.0"}' > /tmp/ynh-edge/repo/.harness.json
+echo '{"name":"edge","version":"0.1.0"}' > /tmp/ynh-edge/repo/.ynh-plugin/plugin.json
 
 ynh install /tmp/ynh-edge/repo --path nonexistent/path
 # Expected: Error: path "nonexistent/path" not found in source
@@ -260,7 +260,7 @@ ynh install /tmp/ynh-edge/repo --path nonexistent/path
 
 ```bash
 mkdir -p /tmp/ynh-edge/dup
-echo '{"name":"dup","version":"0.1.0"}' > /tmp/ynh-edge/dup/.harness.json
+echo '{"name":"dup","version":"0.1.0"}' > /tmp/ynh-edge/dup/.ynh-plugin/plugin.json
 
 ynh install /tmp/ynh-edge/dup
 ynh install /tmp/ynh-edge/dup
@@ -414,11 +414,12 @@ ynd preview /tmp/some-harness -v claude --focus nonexistent
 # Expected: Error: focus "nonexistent" not defined in harness
 ```
 
-### E21: Focus with missing prompt in .harness.json
+### E21: Focus with missing prompt in .ynh-plugin/plugin.json
 
 ```bash
 mkdir -p /tmp/ynh-bad-focus
-cat > /tmp/ynh-bad-focus/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-bad-focus/.ynh-plugin
+cat > /tmp/ynh-bad-focus/.ynh-plugin/plugin.json << 'EOF'
 {"name":"bad","version":"0.1.0","focus":{"review":{"profile":"ci"}}}
 EOF
 ynd validate /tmp/ynh-bad-focus
@@ -430,7 +431,8 @@ rm -rf /tmp/ynh-bad-focus
 
 ```bash
 mkdir -p /tmp/ynh-bad-focus
-cat > /tmp/ynh-bad-focus/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-bad-focus/.ynh-plugin
+cat > /tmp/ynh-bad-focus/.ynh-plugin/plugin.json << 'EOF'
 {"name":"bad","version":"0.1.0","focus":{"review":{"profile":"nonexistent","prompt":"Review code"}}}
 EOF
 ynd validate /tmp/ynh-bad-focus

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -40,7 +40,7 @@ Installations are tracked in `~/.ynh/symlinks.json`. Use `ynh status` to see all
 
 ## Choosing a Vendor
 
-**Per-harness** (in `.harness.json`):
+**Per-harness** (in `.ynh-plugin/plugin.json`):
 
 ```json
 {

--- a/docs/ynd.md
+++ b/docs/ynd.md
@@ -111,7 +111,7 @@ ynd preview --harness ./my-harness          # explicit harness flag
 
 When no `-o` flag is given, preview prints a tree with file contents to stdout. With `-o`, it writes the full assembled output to the specified directory.
 
-Preview supports the same source types as export: local directories with `.harness.json` or bare `AGENTS.md` directories.
+Preview supports the same source types as export: local directories with `.ynh-plugin/plugin.json` or bare `AGENTS.md` directories.
 
 See [Tutorial 8: Developer Preview](tutorial/12-developer-preview.md) for a guided walkthrough.
 

--- a/docs/ynd.md
+++ b/docs/ynd.md
@@ -18,7 +18,7 @@ brew tap eyelock/tap && brew install ynh
 Scaffold a new artifact or full harness.
 
 ```bash
-ynd create harness my-team     # full harness directory structure (.harness.json + artifacts)
+ynd create harness my-team     # full harness directory structure (.ynh-plugin/plugin.json + artifacts)
 ynd create skill commit        # skills/commit/SKILL.md
 ynd create agent reviewer      # agents/reviewer.md
 ynd create rule be-nice        # rules/be-nice.md
@@ -231,6 +231,28 @@ ynd marketplace build --clean                     # remove output dir before bui
 - `plugin` entries are copied as-is (already in vendor-native format)
 - `harness` entries are fully exported — includes resolved, artifacts flattened
 - Codex is excluded (no marketplace system)
+
+### migrate
+
+Run the format migration chain against a harness or registry directory.
+Handles any registered migrator generically — the command itself knows
+nothing about specific formats. See [docs/migration.md](migration.md) for
+the full 0.1 → 0.2 migration guide.
+
+```bash
+ynd migrate                    # current directory
+ynd migrate ./my-harness       # specific directory
+ynd migrate -r ./harnesses     # recursive: walk tree, migrate every match
+```
+
+Idempotent — safe to run twice. No-op if the target already uses the new
+format. Called transparently by ynh on first access to a legacy harness,
+so manual invocation is rarely needed except for source trees.
+
+| Flag | Description |
+|------|-------------|
+| `-r, --recursive` | Walk the tree and migrate every matching dir |
+| `-h, --help` | Show help |
 
 **Output structure:**
 


### PR DESCRIPTION
## Summary

Part 4 of 4. Documentation reflects the migrated world — no code changes.

- **New `docs/namespacing.md`** — `@` syntax, namespace derivation rules,
  storage layout, launcher disambiguation.
- **New `docs/migration.md`** — 0.1 → 0.2 guide covering the filter chain,
  author/registry/end-user paths, and the 0.3 compat timeline.
- **New `docs/tutorial/18-namespacing-and-migration.md`** — walkthrough for
  `@` syntax (same-name harnesses across registries), `ynd migrate` single
  and recursive, and transparent migration on install.
- **Every existing tutorial** — `.harness.json` references rewritten to
  `.ynh-plugin/plugin.json`; `mkdir -p` fixed so `.ynh-plugin` parent
  exists before `cat >`; T7 VENDORS column dropped to match new schema;
  T13 error message matches new format-agnostic wording; T10 uses
  `ls -aR` so `.ynh-plugin` shows up in the listing.
- **Every core reference doc** — artifacts, cli-structured, hooks,
  harness-engineering, harnesses, getting-started, mcp, README, reference,
  marketplace, ynd, profiles, vendors. Backtick, quoted, and path-style
  references rewritten. `docs/migration.md` intentionally retains the old
  names as source formats.
- **`docs/ynd.md`** gains a section for `ynd migrate`.
- **`docs/_sidebar.md`** links the new pages.

## Depends on

- [#80](https://github.com/eyelock/ynh/pull/80), [#81](https://github.com/eyelock/ynh/pull/81),
  [#82](https://github.com/eyelock/ynh/pull/82)

## Test plan

- [x] `/evals` PASS with this stack merged (17 tutorials, 22 error cases)
- [x] Walked T18 manually end-to-end against fresh binaries