### PR TITLE
fix: canonicalise --pick to type/name form (+ constants, did-you-mean hint)

### DIFF
--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -98,7 +98,7 @@ External Git sources to pull artifacts from.
     {
       "git": "github.com/user/skills-repo",
       "ref": "v2.0.0",
-      "pick": ["skills/commit", "agents/reviewer"]
+      "pick": ["skills/commit", "agents/reviewer.md"]
     }
   ]
 }
@@ -136,7 +136,7 @@ See [Private Repositories](getting-started.md#private-repositories) for authenti
     {
       "git": "github.com/company/monorepo",
       "path": "packages/ai-config",
-      "pick": ["skills/deploy", "agents/ops"]
+      "pick": ["skills/deploy", "agents/ops.md"]
     }
   ]
 }
@@ -378,7 +378,7 @@ Just a named launcher. Useful as a starting point.
     {
       "git": "github.com/company/design-system",
       "path": "ai",
-      "pick": ["rules/component-standards"]
+      "pick": ["rules/component-standards.md"]
     }
   ],
   "delegates_to": [

--- a/docs/schema/plugin.schema.json
+++ b/docs/schema/plugin.schema.json
@@ -131,7 +131,14 @@
           "git": { "type": "string" },
           "ref": { "type": "string" },
           "path": { "type": "string" },
-          "pick": { "type": "array", "items": { "type": "string" } }
+          "pick": {
+            "type": "array",
+            "description": "Artifact paths in canonical type/name form. Skills use the bare name (they are directories): skills/<name>. Flat artifacts include the .md extension: agents/<name>.md, rules/<name>.md, commands/<name>.md.",
+            "items": {
+              "type": "string",
+              "pattern": "^(skills/[^/]+|(agents|rules|commands)/[^/]+\\.md)$"
+            }
+          }
         }
       }
     },

--- a/docs/tutorial/17-include-editing.md
+++ b/docs/tutorial/17-include-editing.md
@@ -61,7 +61,7 @@ Add a second include scoped to a subdirectory with specific picks and a pinned r
 ```bash
 ynh include add /tmp/ynh-tutorial-includes/my-harness github.com/eyelock/assistants \
   --path skills/dev \
-  --pick dev-project,dev-quality \
+  --pick skills/dev-project,skills/dev-quality \
   --ref main
 ```
 
@@ -89,8 +89,8 @@ Expected:
       "ref": "main",
       "path": "skills/dev",
       "pick": [
-        "dev-project",
-        "dev-quality"
+        "skills/dev-project",
+        "skills/dev-quality"
       ]
     }
   ]
@@ -102,7 +102,7 @@ Expected:
 | Flag | Purpose |
 |------|---------|
 | `--path <subdir>` | Scope into a subdirectory of the repo |
-| `--pick <items>` | Comma-separated artifact names to include (all others excluded) |
+| `--pick <items>` | Comma-separated artifact paths in `type/name` form: `skills/<name>`, `agents/<name>.md`, `rules/<name>.md`, `commands/<name>.md`. All others excluded. |
 | `--ref <ref>` | Pin to a branch, tag, or commit SHA |
 
 ## T17.3: Duplicate add → error
@@ -125,7 +125,7 @@ Use `--replace` to overwrite an existing include rather than erroring:
 
 ```bash
 ynh include add /tmp/ynh-tutorial-includes/my-harness github.com/anthropics/skills \
-  --pick frontend-design \
+  --pick skills/frontend-design \
   --replace
 ```
 
@@ -148,7 +148,7 @@ Expected:
     {
       "git": "github.com/anthropics/skills",
       "pick": [
-        "frontend-design"
+        "skills/frontend-design"
       ]
     },
     {
@@ -156,8 +156,8 @@ Expected:
       "ref": "main",
       "path": "skills/dev",
       "pick": [
-        "dev-project",
-        "dev-quality"
+        "skills/dev-project",
+        "skills/dev-quality"
       ]
     }
   ]
@@ -196,7 +196,7 @@ Expected:
     {
       "git": "github.com/anthropics/skills",
       "pick": [
-        "frontend-design"
+        "skills/frontend-design"
       ]
     },
     {
@@ -204,8 +204,8 @@ Expected:
       "ref": "v1.0.0",
       "path": "skills/dev",
       "pick": [
-        "dev-project",
-        "dev-quality"
+        "skills/dev-project",
+        "skills/dev-quality"
       ]
     }
   ]
@@ -240,7 +240,7 @@ Expected:
     {
       "git": "github.com/anthropics/skills",
       "pick": [
-        "frontend-design"
+        "skills/frontend-design"
       ]
     },
     {
@@ -248,8 +248,8 @@ Expected:
       "ref": "v1.0.0",
       "path": "skills/tech",
       "pick": [
-        "dev-project",
-        "dev-quality"
+        "skills/dev-project",
+        "skills/dev-quality"
       ]
     }
   ]
@@ -283,8 +283,8 @@ Expected:
       "ref": "v1.0.0",
       "path": "skills/tech",
       "pick": [
-        "dev-project",
-        "dev-quality"
+        "skills/dev-project",
+        "skills/dev-quality"
       ]
     }
   ]
@@ -463,7 +463,8 @@ rm -rf /tmp/ynh-tutorial-includes
 - `ynh include update <harness> <url>` — updates specific fields; only supplied flags change; uses `--from-path` to target one of multiple entries from the same URL; `--path` changes the path value
 - `<harness>` is a **name** (installed harness) or a **path** (local directory); paths take a `/` or `.` prefix
 - Installed harnesses are pre-fetched after `add` or `update` so `ynh run` works immediately — no separate `ynh update` needed
-- `--pick` names are validated against the fetched repo — unknown names produce a clear error with the available list
+- `--pick` values must use the canonical `type/name` form (`skills/<name>`, `agents/<name>.md`, `rules/<name>.md`, `commands/<name>.md`); validated against the fetched repo with a "did you mean" list on error
+- The `type/` prefix disambiguates a skill and a flat artifact that share a basename (e.g., `skills/foo` vs `agents/foo.md` — both can be picked independently)
 - Mutations never happen if validation fails — the `.ynh-plugin/plugin.json` is only written after all checks pass
 
 ## Next

--- a/docs/tutorial/17-include-editing.md
+++ b/docs/tutorial/17-include-editing.md
@@ -463,8 +463,9 @@ rm -rf /tmp/ynh-tutorial-includes
 - `ynh include update <harness> <url>` — updates specific fields; only supplied flags change; uses `--from-path` to target one of multiple entries from the same URL; `--path` changes the path value
 - `<harness>` is a **name** (installed harness) or a **path** (local directory); paths take a `/` or `.` prefix
 - Installed harnesses are pre-fetched after `add` or `update` so `ynh run` works immediately — no separate `ynh update` needed
-- `--pick` values must use the canonical `type/name` form (`skills/<name>`, `agents/<name>.md`, `rules/<name>.md`, `commands/<name>.md`); validated against the fetched repo with a "did you mean" list on error
-- The `type/` prefix disambiguates a skill and a flat artifact that share a basename (e.g., `skills/foo` vs `agents/foo.md` — both can be picked independently)
+- `--pick` values must use the canonical `type/name` form (`skills/<name>`, `agents/<name>.md`, `rules/<name>.md`, `commands/<name>.md`); validated against the fetched repo before the manifest is touched
+- If a bare basename or mistyped pick resolves to existing canonical entries, the error leads with a "Did you mean …?" hint (`--pick foo` → `did you mean skills/foo or agents/foo.md?`); otherwise the full available list is shown
+- The `type/` prefix disambiguates a skill and a flat artifact that share a basename — both can be picked independently
 - Mutations never happen if validation fails — the `.ynh-plugin/plugin.json` is only written after all checks pass
 
 ## Next

--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -182,9 +182,10 @@ func FindUpdateTarget(dir, url string, opts UpdateOptions) (plugin.IncludeMeta, 
 
 // ValidatePicks checks that every pick names an artifact that exists in basePath.
 //
-// Each pick must be in canonical type/name form:
+// Each pick must be in canonical type/name form. Directory-style types carry
+// no extension (skills/<name>); flat-file types carry .md:
 //
-//   - Skills:   "skills/<name>"         (a skill directory containing SKILL.md)
+//   - Skills:   "skills/<name>"        (a skill directory containing SKILL.md)
 //   - Agents:   "agents/<name>.md"
 //   - Rules:    "rules/<name>.md"
 //   - Commands: "commands/<name>.md"
@@ -194,8 +195,11 @@ func FindUpdateTarget(dir, url string, opts UpdateOptions) (plugin.IncludeMeta, 
 // type/name prefix also disambiguates a skill named "foo" from an agent named
 // "foo.md" — both can coexist and be picked independently.
 //
-// The error listing for unknown picks uses the same canonical form so the
-// user can copy an entry directly into their --pick argument.
+// On unknown picks the error lists the canonical candidates. When a user
+// submitted a bare basename that resolves to exactly one canonical entry,
+// the error leads with a "Did you mean <X>?" suggestion; when it resolves
+// to several (e.g. a skill and an agent share a basename) all candidates
+// are suggested; when it matches none the full available list is shown.
 func ValidatePicks(basePath string, picks []string) error {
 	artifacts, err := ScanArtifactsDir(basePath)
 	if err != nil {
@@ -203,17 +207,29 @@ func ValidatePicks(basePath string, picks []string) error {
 	}
 
 	known := make(map[string]bool)
+	// byBasename indexes canonical entries by their basename (sans .md) so we
+	// can offer "did you mean ...?" suggestions when a user submits a bare name.
+	byBasename := make(map[string][]string)
+
 	for _, n := range artifacts.Skills {
-		known["skills/"+n] = true
+		canon := "skills/" + n
+		known[canon] = true
+		byBasename[n] = append(byBasename[n], canon)
 	}
 	for _, n := range artifacts.Agents {
-		known["agents/"+n+".md"] = true
+		canon := "agents/" + n + ".md"
+		known[canon] = true
+		byBasename[n] = append(byBasename[n], canon)
 	}
 	for _, n := range artifacts.Rules {
-		known["rules/"+n+".md"] = true
+		canon := "rules/" + n + ".md"
+		known[canon] = true
+		byBasename[n] = append(byBasename[n], canon)
 	}
 	for _, n := range artifacts.Commands {
-		known["commands/"+n+".md"] = true
+		canon := "commands/" + n + ".md"
+		known[canon] = true
+		byBasename[n] = append(byBasename[n], canon)
 	}
 
 	var unknown []string
@@ -227,16 +243,40 @@ func ValidatePicks(basePath string, picks []string) error {
 		return nil
 	}
 
+	// Build suggestion lines. For each unknown pick try basename → canonical
+	// resolution; if that fails, fall back to dropping any type/ prefix and
+	// retrying (so "skill/foo" with a typo'd type still hints).
+	var suggestions []string
+	for _, bad := range unknown {
+		candidates := suggestionsFor(bad, byBasename)
+		if len(candidates) > 0 {
+			suggestions = append(suggestions, fmt.Sprintf("  %s → did you mean %s?", bad, strings.Join(candidates, " or ")))
+		}
+	}
+
 	available := make([]string, 0, len(known))
 	for n := range known {
 		available = append(available, n)
 	}
 
-	return fmt.Errorf(
-		"unknown pick name(s): %s\nAvailable: %s\n(Picks must use type/name form: skills/<name>, agents/<name>.md, rules/<name>.md, commands/<name>.md)",
-		strings.Join(unknown, ", "),
-		formatAvailable(available),
-	)
+	msg := fmt.Sprintf("unknown pick name(s): %s", strings.Join(unknown, ", "))
+	if len(suggestions) > 0 {
+		msg += "\n" + strings.Join(suggestions, "\n")
+	}
+	msg += fmt.Sprintf("\nAvailable: %s\n(Picks must use type/name form: skills/<name>, agents/<name>.md, rules/<name>.md, commands/<name>.md)", formatAvailable(available))
+	return fmt.Errorf("%s", msg)
+}
+
+// suggestionsFor returns canonical entries that share the unknown pick's
+// basename. Strips any leading "type/" and trailing ".md" before lookup
+// so "foo", "skill/foo", and "foo.md" all resolve to the same candidates.
+func suggestionsFor(bad string, byBasename map[string][]string) []string {
+	bare := bad
+	if idx := strings.Index(bare, "/"); idx >= 0 {
+		bare = bare[idx+1:]
+	}
+	bare = strings.TrimSuffix(bare, ".md")
+	return byBasename[bare]
 }
 
 func findInclude(includes []plugin.IncludeMeta, url, path string) int {

--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -180,26 +180,40 @@ func FindUpdateTarget(dir, url string, opts UpdateOptions) (plugin.IncludeMeta, 
 	return inc, nil
 }
 
-// ValidatePicks checks that every named pick exists as an artifact in basePath.
-// Returns an error listing any unrecognised names.
+// ValidatePicks checks that every pick names an artifact that exists in basePath.
+//
+// Each pick must be in canonical type/name form:
+//
+//   - Skills:   "skills/<name>"         (a skill directory containing SKILL.md)
+//   - Agents:   "agents/<name>.md"
+//   - Rules:    "rules/<name>.md"
+//   - Commands: "commands/<name>.md"
+//
+// This is the same format the assembler expects (see assembler.CopyPicked), so
+// a pick that passes validation here is guaranteed to work end-to-end. The
+// type/name prefix also disambiguates a skill named "foo" from an agent named
+// "foo.md" — both can coexist and be picked independently.
+//
+// The error listing for unknown picks uses the same canonical form so the
+// user can copy an entry directly into their --pick argument.
 func ValidatePicks(basePath string, picks []string) error {
 	artifacts, err := ScanArtifactsDir(basePath)
 	if err != nil {
 		return fmt.Errorf("scanning artifacts for pick validation: %w", err)
 	}
 
-	known := make(map[string]bool, len(artifacts.Skills)+len(artifacts.Agents)+len(artifacts.Rules)+len(artifacts.Commands))
+	known := make(map[string]bool)
 	for _, n := range artifacts.Skills {
-		known[n] = true
+		known["skills/"+n] = true
 	}
 	for _, n := range artifacts.Agents {
-		known[n] = true
+		known["agents/"+n+".md"] = true
 	}
 	for _, n := range artifacts.Rules {
-		known[n] = true
+		known["rules/"+n+".md"] = true
 	}
 	for _, n := range artifacts.Commands {
-		known[n] = true
+		known["commands/"+n+".md"] = true
 	}
 
 	var unknown []string
@@ -219,7 +233,7 @@ func ValidatePicks(basePath string, picks []string) error {
 	}
 
 	return fmt.Errorf(
-		"unknown pick name(s): %s\nAvailable: %s",
+		"unknown pick name(s): %s\nAvailable: %s\n(Picks must use type/name form: skills/<name>, agents/<name>.md, rules/<name>.md, commands/<name>.md)",
 		strings.Join(unknown, ", "),
 		formatAvailable(available),
 	)

--- a/internal/harness/editor_test.go
+++ b/internal/harness/editor_test.go
@@ -1,8 +1,11 @@
 package harness
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -477,5 +480,71 @@ func TestFindUpdateTarget_ComputesFinalState(t *testing.T) {
 	}
 	if inc.Path != "new" || inc.Ref != "v2" {
 		t.Errorf("expected path=new ref=v2, got path=%q ref=%q", inc.Path, inc.Ref)
+	}
+}
+
+// TestArtifactTypes_SchemaAgreement asserts that the pick regex in
+// docs/schema/plugin.schema.json covers exactly the artifact types declared
+// in ArtifactTypeDirs + ArtifactTypeFiles. If someone adds a new directory-
+// or file-style artifact root to harness without updating the schema, this
+// test fails and names the divergent type.
+func TestArtifactTypes_SchemaAgreement(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	schemaPath := filepath.Join(filepath.Dir(thisFile), "..", "..", "docs", "schema", "plugin.schema.json")
+
+	data, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+
+	// Walk into $defs.includes.items.properties.pick.items.pattern.
+	defs, _ := schema["$defs"].(map[string]any)
+	includes, _ := defs["includes"].(map[string]any)
+	items, _ := includes["items"].(map[string]any)
+	props, _ := items["properties"].(map[string]any)
+	pick, _ := props["pick"].(map[string]any)
+	pickItems, _ := pick["items"].(map[string]any)
+	pattern, _ := pickItems["pattern"].(string)
+	if pattern == "" {
+		t.Fatal("schema: could not locate pick.items.pattern")
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		t.Fatalf("compile schema pattern %q: %v", pattern, err)
+	}
+
+	// Every directory-style type must match as type/<bare>. (A skill named
+	// "foo.md" is legal — it's an unusual but valid directory name — so we
+	// don't assert the suffix is rejected here.)
+	for _, typ := range ArtifactTypeDirs {
+		sample := typ + "/demo"
+		if !re.MatchString(sample) {
+			t.Errorf("schema pick.items.pattern does not match directory-style type %q (sample %q)", typ, sample)
+		}
+	}
+
+	// Every flat-file type must match as type/<bare>.md and reject bare form.
+	for _, typ := range ArtifactTypeFiles {
+		sampleOK := typ + "/demo.md"
+		sampleBad := typ + "/demo"
+		if !re.MatchString(sampleOK) {
+			t.Errorf("schema pick.items.pattern does not match flat-file type %q (sample %q)", typ, sampleOK)
+		}
+		if re.MatchString(sampleBad) {
+			t.Errorf("schema pattern wrongly accepts %s/demo — flat-file types require .md", typ)
+		}
+	}
+
+	// Bare basenames must always fail.
+	for _, bare := range []string{"foo", "foo.md"} {
+		if re.MatchString(bare) {
+			t.Errorf("schema pattern wrongly accepts bare basename %q", bare)
+		}
 	}
 }

--- a/internal/harness/editor_test.go
+++ b/internal/harness/editor_test.go
@@ -372,19 +372,39 @@ func TestValidatePicks_Valid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ValidatePicks(dir, []string{"web-search"}); err != nil {
+	if err := ValidatePicks(dir, []string{"skills/web-search"}); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidatePicks_RejectsBareName(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "skills", "web-search")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# web-search"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bare basename is no longer valid — canonical form is type/name.
+	err := ValidatePicks(dir, []string{"web-search"})
+	if err == nil {
+		t.Fatal("expected error when pick is a bare name without type/ prefix")
+	}
+	if !strings.Contains(err.Error(), "skills/web-search") {
+		t.Errorf("error should suggest the canonical form, got: %v", err)
 	}
 }
 
 func TestValidatePicks_Unknown(t *testing.T) {
 	dir := t.TempDir()
 
-	err := ValidatePicks(dir, []string{"nonexistent"})
+	err := ValidatePicks(dir, []string{"skills/nonexistent"})
 	if err == nil {
 		t.Fatal("expected error for unknown pick")
 	}
-	if !strings.Contains(err.Error(), "nonexistent") {
+	if !strings.Contains(err.Error(), "skills/nonexistent") {
 		t.Errorf("error should name the unknown pick, got: %v", err)
 	}
 }
@@ -393,6 +413,50 @@ func TestValidatePicks_Empty(t *testing.T) {
 	dir := t.TempDir()
 	if err := ValidatePicks(dir, nil); err != nil {
 		t.Fatalf("nil picks should always pass: %v", err)
+	}
+}
+
+// TestValidatePicks_BasenameClash asserts the canonical type/name form
+// disambiguates a skill and an agent that share a basename.
+//
+// With the old bare-name validation they collided on a single key ("foo")
+// and the user could not pick one without also picking the other.
+func TestValidatePicks_BasenameClash(t *testing.T) {
+	dir := t.TempDir()
+
+	// skill "foo"
+	skillDir := filepath.Join(dir, "skills", "foo")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# foo skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// agent "foo.md"
+	agentsDir := filepath.Join(dir, "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "foo.md"), []byte("agent foo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Either alone is valid.
+	if err := ValidatePicks(dir, []string{"skills/foo"}); err != nil {
+		t.Errorf("pick skills/foo alone should validate: %v", err)
+	}
+	if err := ValidatePicks(dir, []string{"agents/foo.md"}); err != nil {
+		t.Errorf("pick agents/foo.md alone should validate: %v", err)
+	}
+	// Both together.
+	if err := ValidatePicks(dir, []string{"skills/foo", "agents/foo.md"}); err != nil {
+		t.Errorf("picking both skills/foo and agents/foo.md should validate: %v", err)
+	}
+	// Bare "foo" is ambiguous and no longer accepted.
+	err := ValidatePicks(dir, []string{"foo"})
+	if err == nil {
+		t.Error("bare basename should not validate (canonical type/name required)")
 	}
 }
 

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -439,6 +439,22 @@ func (a *Artifacts) Total() int {
 	return len(a.Skills) + len(a.Agents) + len(a.Rules) + len(a.Commands)
 }
 
+// ArtifactTypeDirs lists the directory-style artifact roots — each entry
+// is a subdirectory of the harness root whose children are themselves
+// directories, each holding a manifest file (SKILL.md today).
+//
+// Keep this list in lock-step with the pick.items pattern in
+// docs/schema/plugin.schema.json. The TestArtifactTypes_SchemaAgreement
+// test in this package asserts they match.
+var ArtifactTypeDirs = []string{"skills"}
+
+// ArtifactTypeFiles lists the flat-file artifact roots — each entry is a
+// subdirectory of the harness root whose children are individual .md files.
+//
+// Keep this list in lock-step with the pick.items pattern in
+// docs/schema/plugin.schema.json.
+var ArtifactTypeFiles = []string{"agents", "rules", "commands"}
+
 // ScanArtifacts discovers local artifacts in a harness's installed directory.
 // Skills are directories containing SKILL.md; agents, rules, and commands are .md files.
 func ScanArtifacts(name string) (*Artifacts, error) {
@@ -448,6 +464,7 @@ func ScanArtifacts(name string) (*Artifacts, error) {
 // ScanArtifactsDir discovers artifacts in an arbitrary directory.
 func ScanArtifactsDir(dir string) (*Artifacts, error) {
 	a := &Artifacts{}
+	// ArtifactTypeDirs[0] is "skills" — update if more directory-style types are added.
 	a.Skills = scanSkillDirs(filepath.Join(dir, "skills"))
 	a.Agents = scanMDFiles(filepath.Join(dir, "agents"))
 	a.Rules = scanMDFiles(filepath.Join(dir, "rules"))


### PR DESCRIPTION
## Summary

The `--pick` pipeline had two layers that disagreed on format:

- `assembler.CopyPicked` has always required canonical `type/name` paths
  (`skills/commit`, `agents/code-reviewer.md`). Bare basenames errored with
  "pick path must be in format 'type/name'".
- `harness.ValidatePicks` was accepting bare basenames (`commit`,
  `code-reviewer`) and dumping every artifact type into a single flat set
  keyed by basename.

Result: `--pick commit` got past validation then failed at assembly.
`--pick skills/commit` (the form in every JSON example in the docs)
**failed** validation. And a skill `foo` + an agent `foo.md` collided
on a single map key — unpickable independently.

This PR:

- Makes `ValidatePicks` key by canonical `type/name[.md]` form so a pick
  that passes validation is guaranteed to work end-to-end.
- Drops bare-name acceptance (no deprecation window — the bare form was
  silently broken past validation anyway, so callers get a fail-loud
  error pointing at the canonical form).
- Adds a "Did you mean ...?" hint when an unknown pick's basename
  resolves to one or more canonical entries. The clash case
  (`skills/foo` + `agents/foo.md`) produces a two-option hint.
- Schema regex on `pick.items` catches bare names in the editor before
  the command runs.
- Extracts `harness.ArtifactTypeDirs` / `harness.ArtifactTypeFiles`
  constants so the scanner and validator share a single source of truth.
  A schema-agreement test (`TestArtifactTypes_SchemaAgreement`) fails
  loudly if someone adds a new artifact type to the constants without
  updating the schema regex.
- Tests for the clash case, bare-name rejection, and schema agreement.
- `docs/tutorial/17-include-editing.md` CLI examples rewritten to
  canonical form (they were bare names that never actually worked past
  validation); flag description spells out the canonical form; "What you
  learned" documents the did-you-mean hint.
- `docs/harnesses.md` JSON examples corrected (`agents/reviewer` →
  `agents/reviewer.md`, etc.).

## Compatibility

Bare-name picks were never consumable at runtime — `assembler.CopyPicked`
has required `type/name` since before 0.2. No installed-harness
migration is required. The fix moves the failure from run-time
("pick path must be in format 'type/name'") to validation-time
("unknown pick name(s)" with a "Did you mean ...?" hint).

TermQ's forthcoming PR 8f90d90 gates on this PR merging first.

## Test plan

- [x] `make check` passes (build, lint, tests including the three new cases)
- [x] Manual smoke: `ynh include add h ./src --pick dev-project` against
      a source with one `skills/dev-project` hints
      `did you mean skills/dev-project?`
- [x] Manual smoke: clash case — skill + agent share basename, both
      picked independently with the `type/` prefix