### PR TITLE
feat: CapabilitiesVersion + version --format json

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -92,6 +92,25 @@ make lint
 make check
 ```
 
+### Testing Unreleased ynh Against Downstream Tooling
+
+Downstream consumers (e.g. TermQ) gate on `ynh`'s wire-contract version, exposed as `capabilities` in `ynh version --format json`. Unlike `version` (release tag, injected via ldflags), `capabilities` is a source constant in `internal/config/config.go` — `make install` produces a developer build that honestly reports whatever contract the current branch implements.
+
+To test a branch against downstream tooling without cutting a release:
+
+```bash
+# From this repo — build and install to ~/.ynh/bin/
+make install
+
+# Verify the contract
+ynh version --format json
+# {"version": "dev-<branch>-<sha>", "capabilities": "0.2.0"}
+
+# Downstream tooling on PATH now sees the dev build
+```
+
+Bump `CapabilitiesVersion` whenever you change a JSON shape, command name, or manifest field that downstream code decodes or depends on. Do **not** bump it for internal refactors, bug fixes, or additive fields that older clients can safely ignore.
+
 ### Two Binaries
 
 The project produces two binaries:

--- a/cmd/ynd/main.go
+++ b/cmd/ynd/main.go
@@ -44,7 +44,7 @@ func main() {
 	case "migrate":
 		err = cmdMigrate(os.Args[2:])
 	case "version", "--version", "-v":
-		fmt.Println(config.Version)
+		err = cmdVersion(os.Args[2:])
 	case "help", "--help", "-h":
 		printUsage()
 	default:

--- a/cmd/ynd/version.go
+++ b/cmd/ynd/version.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/eyelock/ynh/internal/config"
+)
+
+// cmdVersion prints the release version and, with --format json, a structured
+// envelope that also carries the wire-contract CapabilitiesVersion.
+//
+// Consumers like TermQ call `ynd version --format json` (or `ynh version
+// --format json`) to gate their feature surface on ynh's contract capability.
+func cmdVersion(args []string) error {
+	return cmdVersionTo(args, os.Stdout, os.Stderr)
+}
+
+func cmdVersionTo(args []string, stdout, _ io.Writer) error {
+	format := "text"
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--format":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--format requires a value")
+			}
+			i++
+			format = args[i]
+		default:
+			return fmt.Errorf("unknown flag: %s", args[i])
+		}
+	}
+
+	switch format {
+	case "text":
+		_, _ = fmt.Fprintln(stdout, config.Version)
+		return nil
+	case "json":
+		payload := struct {
+			Version      string `json:"version"`
+			Capabilities string `json:"capabilities"`
+		}{
+			Version:      config.Version,
+			Capabilities: config.CapabilitiesVersion,
+		}
+		data, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encoding version payload: %w", err)
+		}
+		_, _ = fmt.Fprintln(stdout, string(data))
+		return nil
+	default:
+		return fmt.Errorf("invalid --format value %q (want text or json)", format)
+	}
+}

--- a/cmd/ynd/version_test.go
+++ b/cmd/ynd/version_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/config"
+)
+
+func TestCmdVersion_Text(t *testing.T) {
+	var out, errb bytes.Buffer
+	if err := cmdVersionTo(nil, &out, &errb); err != nil {
+		t.Fatalf("cmdVersionTo: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	if got != config.Version {
+		t.Errorf("text output = %q, want %q", got, config.Version)
+	}
+}
+
+func TestCmdVersion_JSON(t *testing.T) {
+	var out, errb bytes.Buffer
+	if err := cmdVersionTo([]string{"--format", "json"}, &out, &errb); err != nil {
+		t.Fatalf("cmdVersionTo: %v", err)
+	}
+
+	var payload struct {
+		Version      string `json:"version"`
+		Capabilities string `json:"capabilities"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v\nraw: %s", err, out.String())
+	}
+
+	if payload.Version != config.Version {
+		t.Errorf("Version = %q, want %q", payload.Version, config.Version)
+	}
+	if payload.Capabilities != config.CapabilitiesVersion {
+		t.Errorf("Capabilities = %q, want %q", payload.Capabilities, config.CapabilitiesVersion)
+	}
+}
+
+func TestCmdVersion_InvalidFormat(t *testing.T) {
+	var out, errb bytes.Buffer
+	if err := cmdVersionTo([]string{"--format", "yaml"}, &out, &errb); err == nil {
+		t.Fatal("expected error for unknown format")
+	}
+}
+
+func TestCmdVersion_UnknownFlag(t *testing.T) {
+	var out, errb bytes.Buffer
+	if err := cmdVersionTo([]string{"--bogus"}, &out, &errb); err == nil {
+		t.Fatal("expected error for unknown flag")
+	}
+}
+
+// See cmd/ynh/version_test.go for rationale.
+func TestCmdVersion_JSONShapeStability(t *testing.T) {
+	var out, errb bytes.Buffer
+	if err := cmdVersionTo([]string{"--format", "json"}, &out, &errb); err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"version", "capabilities"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing required key %q in version JSON", key)
+		}
+	}
+}

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -64,7 +64,7 @@ func main() {
 	case "prune":
 		err = cmdPrune()
 	case "version", "--version":
-		fmt.Println(config.Version)
+		err = cmdVersion(os.Args[2:])
 	case "help", "--help", "-h":
 		printUsage()
 	default:

--- a/cmd/ynh/version.go
+++ b/cmd/ynh/version.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/eyelock/ynh/internal/config"
+)
+
+// cmdVersion prints the release version and, with --format json, a structured
+// envelope that also carries the wire-contract CapabilitiesVersion.
+//
+// Consumers like TermQ call `ynh version --format json` to gate their feature
+// surface on ynh's contract capability, decoupling the gate from the release
+// tag (dev builds report the same capability string as the release they
+// branched from).
+func cmdVersion(args []string) error {
+	return cmdVersionTo(args, os.Stdout, os.Stderr)
+}
+
+func cmdVersionTo(args []string, stdout, stderr io.Writer) error {
+	format := "text"
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--format":
+			if i+1 >= len(args) {
+				return cliError(stderr, true, errCodeInvalidInput, "--format requires a value")
+			}
+			i++
+			format = args[i]
+		default:
+			return cliError(stderr, true, errCodeInvalidInput, fmt.Sprintf("unknown flag: %s", args[i]))
+		}
+	}
+
+	switch format {
+	case "text":
+		_, _ = fmt.Fprintln(stdout, config.Version)
+		return nil
+	case "json":
+		payload := versionPayload{
+			Version:      config.Version,
+			Capabilities: config.CapabilitiesVersion,
+		}
+		data, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encoding version payload: %w", err)
+		}
+		_, _ = fmt.Fprintln(stdout, string(data))
+		return nil
+	default:
+		return cliError(stderr, true, errCodeInvalidInput,
+			fmt.Sprintf("invalid --format value %q (want text or json)", format))
+	}
+}
+
+// versionPayload is the JSON shape of `ynh version --format json`.
+// Keep field names stable — external consumers (TermQ) decode this.
+type versionPayload struct {
+	Version      string `json:"version"`
+	Capabilities string `json:"capabilities"`
+}

--- a/cmd/ynh/version_test.go
+++ b/cmd/ynh/version_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/config"
+)
+
+func TestCmdVersion_Text(t *testing.T) {
+	var out, errb bytes.Buffer
+	if err := cmdVersionTo(nil, &out, &errb); err != nil {
+		t.Fatalf("cmdVersionTo: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	if got != config.Version {
+		t.Errorf("text output = %q, want %q", got, config.Version)
+	}
+}
+
+func TestCmdVersion_JSON(t *testing.T) {
+	var out, errb bytes.Buffer
+	if err := cmdVersionTo([]string{"--format", "json"}, &out, &errb); err != nil {
+		t.Fatalf("cmdVersionTo: %v", err)
+	}
+
+	var payload struct {
+		Version      string `json:"version"`
+		Capabilities string `json:"capabilities"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v\nraw: %s", err, out.String())
+	}
+
+	if payload.Version != config.Version {
+		t.Errorf("Version = %q, want %q", payload.Version, config.Version)
+	}
+	if payload.Capabilities != config.CapabilitiesVersion {
+		t.Errorf("Capabilities = %q, want %q", payload.Capabilities, config.CapabilitiesVersion)
+	}
+	if payload.Capabilities == "" {
+		t.Error("Capabilities must not be empty — TermQ relies on this field for gating")
+	}
+}
+
+func TestCmdVersion_InvalidFormat(t *testing.T) {
+	var out, errb bytes.Buffer
+	err := cmdVersionTo([]string{"--format", "yaml"}, &out, &errb)
+	if err == nil {
+		t.Fatal("expected error for unknown format")
+	}
+}
+
+func TestCmdVersion_UnknownFlag(t *testing.T) {
+	var out, errb bytes.Buffer
+	err := cmdVersionTo([]string{"--bogus"}, &out, &errb)
+	if err == nil {
+		t.Fatal("expected error for unknown flag")
+	}
+}
+
+// TestCmdVersion_JSONShapeStability pins the JSON field names. Downstream
+// consumers (TermQ) decode this into their own struct; renaming a field is
+// a breaking contract change that must be accompanied by a CapabilitiesVersion
+// bump and a coordinated TermQ release.
+func TestCmdVersion_JSONShapeStability(t *testing.T) {
+	var out, errb bytes.Buffer
+	if err := cmdVersionTo([]string{"--format", "json"}, &out, &errb); err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert raw keys as strings to catch any rename.
+	var raw map[string]any
+	if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"version", "capabilities"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing required key %q in version JSON", key)
+		}
+	}
+}

--- a/docs/cli-structured.md
+++ b/docs/cli-structured.md
@@ -80,6 +80,24 @@ Pre-1.0 caveat: breaking changes remain possible across minor versions, but will
 - Booleans are `true` / `false`, never `0` / `1` or `"yes"` / `"no"`.
 - Vendor and adapter IDs use the canonical short form (`claude`, `codex`, `cursor`) — the same identifiers used in `.ynh-plugin/plugin.json` and on the `-v` flag.
 
+## Wire-contract capability (`version --format json`)
+
+Both `ynh version --format json` and `ynd version --format json` emit:
+
+```json
+{
+  "version": "0.2.0",
+  "capabilities": "0.2.0"
+}
+```
+
+- `version` — the release version (or `dev-*` for developer builds).
+- `capabilities` — the **wire-contract version**: a semantic version consumers gate on when they depend on specific JSON shapes, command names, or manifest fields exposed by this ynh build.
+
+`capabilities` is a source constant (`internal/config.CapabilitiesVersion`), so developer builds report the contract they actually support — not whatever tag the repo was last released at. Bumped when consumer-visible contracts change; additive fields older clients can ignore do **not** bump it.
+
+Downstream tooling (e.g. TermQ) reads `capabilities` and refuses to run against an older ynh than it requires.
+
 ## Scope
 
 This document governs *output* shape and stability. It does not govern:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -84,6 +84,7 @@ Commands that take `--format json` emit machine-readable output conforming to [S
 | `ynh paths` | `home`, `config`, `harnesses`, `symlinks`, `cache`, `run`, `bin` — all absolute paths resolved for the current `$YNH_HOME` |
 | `ynh search [query]` | Array of result objects: `name`, `description`, `keywords`, `repo`, `path`, `vendors`, `version`, `from` (`type`, `name`) |
 | `ynh vendors` | Array of vendor objects: `name`, `display_name`, `cli`, `config_dir`, `available` (bool) |
+| `ynh version` / `ynd version` | `version` (release), `capabilities` (wire-contract). See [Wire-contract capability](cli-structured.md#wire-contract-capability-version---format-json). |
 | `ynh sources list` | Array of source objects: `name`, `path`, `description`, `harnesses` (discovery count) |
 
 Human-readable tabwriter output remains the default for every command. Structured mode is strictly opt-in.

--- a/docs/tutorial/07-registry-and-discovery.md
+++ b/docs/tutorial/07-registry-and-discovery.md
@@ -219,8 +219,8 @@ ynh registry list
 Local sources are directories of harnesses registered in config — no Git or internet required. When a source name matches a harness name, uninstalling the harness also removes the source entry.
 
 ```bash
-mkdir -p /tmp/ynh-tutorial/sources/codereview
-cat > /tmp/ynh-tutorial/sources/codereview/.harness.json << 'EOF'
+mkdir -p /tmp/ynh-tutorial/sources/codereview/.ynh-plugin
+cat > /tmp/ynh-tutorial/sources/codereview/.ynh-plugin/plugin.json << 'EOF'
 {
   "name": "codereview",
   "version": "0.1.0",
@@ -259,8 +259,8 @@ ynh search "code review"
 
 Expected:
 ```
-NAME        DESCRIPTION          REPO                                  VENDORS  FROM
-codereview  Code review harness  /tmp/ynh-tutorial/sources/codereview  claude   codereview (source)
+NAME        DESCRIPTION          REPO                                  FROM
+codereview  Code review harness  /tmp/ynh-tutorial/sources/codereview  codereview (source)
 ```
 
 ## T7.15: Install from source

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,23 @@ import (
 	"path/filepath"
 )
 
+// Version is the release version, injected by goreleaser via ldflags.
+// "dev" when building from a developer checkout.
 var Version = "dev"
+
+// CapabilitiesVersion declares the TermQ-facing wire-contract version of this
+// ynh build. Unlike Version it is a source constant, so developer builds
+// (`make install` from any branch) honestly report what the contract supports
+// without needing a release tag.
+//
+// Bump when the JSON shapes consumers decode, the commands they invoke, or
+// the manifest fields they rely on change in a way that requires downstream
+// code to adapt. Do NOT bump for internal refactors, bug fixes, or additive
+// fields older clients can ignore.
+//
+// Consumers (e.g. TermQ) read this via `ynh version --format json` and gate
+// features on it with their own `minimumYNHCapabilities` constant.
+const CapabilitiesVersion = "0.2.0"
 
 const (
 	DefaultDirName = ".ynh"


### PR DESCRIPTION
## Summary

- New source constant `internal/config.CapabilitiesVersion = "0.2.0"` — a wire-contract version decoupled from the release `Version` ldflag, so developer builds (`make install` from any branch) honestly report the contract they support.
- New `ynh version --format json` and `ynd version --format json` emit `{"version": "...", "capabilities": "..."}`. Text output unchanged.
- Downstream tooling (TermQ) reads `capabilities` to gate features without coupling to release tags.
- Docs: `cli-structured.md` section, `reference.md` table row, `CONTRIBUTING.md` local-dev flow for testing unreleased ynh against downstream tools.
- Tutorial fix-up: T7.12/T7.14 — legacy `.harness.json` → `.ynh-plugin/plugin.json`, drop spurious `VENDORS` column from T7.14 expected output (pre-existing defects, flagged by evals).

## Contract policy

Bump `CapabilitiesVersion` when the JSON shapes consumers decode, command names they invoke, or manifest fields they rely on change in a way that requires downstream code to adapt. Do **not** bump for internal refactors, bug fixes, or additive fields older clients can ignore.

## Test plan

- [x] `make check` green
- [x] `ynh version` / `ynd version` unchanged text output
- [x] `ynh version --format json` / `ynd version --format json` emit expected shape
- [x] Invalid `--format yaml` / unknown flag return non-zero with error envelope
- [x] JSON shape stability test pins `version` + `capabilities` field names
- [x] Evals re-run after tutorial fix (T7.14 reproduced against binary to verify fix is correct)
- [ ] End-to-end test against TermQ (next step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)