### PR TITLE
feat: profile-level includes + local-path include sources

### DIFF
--- a/.ynh-plugin/plugin.json
+++ b/.ynh-plugin/plugin.json
@@ -23,7 +23,12 @@
             "command": "sh -c 'case \"$YNH_TOOL_INPUT\" in *\"git push\"*|*\"gh pr create\"*|*\"gh pr merge\"*) echo \"Reminder: .claude/rules/pre-remote.md requires make check + /evals before remote operations\" >&2 ;; esac; exit 0'"
           }
         ]
-      }
+      },
+      "includes": [
+        {
+          "local": ".claude"
+        }
+      ]
     }
   },
   "focus": {

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -314,6 +314,13 @@ func cmdInstall(args []string) error {
 		fmt.Printf("Fetching %d include(s) and %d delegate(s)...\n", len(p.Includes), len(p.DelegatesTo))
 	}
 	for _, inc := range p.Includes {
+		// Local-path includes are resolved on-demand from the harness dir
+		// — there's nothing to pre-fetch. Skip the allow-list check and the
+		// EnsureRepo clone; the resolver will hit the filesystem at run time.
+		if inc.IsLocal() {
+			fmt.Printf("  Local  %s\n", inc.Local)
+			continue
+		}
 		if !isLocalPath(inc.Git) {
 			if err := cfg.CheckRemoteSource(inc.Git); err != nil {
 				return fmt.Errorf("include %q: %w", inc.Git, err)
@@ -428,6 +435,10 @@ func cmdUpdate(args []string) error {
 	checked := 0
 	updated := 0
 	for _, inc := range p.Includes {
+		// Local-path includes have no cache entry to refresh.
+		if inc.IsLocal() {
+			continue
+		}
 		if err := cfg.CheckRemoteSource(inc.Git); err != nil {
 			return fmt.Errorf("include %q: %w", inc.Git, err)
 		}

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -120,8 +120,15 @@ the two must be set.
 | `pick` | no | Specific artifact paths to include. If omitted, includes all. |
 
 Local includes are useful when a harness ships bundled artifact directories
-alongside its manifest, or when a profile needs to pull in a sibling
+**inside** its root, or when a profile needs to pull in an adjacent
 directory (see [Profiles](#profiles) for profile-level includes).
+
+> **Relative paths must stay inside the harness root.** `ynh install`
+> copies the harness directory to `~/.ynh/harnesses/…`; anything outside
+> the source tree (e.g. `../sibling`) is not copied and the include fails
+> to resolve post-install. Use an absolute path or fold the content into
+> the harness if you need it after install. Absolute paths are resolved
+> as-is and are unaffected by the install copy.
 
 **Git URL formats:**
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -90,7 +90,9 @@ If omitted, falls back to `~/.ynh/config.json` default.
 
 ### includes (optional)
 
-External Git sources to pull artifacts from.
+Additional sources to pull artifacts from. Each include is either a remote
+Git source (`git`) or a local filesystem source (`local`) — exactly one of
+the two must be set.
 
 ```json
 {
@@ -99,6 +101,9 @@ External Git sources to pull artifacts from.
       "git": "github.com/user/skills-repo",
       "ref": "v2.0.0",
       "pick": ["skills/commit", "agents/reviewer.md"]
+    },
+    {
+      "local": "shared-artifacts"
     }
   ]
 }
@@ -108,10 +113,15 @@ External Git sources to pull artifacts from.
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `git` | yes | Git URL (see formats below) |
-| `ref` | no | Git tag, branch, or commit |
-| `path` | no | Subdirectory within the repo (monorepo support) |
+| `git` | one of git/local | Git URL (see formats below) |
+| `local` | one of git/local | Local filesystem path. Absolute, or relative to the harness root. |
+| `ref` | no | Git tag, branch, or commit (Git sources only) |
+| `path` | no | Subdirectory within the resolved source |
 | `pick` | no | Specific artifact paths to include. If omitted, includes all. |
+
+Local includes are useful when a harness ships bundled artifact directories
+alongside its manifest, or when a profile needs to pull in a sibling
+directory (see [Profiles](#profiles) for profile-level includes).
 
 **Git URL formats:**
 
@@ -202,7 +212,7 @@ MCP server declarations. See [MCP Servers](mcp.md) for full reference.
 
 ### profiles (optional)
 
-Named configuration variants. A profile can override `hooks` and `mcp_servers`. It cannot override identity fields (`name`, `version`, `description`), composition (`includes`, `delegates_to`), or `default_vendor`. See [Profiles](profiles.md) for full scope reference.
+Named configuration variants. A profile can override `hooks`, override `mcp_servers`, and append additional `includes`. It cannot override identity fields (`name`, `version`, `description`), `delegates_to`, or `default_vendor`. See [Profiles](profiles.md) for full scope reference.
 
 ## Profiles
 
@@ -216,7 +226,16 @@ Profiles let a single harness carry multiple configurations — e.g. a `strict` 
 | 2 | `YNH_PROFILE` env var | `export YNH_PROFILE=strict` |
 | 3 (lowest) | Top-level config | Fields in `.ynh-plugin/plugin.json` root |
 
-When a profile is selected, its `hooks` and `mcp_servers` **fully replace** the corresponding top-level values. No merge, no inheritance. If a profile defines `hooks`, the top-level hooks are discarded entirely.
+When a profile is selected, its fields are **merged** with the top-level values:
+
+- **`hooks`** use per-event replace. If the profile declares an event
+  (e.g. `before_tool`), that event is replaced wholesale; events the
+  profile does not declare are inherited from the top-level config.
+- **`mcp_servers`** use deep merge. Profile entries win on collision;
+  entries the profile does not declare are inherited. Setting a server
+  to `null` in the profile removes an inherited server.
+- **`includes`** are appended to the base harness's includes. A profile
+  cannot remove a base include; it only adds.
 
 ### Example
 
@@ -249,7 +268,39 @@ When a profile is selected, its `hooks` and `mcp_servers` **fully replace** the 
 }
 ```
 
-Running `ops-team --profile strict` uses the strict hooks (replacing the top-level hooks entirely). Running `ops-team --profile lite` drops all MCP servers while keeping the base vendor and no hooks (both hooks and mcp_servers are replaced — lite defines empty mcp_servers and no hooks).
+Running `ops-team --profile strict` uses the strict `before_tool` hook in
+place of the basic one, and keeps any base hooks on other events.
+
+### Profile-level includes
+
+Profiles can pull in additional artifact sources that are only active when
+the profile is selected. This is how a single harness can ship a
+"user-facing" view by default and a "contributor" view under a `dev`
+profile:
+
+```json
+{
+  "name": "ynh-guide",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "profiles": {
+    "ynh-dev": {
+      "includes": [
+        {"local": ".claude"}
+      ]
+    }
+  }
+}
+```
+
+Running `ynh-guide` gives users the base artifact set (whatever sits at the
+harness root under `skills/`, `agents/`, `rules/`, `commands/`). Running
+`ynh-guide --profile ynh-dev` additionally includes everything from the
+harness's `.claude/` directory on top of the base set.
+
+Profile-level includes use the same schema as top-level `includes` — either
+a remote Git source (`git`) or a local path (`local`), with optional
+`path`, `ref`, and `pick`.
 
 ## Editing an Installed Harness
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,6 +1,6 @@
 # Profiles
 
-Profiles are named configuration variants that allow the same harness to serve different execution contexts — CI, developer, security audit — with different hooks and MCP servers. A single `.ynh-plugin/plugin.json` carries one set of top-level defaults plus any number of profiles that can be selected at run time.
+Profiles are named configuration variants that allow the same harness to serve different execution contexts — CI, developer, security audit — with different hooks, MCP servers, and additional artifact sources. A single `.ynh-plugin/plugin.json` carries one set of top-level defaults plus any number of profiles that can be selected at run time.
 
 ## Why Profiles Matter
 
@@ -8,7 +8,7 @@ A harness that works well for interactive development may need different control
 
 ## Manifest Format
 
-Profiles live under the `profiles` key in `.ynh-plugin/plugin.json`. Each profile name maps to an object containing `hooks` and/or `mcp_servers`:
+Profiles live under the `profiles` key in `.ynh-plugin/plugin.json`. Each profile name maps to an object containing any of `hooks`, `mcp_servers`, and `includes`:
 
 ```json
 {
@@ -51,6 +51,8 @@ Profiles declare only what they change. Absent fields inherit from the top-level
 
 **Hooks** use per-event replace — if a profile declares `before_tool`, it replaces the default `before_tool`. Other events (like `after_tool`) are inherited.
 
+**Includes** are appended to the base harness's `includes` when the profile is active. A profile cannot remove a base include; it only adds additional artifact sources. See [Profile-level Includes](#profile-level-includes) below.
+
 Using the example above, selecting the `ci` profile produces:
 - **hooks**: `before_tool` replaced with the CI lint hook; `after_tool` inherited from defaults
 - **mcp_servers**: `github` inherited, `postgres` removed (null), `ci-metrics` added
@@ -58,6 +60,30 @@ Using the example above, selecting the `ci` profile produces:
 Selecting `security-audit` produces:
 - **hooks**: all inherited (profile declares none)
 - **mcp_servers**: `github` and `postgres` inherited, `sast` added
+
+## Profile-level Includes
+
+A profile can declare its own `includes` array that is appended to the base harness's `includes` when the profile is active. This lets one harness carry multiple artifact sets and swap them based on context — the obvious use case is a "user view" under the default profile and a "contributor view" under a dev profile.
+
+```json
+{
+  "name": "ynh-guide",
+  "version": "0.1.0",
+  "profiles": {
+    "ynh-dev": {
+      "includes": [
+        {"local": ".claude"}
+      ]
+    }
+  }
+}
+```
+
+With no profile selected, the assembled output uses only the artifacts at the harness root (`skills/`, `agents/`, `rules/`, `commands/`). With `--profile ynh-dev`, the artifacts under `.claude/skills/`, `.claude/agents/`, `.claude/rules/`, and `.claude/commands/` are merged into the output on top of the base set.
+
+Profile-level includes use the same shape as top-level includes — either `git` (remote) or `local` (path), with optional `path`, `ref`, and `pick`. See [Harness Manifest → includes](harnesses.md#includes-optional) for the full include schema.
+
+Artifact-collision behaviour: profile includes are appended after base includes, so a later artifact with the same name takes precedence over an earlier one. This lets a profile shadow a base artifact with an alternative implementation while keeping the rest of the base intact.
 
 ## Profile Selection
 
@@ -85,17 +111,18 @@ This is intentional — a typo in a CI pipeline should fail loudly rather than s
 
 ## Scope
 
-Profiles can override two fields:
+Profiles can override or extend three fields:
 
-| Field | Overridable by profile |
+| Field | Profile behaviour |
 |-------|----------------------|
-| `hooks` | Yes |
-| `mcp_servers` | Yes |
-| `name`, `version`, `description` | No — identity fields |
-| `includes`, `delegates_to` | No — composition fields |
-| `default_vendor` | No |
+| `hooks` | Per-event replace |
+| `mcp_servers` | Deep merge (null removes) |
+| `includes` | Append (profile entries added after base entries) |
+| `name`, `version`, `description` | Fixed — identity fields |
+| `delegates_to` | Fixed — composition field |
+| `default_vendor` | Fixed |
 
-Restricting scope to hooks and MCP servers keeps profiles focused on runtime behavior. Identity and composition are fixed properties of the harness itself.
+Keeping identity and delegation fixed keeps a harness's surface stable across profiles — what varies is the runtime behaviour (hooks, MCP servers) and the artifact set.
 
 ## Validation
 
@@ -103,6 +130,7 @@ Restricting scope to hooks and MCP servers keeps profiles focused on runtime beh
 
 - Hook entries must have a `command` field.
 - MCP server entries must have either `command` or `url`, not both.
+- Include entries must have exactly one of `git` or `local`.
 - Profile names must be non-empty strings.
 - Unknown fields inside a profile block are rejected.
 

--- a/docs/schema/plugin.schema.json
+++ b/docs/schema/plugin.schema.json
@@ -35,14 +35,15 @@
     "hooks": { "$ref": "#/$defs/hooks" },
     "mcp_servers": { "$ref": "#/$defs/mcp_servers" },
     "profiles": {
-      "description": "Named configuration variants. Merge semantics: mcp_servers are deep-merged (profile keys win), hooks use per-event replace (profile event replaces default, absent events inherited). Set a server to null to remove it.",
+      "description": "Named configuration variants. Merge semantics: mcp_servers are deep-merged (profile keys win), hooks use per-event replace (profile event replaces default, absent events inherited), includes are appended to the base harness's includes when the profile is active. Set a server to null to remove it.",
       "type": "object",
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
           "hooks": { "$ref": "#/$defs/hooks" },
-          "mcp_servers": { "$ref": "#/$defs/profile_mcp_servers" }
+          "mcp_servers": { "$ref": "#/$defs/profile_mcp_servers" },
+          "includes": { "$ref": "#/$defs/includes" }
         }
       }
     },
@@ -125,12 +126,24 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["git"],
         "additionalProperties": false,
         "properties": {
-          "git": { "type": "string" },
-          "ref": { "type": "string" },
-          "path": { "type": "string" },
+          "git": {
+            "type": "string",
+            "description": "Remote Git URL or shorthand (e.g. github.com/org/repo). Mutually exclusive with local."
+          },
+          "local": {
+            "type": "string",
+            "description": "Local filesystem path. Absolute or relative to the harness root. Mutually exclusive with git."
+          },
+          "ref": {
+            "type": "string",
+            "description": "Git ref (branch, tag, SHA). Only meaningful when git is set."
+          },
+          "path": {
+            "type": "string",
+            "description": "Subdirectory within the resolved source."
+          },
           "pick": {
             "type": "array",
             "description": "Artifact paths in canonical type/name form. Skills use the bare name (they are directories): skills/<name>. Flat artifacts include the .md extension: agents/<name>.md, rules/<name>.md, commands/<name>.md.",
@@ -139,7 +152,11 @@
               "pattern": "^(skills/[^/]+|(agents|rules|commands)/[^/]+\\.md)$"
             }
           }
-        }
+        },
+        "oneOf": [
+          { "required": ["git"] },
+          { "required": ["local"] }
+        ]
       }
     },
     "delegates": {

--- a/docs/tutorial/03-composition.md
+++ b/docs/tutorial/03-composition.md
@@ -473,20 +473,66 @@ mv ~/.ynh/config.json.bak ~/.ynh/config.json
 | Not set (default) | All sources allowed |
 | `[]` (empty array) | All sources denied |
 
+## T3.11: Local — sibling directory (no Git repo)
+
+If you just want to pull artifacts from a sibling directory that is **not** a Git repo (e.g. a `shared-artifacts/` folder checked in alongside your harness), use a `local` include instead of `git`:
+
+```bash
+# Create a sibling directory with some artifacts
+mkdir -p /tmp/ynh-tutorial/shared/skills/team-standards
+cat > /tmp/ynh-tutorial/shared/skills/team-standards/SKILL.md << 'EOF'
+---
+name: team-standards
+description: Team coding standards and review checklist.
+---
+Apply our team's code review checklist to the diff.
+EOF
+
+# Point a harness at it via a local include
+mkdir -p /tmp/ynh-tutorial/uses-local/.ynh-plugin
+cat > /tmp/ynh-tutorial/uses-local/.ynh-plugin/plugin.json << 'EOF'
+{
+  "name": "uses-local",
+  "version": "0.1.0",
+  "includes": [
+    {"local": "../shared"}
+  ]
+}
+EOF
+
+ynh install /tmp/ynh-tutorial/uses-local
+uses-local "what skills do you have?"
+```
+
+```bash
+ls ~/.ynh/run/uses-local/.claude/skills/
+# Expected: team-standards/
+```
+
+Key differences vs `git`:
+
+- **`local`** expects a filesystem path (absolute or relative to the harness root). No Git required — no clone, no cache.
+- **`git`** expects a Git URL (or a local path that happens to be a Git repo). ynh clones/caches it.
+
+Use `local` when shipping a harness with pre-bundled artifact directories next to it. Use `git` when the artifact source has its own version history and lifecycle.
+
+`local` pairs well with profiles — see [Tutorial 13 → Profile-level includes](tutorial/13-profiles.md#t139-profile-level-includes--bundle-extra-artifacts-per-profile).
+
 ## Clean up
 
 ```bash
-ynh uninstall my-dev with-anthropic with-vercel full-stack mixed local-ref pinned david 2>/dev/null
+ynh uninstall my-dev with-anthropic with-vercel full-stack mixed local-ref pinned david uses-local 2>/dev/null
 ```
 
 ## What you learned
 
 - **Your own repos:** Use `github.com/eyelock/assistants` (or any Git URL) with `path` and `pick`
 - **Third-party repos:** Skills from [skills.sh](https://skills.sh), [anthropics/skills](https://github.com/anthropics/skills), [vercel-labs/skills](https://github.com/vercel-labs/skills) — any agentskills.io-compatible repo works
-- **Local paths:** Start Git URLs with `/` or `.` to use local checkouts (faster, no clone)
+- **Local paths:** Start Git URLs with `/` or `.` to use a local Git checkout (faster, no clone)
+- **Local sibling directories:** Use `"local": "path"` for a directory that's not a Git repo — no Git required
 - **Embedded skills:** Put skills directly in the harness's `skills/` directory
 - **`pick` is the differentiator:** No vendor natively supports cherry-picking individual skills from a larger repo. ynh does.
-- **Mixing sources:** Combine your own skills, third-party skills, and local skills in one harness
+- **Mixing sources:** Combine your own skills, third-party skills, local sibling dirs, and embedded skills in one harness
 - **Offline-ready:** All includes are fetched at install time — `ynh run` works offline
 - `ref` pins to branches, tags, or commits
 - `ynh update` refreshes cached repos

--- a/docs/tutorial/03-composition.md
+++ b/docs/tutorial/03-composition.md
@@ -320,6 +320,52 @@ ls ~/.ynh/run/local-ref/.claude/skills/
 # Expected: fast-deploy/
 ```
 
+## T3.7b: Local — bundled subdirectory (no Git repo)
+
+When a harness ships its own artifact bundle inside the harness root — no Git, no cache, no clone — use a `local` include instead of `git`. The bundled directory is copied along with the harness at install time, so `ynh install` and `ynh run` both resolve it from the install location.
+
+```bash
+mkdir -p /tmp/ynh-tutorial/with-bundled/.ynh-plugin
+mkdir -p /tmp/ynh-tutorial/with-bundled/extras/skills/team-standards
+
+cat > /tmp/ynh-tutorial/with-bundled/extras/skills/team-standards/SKILL.md << 'EOF'
+---
+name: team-standards
+description: Team coding standards and review checklist.
+---
+Apply our team's code review checklist to the diff.
+EOF
+
+cat > /tmp/ynh-tutorial/with-bundled/.ynh-plugin/plugin.json << 'EOF'
+{
+  "name": "with-bundled",
+  "version": "0.1.0",
+  "includes": [
+    {"local": "extras"}
+  ]
+}
+EOF
+
+ynh install /tmp/ynh-tutorial/with-bundled
+with-bundled "what skills do you have?"
+```
+
+```bash
+ls ~/.ynh/run/with-bundled/.claude/skills/
+# Expected: team-standards/
+```
+
+Key differences vs `git`:
+
+- **`local`** expects a filesystem path. Relative paths resolve against the harness root; absolute paths are used as-is. No Git required — no clone, no cache, no ref.
+- **`git`** expects a Git URL (or a local path that happens to be a Git repo). ynh clones/caches it.
+
+Use `local` for artifact directories that travel with the harness source. Use `git` when the artifact source has its own version history and lifecycle.
+
+> **Note on layout.** Relative `local` paths should stay inside the harness root so the bundle is copied along with the harness at install time. Sibling directories (e.g. `../shared`) work for `ynd preview` against a source tree but **won't survive `ynh install`** — the referenced dir isn't copied. Use an absolute path or fold the shared content into the harness if you need it after install.
+
+`local` pairs well with profiles — see [Tutorial 13 → Profile-level includes](tutorial/13-profiles.md#t139-profile-level-includes--bundle-extra-artifacts-per-profile).
+
 ## T3.8: Pin a version with ref
 
 ```bash
@@ -473,55 +519,10 @@ mv ~/.ynh/config.json.bak ~/.ynh/config.json
 | Not set (default) | All sources allowed |
 | `[]` (empty array) | All sources denied |
 
-## T3.11: Local — sibling directory (no Git repo)
-
-If you just want to pull artifacts from a sibling directory that is **not** a Git repo (e.g. a `shared-artifacts/` folder checked in alongside your harness), use a `local` include instead of `git`:
-
-```bash
-# Create a sibling directory with some artifacts
-mkdir -p /tmp/ynh-tutorial/shared/skills/team-standards
-cat > /tmp/ynh-tutorial/shared/skills/team-standards/SKILL.md << 'EOF'
----
-name: team-standards
-description: Team coding standards and review checklist.
----
-Apply our team's code review checklist to the diff.
-EOF
-
-# Point a harness at it via a local include
-mkdir -p /tmp/ynh-tutorial/uses-local/.ynh-plugin
-cat > /tmp/ynh-tutorial/uses-local/.ynh-plugin/plugin.json << 'EOF'
-{
-  "name": "uses-local",
-  "version": "0.1.0",
-  "includes": [
-    {"local": "../shared"}
-  ]
-}
-EOF
-
-ynh install /tmp/ynh-tutorial/uses-local
-uses-local "what skills do you have?"
-```
-
-```bash
-ls ~/.ynh/run/uses-local/.claude/skills/
-# Expected: team-standards/
-```
-
-Key differences vs `git`:
-
-- **`local`** expects a filesystem path (absolute or relative to the harness root). No Git required — no clone, no cache.
-- **`git`** expects a Git URL (or a local path that happens to be a Git repo). ynh clones/caches it.
-
-Use `local` when shipping a harness with pre-bundled artifact directories next to it. Use `git` when the artifact source has its own version history and lifecycle.
-
-`local` pairs well with profiles — see [Tutorial 13 → Profile-level includes](tutorial/13-profiles.md#t139-profile-level-includes--bundle-extra-artifacts-per-profile).
-
 ## Clean up
 
 ```bash
-ynh uninstall my-dev with-anthropic with-vercel full-stack mixed local-ref pinned david uses-local 2>/dev/null
+ynh uninstall my-dev with-anthropic with-vercel full-stack mixed local-ref pinned david with-bundled 2>/dev/null
 ```
 
 ## What you learned
@@ -529,7 +530,7 @@ ynh uninstall my-dev with-anthropic with-vercel full-stack mixed local-ref pinne
 - **Your own repos:** Use `github.com/eyelock/assistants` (or any Git URL) with `path` and `pick`
 - **Third-party repos:** Skills from [skills.sh](https://skills.sh), [anthropics/skills](https://github.com/anthropics/skills), [vercel-labs/skills](https://github.com/vercel-labs/skills) — any agentskills.io-compatible repo works
 - **Local paths:** Start Git URLs with `/` or `.` to use a local Git checkout (faster, no clone)
-- **Local sibling directories:** Use `"local": "path"` for a directory that's not a Git repo — no Git required
+- **Bundled local directories:** Use `"local": "path"` for a subdirectory that ships inside the harness — no Git required. The path is relative to the harness root (or absolute), and the directory is copied along with the harness at install time.
 - **Embedded skills:** Put skills directly in the harness's `skills/` directory
 - **`pick` is the differentiator:** No vendor natively supports cherry-picking individual skills from a larger repo. ynh does.
 - **Mixing sources:** Combine your own skills, third-party skills, local sibling dirs, and embedded skills in one harness

--- a/docs/tutorial/13-profiles.md
+++ b/docs/tutorial/13-profiles.md
@@ -206,6 +206,72 @@ Compare with no profile to see what the profile adds:
 ynd diff /tmp/ynh-tutorial/profile-harness claude cursor
 ```
 
+## T13.9: Profile-level includes — bundle extra artifacts per profile
+
+Profiles can also declare their own `includes` array. When the profile is active, those artifact sources are **appended** to the base harness's includes. This is how a single harness can carry a "user view" by default and a "contributor view" under a dev profile.
+
+The include source can be a local filesystem path (`local`) — ideal for ship-alongside-the-manifest directories — or a remote Git URL (`git`), same as a top-level include.
+
+Create a bundle directory next to the harness:
+
+```bash
+mkdir -p /tmp/ynh-tutorial/profile-harness/dev-extras/skills/deep-debug
+
+cat > /tmp/ynh-tutorial/profile-harness/dev-extras/skills/deep-debug/SKILL.md << 'EOF'
+---
+name: deep-debug
+description: Systematic debugging workflow for production incidents.
+---
+
+When invoked, walk through: reproduce, isolate, bisect, hypothesize, verify.
+EOF
+```
+
+Add a profile that pulls it in:
+
+```bash
+cat > /tmp/ynh-tutorial/profile-harness/.ynh-plugin/plugin.json << 'EOF'
+{
+  "name": "profile-demo",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "profiles": {
+    "ci": {
+      "hooks": {
+        "before_tool": [
+          {
+            "matcher": "Bash",
+            "command": "/usr/local/bin/ci-guard.sh"
+          }
+        ]
+      }
+    },
+    "dev": {
+      "includes": [
+        {"local": "dev-extras"}
+      ]
+    }
+  }
+}
+EOF
+```
+
+Preview without profile — only the base artifacts appear:
+
+```bash
+ynd preview /tmp/ynh-tutorial/profile-harness -v claude | grep SKILL
+# Expected: only skills declared at the harness root
+```
+
+Preview with `--profile dev` — `deep-debug` appears on top of the base set:
+
+```bash
+ynd preview /tmp/ynh-tutorial/profile-harness -v claude --profile dev | grep deep-debug
+# Expected: skills/deep-debug/SKILL.md shows up
+```
+
+Paths in `local` are relative to the harness root (or absolute). The `pick` field filters which artifacts to include from the source. A profile cannot remove base includes — it only appends.
+
 ## Clean up
 
 ```bash
@@ -216,12 +282,13 @@ rm -rf /tmp/ynh-tutorial
 ## What You Learned
 
 - Profiles are declared in `.ynh-plugin/plugin.json` under `profiles` as named config objects
-- Each profile can override `hooks` and `mcp_servers`
-- Profiles use merge semantics: MCP servers are deep-merged (profile keys win), hooks use per-event replace (absent events inherited)
+- Each profile can override `hooks`, `mcp_servers`, and add `includes`
+- Profiles use merge semantics: MCP servers are deep-merged (profile keys win), hooks use per-event replace (absent events inherited), includes are appended (profile cannot remove a base include)
 - Set an MCP server to `null` in a profile to remove an inherited server
 - `--profile <name>` activates a profile on `ynh run`, `ynd preview`, and `ynd diff`
 - `YNH_PROFILE` env var activates a profile (flag takes precedence)
 - Invalid profile names produce helpful errors listing available profiles
+- Profile-level `includes` support both remote (`git`) and local (`local`) sources — same shape as top-level includes
 - `ynd validate` checks profile schema validity
 
 ## Next

--- a/internal/assembler/integration_test.go
+++ b/internal/assembler/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/plugin"
 	"github.com/eyelock/ynh/internal/resolver"
 	"github.com/eyelock/ynh/internal/vendor"
 )
@@ -361,5 +362,109 @@ func assertFileContains(t *testing.T, path string, substr string) {
 	}
 	if !strings.Contains(string(data), substr) {
 		t.Errorf("file %s does not contain %q", path, substr)
+	}
+}
+
+// TestIntegration_ProfileIncludes_LocalPath verifies end-to-end that a
+// profile-level local include flows through Resolve → Assemble and the
+// picked artifacts land in the assembled vendor output.
+//
+// Harness layout under the test dir:
+//
+//	harness/
+//	  .ynh-plugin/plugin.json   (with profiles.ynh-dev.includes = [{local: "dev-extras"}])
+//	  skills/base-skill/SKILL.md
+//	  dev-extras/
+//	    skills/dev-skill/SKILL.md
+//	    agents/dev-agent.md
+//
+// With no profile, only base-skill should appear. With the ynh-dev profile,
+// both base-skill and the dev-extras content should appear.
+func TestIntegration_ProfileIncludes_LocalPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	harnessDir := t.TempDir()
+
+	// Base artifacts — live at harness root
+	writeFileTree(t, harnessDir, map[string]string{
+		"skills/base-skill/SKILL.md": "---\nname: base-skill\ndescription: base only\n---\nbase\n",
+	})
+
+	// dev-extras — a sibling directory the profile pulls in
+	writeFileTree(t, harnessDir, map[string]string{
+		"dev-extras/skills/dev-skill/SKILL.md": "---\nname: dev-skill\ndescription: dev only\n---\ndev\n",
+		"dev-extras/agents/dev-agent.md":       "---\nname: dev-agent\ndescription: dev agent\ntools: Read\n---\nbody\n",
+	})
+
+	baseHarness := &harness.Harness{
+		Name:          "test",
+		DefaultVendor: "claude",
+		Dir:           harnessDir,
+		Profiles: map[string]plugin.Profile{
+			"ynh-dev": {
+				Includes: []plugin.IncludeMeta{
+					{Local: "dev-extras"},
+				},
+			},
+		},
+	}
+
+	adapter, _ := vendor.Get("claude")
+
+	// Case 1: no profile — only base content should resolve + assemble.
+	resolved, err := resolver.Resolve(baseHarness, nil)
+	if err != nil {
+		t.Fatalf("Resolve (base): %v", err)
+	}
+	content := extractContent(resolved)
+	content = append(content, resolver.ResolvedContent{BasePath: harnessDir})
+	workDir, err := Assemble(adapter, content)
+	if err != nil {
+		t.Fatalf("Assemble (base): %v", err)
+	}
+	defer Cleanup(workDir)
+
+	baseSkills := filepath.Join(workDir, ".claude", "skills")
+	assertFileExists(t, filepath.Join(baseSkills, "base-skill", "SKILL.md"))
+	if _, err := os.Stat(filepath.Join(baseSkills, "dev-skill")); err == nil {
+		t.Error("dev-skill leaked into base assembly — profile include should not be active")
+	}
+
+	// Case 2: with --profile ynh-dev — profile includes are merged in.
+	devHarness, err := harness.ResolveProfile(baseHarness, "ynh-dev")
+	if err != nil {
+		t.Fatalf("ResolveProfile: %v", err)
+	}
+	resolvedDev, err := resolver.Resolve(devHarness, nil)
+	if err != nil {
+		t.Fatalf("Resolve (ynh-dev): %v", err)
+	}
+	contentDev := extractContent(resolvedDev)
+	contentDev = append(contentDev, resolver.ResolvedContent{BasePath: harnessDir})
+	workDirDev, err := Assemble(adapter, contentDev)
+	if err != nil {
+		t.Fatalf("Assemble (ynh-dev): %v", err)
+	}
+	defer Cleanup(workDirDev)
+
+	devSkills := filepath.Join(workDirDev, ".claude", "skills")
+	devAgents := filepath.Join(workDirDev, ".claude", "agents")
+	assertFileExists(t, filepath.Join(devSkills, "base-skill", "SKILL.md"))
+	assertFileExists(t, filepath.Join(devSkills, "dev-skill", "SKILL.md"))
+	assertFileExists(t, filepath.Join(devAgents, "dev-agent.md"))
+}
+
+// writeFileTree writes all (relpath, content) pairs into root, creating
+// parent directories as needed. Test-only helper.
+func writeFileTree(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", full, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
 	}
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -19,12 +19,20 @@ import (
 // Must start with a letter or digit. Prevents path traversal and shell injection.
 var validName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
-// GitSource holds the common fields for any Git-backed reference.
+// GitSource holds the common fields for any include or delegate source.
+// Exactly one of Git (remote) or Local (filesystem path) is set at any
+// given time. Path is a subdirectory scoped within the source; Ref
+// applies to Git sources only.
 type GitSource struct {
-	Git  string
-	Ref  string
-	Path string
+	Git   string
+	Local string
+	Ref   string
+	Path  string
 }
+
+// IsLocal reports whether the source is a filesystem path (Local set,
+// Git empty). Callers use this to skip git fetch and resolve directly.
+func (g GitSource) IsLocal() bool { return g.Local != "" && g.Git == "" }
 
 type Include struct {
 	GitSource
@@ -53,6 +61,7 @@ type Harness struct {
 	Description   string
 	DefaultVendor string
 	Namespace     string // e.g. "eyelock/assistants"; empty for local/unqualified installs
+	Dir           string // absolute path to the harness directory — the base for relative local includes
 	Includes      []Include
 	DelegatesTo   []Delegate
 	Hooks         map[string][]plugin.HookEntry
@@ -248,10 +257,15 @@ func LoadDir(dir string) (*Harness, error) {
 	p := &Harness{Name: hj.Name, Version: hj.Version, Description: hj.Description}
 	p.DefaultVendor = hj.DefaultVendor
 	p.Namespace = inferNamespace(dir)
+	if abs, err := filepath.Abs(dir); err == nil {
+		p.Dir = abs
+	} else {
+		p.Dir = dir
+	}
 
 	for _, inc := range hj.Includes {
 		p.Includes = append(p.Includes, Include{
-			GitSource: GitSource{Git: inc.Git, Ref: inc.Ref, Path: inc.Path},
+			GitSource: GitSource{Git: inc.Git, Local: inc.Local, Ref: inc.Ref, Path: inc.Path},
 			Pick:      inc.Pick,
 		})
 	}
@@ -384,6 +398,27 @@ func ResolveProfile(h *Harness, profileName string) (*Harness, error) {
 		resolved.MCPServers = merged
 	}
 
+	// Append profile-level includes to the harness's base includes. Profile
+	// includes cannot remove base includes — they only add. Order: base first,
+	// then profile entries, so a later profile pick can shadow a base pick
+	// when the assembler resolves collisions.
+	if len(profile.Includes) > 0 {
+		merged := make([]Include, 0, len(h.Includes)+len(profile.Includes))
+		merged = append(merged, h.Includes...)
+		for _, inc := range profile.Includes {
+			merged = append(merged, Include{
+				GitSource: GitSource{
+					Git:   inc.Git,
+					Local: inc.Local,
+					Ref:   inc.Ref,
+					Path:  inc.Path,
+				},
+				Pick: inc.Pick,
+			})
+		}
+		resolved.Includes = merged
+	}
+
 	return &resolved, nil
 }
 
@@ -400,7 +435,7 @@ func LoadFile(path string) (*Harness, error) {
 
 	for _, inc := range hj.Includes {
 		p.Includes = append(p.Includes, Include{
-			GitSource: GitSource{Git: inc.Git, Ref: inc.Ref, Path: inc.Path},
+			GitSource: GitSource{Git: inc.Git, Local: inc.Local, Ref: inc.Ref, Path: inc.Path},
 			Pick:      inc.Pick,
 		})
 	}

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -711,3 +711,44 @@ func writeTestHarnessMinimal(t *testing.T, dir, name string) {
 		t.Fatal(err)
 	}
 }
+
+func TestResolveProfile_AppendsIncludes(t *testing.T) {
+	h := &Harness{
+		Name: "x",
+		Includes: []Include{
+			{GitSource: GitSource{Git: "github.com/base/repo"}},
+		},
+		Profiles: map[string]plugin.Profile{
+			"ci": {
+				Includes: []plugin.IncludeMeta{
+					{Local: ".ci-scripts"},
+					{Git: "github.com/ci/extras", Ref: "main"},
+				},
+			},
+		},
+	}
+
+	resolved, err := ResolveProfile(h, "ci")
+	if err != nil {
+		t.Fatalf("ResolveProfile: %v", err)
+	}
+	if len(resolved.Includes) != 3 {
+		t.Fatalf("expected 3 includes (1 base + 2 profile), got %d", len(resolved.Includes))
+	}
+	// Base preserved first
+	if resolved.Includes[0].Git != "github.com/base/repo" {
+		t.Errorf("first include = %q, want base git URL", resolved.Includes[0].Git)
+	}
+	// Profile entries appended
+	if !resolved.Includes[1].IsLocal() || resolved.Includes[1].Local != ".ci-scripts" {
+		t.Errorf("second include should be local include %q, got %+v", ".ci-scripts", resolved.Includes[1])
+	}
+	if resolved.Includes[2].Git != "github.com/ci/extras" {
+		t.Errorf("third include git = %q, want github.com/ci/extras", resolved.Includes[2].Git)
+	}
+
+	// Original harness untouched
+	if len(h.Includes) != 1 {
+		t.Errorf("base harness mutated: includes = %d, want 1", len(h.Includes))
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -33,12 +33,18 @@ type Focus struct {
 }
 
 // Profile is a named configuration variant. When selected, its fields
-// are merged with top-level values: mcp_servers uses deep merge (profile
-// keys win), hooks uses per-event replace. A nil *MCPServer removes an
-// inherited server (JSON null).
+// are merged with top-level values:
+//   - `hooks`: per-event replace. If the profile declares an event,
+//     it replaces the default; absent events are inherited.
+//   - `mcp_servers`: deep merge (profile keys win on collision;
+//     absent keys inherited; nil pointer removes an inherited server).
+//   - `includes`: appended to the harness's base includes. Profile-only
+//     includes let a single harness carry multiple artifact sets and
+//     swap them based on the active profile.
 type Profile struct {
 	Hooks      map[string][]HookEntry `json:"hooks,omitempty"`
 	MCPServers map[string]*MCPServer  `json:"mcp_servers,omitempty"`
+	Includes   []IncludeMeta          `json:"includes,omitempty"`
 }
 
 // AuthorInfo holds harness author information.
@@ -146,12 +152,16 @@ type ProvenanceMeta struct {
 	InstalledAt  string `json:"installed_at"`
 }
 
-// IncludeMeta is the JSON representation of a Git include.
+// IncludeMeta is the JSON representation of an include source. Exactly one
+// of `git` (remote) or `local` (path-based) must be set. For both forms
+// `path` scopes into a subdirectory of the source and `pick` filters paths.
+// `ref` is Git-only.
 type IncludeMeta struct {
-	Git  string   `json:"git"`
-	Ref  string   `json:"ref,omitempty"`
-	Path string   `json:"path,omitempty"`
-	Pick []string `json:"pick,omitempty"`
+	Git   string   `json:"git,omitempty"`
+	Local string   `json:"local,omitempty"`
+	Ref   string   `json:"ref,omitempty"`
+	Path  string   `json:"path,omitempty"`
+	Pick  []string `json:"pick,omitempty"`
 }
 
 // DelegateMeta is the JSON representation of a delegate reference.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -51,11 +51,54 @@ func resolveGitSourceWith(gs harness.GitSource, fetch repoFunc) (string, *RepoRe
 	return basePath, &result, nil
 }
 
+// resolveLocalSource resolves a local filesystem include against the harness
+// root. Absolute paths are used as-is; relative paths are joined to harnessDir.
+// Subpath (gs.Path) is applied on top if set.
+func resolveLocalSource(gs harness.GitSource, harnessDir string) (string, error) {
+	local := gs.Local
+	if !filepath.IsAbs(local) {
+		if harnessDir == "" {
+			return "", fmt.Errorf("local include %q: harness directory not known, cannot resolve relative path", local)
+		}
+		local = filepath.Join(harnessDir, local)
+	}
+	if _, err := os.Stat(local); os.IsNotExist(err) {
+		return "", fmt.Errorf("local include %q: path not found", gs.Local)
+	}
+
+	basePath := local
+	if gs.Path != "" {
+		basePath = filepath.Join(local, gs.Path)
+		if _, err := os.Stat(basePath); os.IsNotExist(err) {
+			return "", fmt.Errorf("path %q not found in local source %q", gs.Path, gs.Local)
+		}
+	}
+	return basePath, nil
+}
+
 // resolveWith fetches all includes using the given repo function.
 func resolveWith(p *harness.Harness, cfg *config.Config, fetch repoFunc) ([]ResolveResult, error) {
 	var results []ResolveResult
 
 	for _, inc := range p.Includes {
+		if inc.IsLocal() {
+			basePath, err := resolveLocalSource(inc.GitSource, p.Dir)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, ResolveResult{
+				Content: ResolvedContent{
+					BasePath: basePath,
+					Paths:    inc.Pick,
+				},
+				Source: inc.Local,
+				Path:   inc.Path,
+				Cloned: false,
+				Cached: true,
+			})
+			continue
+		}
+
 		if cfg != nil {
 			if err := cfg.CheckRemoteSource(inc.Git); err != nil {
 				return nil, fmt.Errorf("include %q: %w", inc.Git, err)

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -492,3 +492,85 @@ func runGit(t *testing.T, dir string, args ...string) {
 		t.Fatalf("git %v failed: %v\n%s", args, err, out)
 	}
 }
+
+func TestResolve_LocalInclude_Relative(t *testing.T) {
+	// Harness root contains a child "extras/" with an artifact.
+	harnessDir := t.TempDir()
+	extras := filepath.Join(harnessDir, "extras", "skills", "demo")
+	if err := os.MkdirAll(extras, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extras, "SKILL.md"),
+		[]byte("---\nname: demo\ndescription: d\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &harness.Harness{
+		Name: "h",
+		Dir:  harnessDir,
+		Includes: []harness.Include{
+			{GitSource: harness.GitSource{Local: "extras"}},
+		},
+	}
+
+	results, err := Resolve(p, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	want := filepath.Join(harnessDir, "extras")
+	if results[0].Content.BasePath != want {
+		t.Errorf("BasePath = %q, want %q", results[0].Content.BasePath, want)
+	}
+	if !results[0].Cached || results[0].Cloned {
+		t.Errorf("local include should report Cached=true Cloned=false, got Cached=%v Cloned=%v",
+			results[0].Cached, results[0].Cloned)
+	}
+}
+
+func TestResolve_LocalInclude_Absolute(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "rules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "rules", "r.md"), []byte("r"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &harness.Harness{
+		Name: "h",
+		Dir:  "/does/not/matter", // absolute Local ignores Dir
+		Includes: []harness.Include{
+			{GitSource: harness.GitSource{Local: dir}},
+		},
+	}
+
+	results, err := Resolve(p, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if results[0].Content.BasePath != dir {
+		t.Errorf("BasePath = %q, want %q", results[0].Content.BasePath, dir)
+	}
+}
+
+func TestResolve_LocalInclude_Missing(t *testing.T) {
+	harnessDir := t.TempDir()
+	p := &harness.Harness{
+		Name: "h",
+		Dir:  harnessDir,
+		Includes: []harness.Include{
+			{GitSource: harness.GitSource{Local: "does-not-exist"}},
+		},
+	}
+
+	_, err := Resolve(p, nil)
+	if err == nil {
+		t.Fatal("expected error for missing local include")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Two interlocking additions, motivated by the self-harness use case
(covered by PR #85) where `.claude/` contributor tooling should be
available under a `ynh-dev` profile but not to base users of the harness:

1. **Local-path include sources.** `IncludeMeta` gains a `local` field
   (mutually exclusive with `git`). Relative paths resolve against the
   harness root; absolute paths are used as-is. No git clone, no cache.
   `ynh install` and `ynh update` short-circuit local includes (nothing
   to pre-fetch). Relative paths must stay inside the harness root so
   they travel with the source at install time — the docs call this out
   explicitly.

2. **Profile-level includes.** `Profile` gains its own `includes` array
   that is **appended** to the base harness's `includes` when the
   profile is active. Profiles cannot remove a base include; they only
   add. Combined with local paths, this lets a single harness carry
   multiple artifact sets and swap them based on context.

The self-harness on this branch (from PR #85) adopts both:
`profiles.ynh-dev.includes = [{"local": ".claude"}]`, so
`ynh-guide --profile ynh-dev` sees the contributor skills/agents/rules
/commands on top of the base user-facing set.

## Commits

- `feat: profile-level includes and local-path include sources` — types,
  resolver, docs, schema, self-harness adopts it
- `fix(install,update): skip git pre-fetch for local-path includes` —
  caught by T3 smoke-test; install/update loops now skip local entries

## Docs + tutorials

- `docs/harnesses.md` — `git | local` schema; profile scope updated;
  relative-path caveat documented
- `docs/profiles.md` — merge semantics now include the includes case;
  new "Profile-level Includes" section; Scope table updated
- `docs/tutorial/03-composition.md` — new T3.7b walkthrough for
  bundled-subdirectory local includes (sits with the other "Local —"
  sections; `extras/` inside the harness so it survives install)
- `docs/tutorial/13-profiles.md` — new T13.9 for profile-level
  includes with a base-vs-profile diff
- `docs/schema/plugin.schema.json` — `oneOf: [git, local]` on includes;
  profile accepts the includes field

## Depends on

- [#85](https://github.com/eyelock/ynh/pull/85) — the self-harness
  migration this PR extends. Cherry-pick of the feature hunks patches
  into the `ynh-dev` profile block that PR #85 creates, so #85 must
  merge first (or this PR rebases onto develop afterwards).

## Test plan

- [x] `make check` passes (includes the assembler integration test
      `TestIntegration_ProfileIncludes_LocalPath` proving end-to-end
      that profile-only includes don't leak into base assembly and do
      appear when the profile is active)
- [x] T3.7b, T13.9, and the self-harness dogfood diff all verified
      end-to-end against built binaries