### PR TITLE
fix: ynd validate and ynd migrate auto-recurse directories

### DIFF
--- a/cmd/ynd/migrate.go
+++ b/cmd/ynd/migrate.go
@@ -4,33 +4,31 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/eyelock/ynh/internal/migration"
 	"github.com/eyelock/ynh/internal/plugin"
 )
 
-// cmdMigrate runs the format migration chain against a directory.
+// cmdMigrate runs the format migration chain against a directory tree.
 // Idempotent — the chain no-ops when no migrator applies.
 //
 // The command itself knows nothing about specific migrations. Adding or
 // removing a migrator in internal/migration/ changes what this command
 // handles automatically. Storage relocation is intentionally excluded;
 // ynh itself triggers that when installing or relocating harnesses.
-//
-// Supports -r/--recursive to walk a tree and migrate every directory that
-// any registered migrator applies to.
 func cmdMigrate(args []string) error {
-	recursive := false
 	var target string
 
 	for _, a := range args {
 		switch a {
-		case "-r", "--recursive":
-			recursive = true
 		case "-h", "--help":
 			printMigrateUsage()
 			return nil
 		default:
+			if strings.HasPrefix(a, "-") {
+				return fmt.Errorf("unknown flag: %s", a)
+			}
 			if target != "" {
 				return fmt.Errorf("unexpected argument %q", a)
 			}
@@ -52,13 +50,10 @@ func cmdMigrate(args []string) error {
 
 	chain := migration.FormatChain()
 
-	dirs := []string{target}
-	if recursive {
-		dirs = findMigratableDirs(target, chain)
-		if len(dirs) == 0 {
-			fmt.Printf("Nothing to migrate under %s\n", target)
-			return nil
-		}
+	dirs := findMigratableDirs(target, chain)
+	if len(dirs) == 0 {
+		fmt.Println("Nothing to migrate.")
+		return nil
 	}
 
 	migrated := 0
@@ -113,15 +108,13 @@ func findMigratableDirs(root string, chain migration.Chain) []string {
 func printMigrateUsage() {
 	fmt.Println(`ynd migrate - run the format migration chain
 
-Runs every registered format migrator against the target directory.
+Runs every registered format migrator against the target directory tree.
 Migrators decide whether they apply based on the directory contents,
 so the command works for any format transition handled by the chain.
 
 Usage:
-  ynd migrate [path]              Migrate a single directory (default: .)
-  ynd migrate -r [path]           Recursively migrate all matching dirs under path
+  ynd migrate [path]              Migrate all matching dirs under path (default: .)
 
 Options:
-  -r, --recursive                 Walk the tree and migrate every matching dir
   -h, --help                      Show this help`)
 }

--- a/cmd/ynd/validate.go
+++ b/cmd/ynd/validate.go
@@ -138,27 +138,23 @@ func isLegacyHarnessRoot(dir string) bool {
 }
 
 func findHarnessRoots(root string) []string {
-	// Check if root itself is a harness
-	if isHarnessRoot(root) {
-		return []string{root}
-	}
-
-	// Check immediate children
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return nil
-	}
-
 	var roots []string
-	for _, entry := range entries {
-		if entry.IsDir() {
-			child := filepath.Join(root, entry.Name())
-			if isHarnessRoot(child) {
-				roots = append(roots, child)
-			}
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
 		}
-	}
-
+		if !d.IsDir() {
+			return nil
+		}
+		if d.Name() == plugin.PluginDir {
+			return filepath.SkipDir
+		}
+		if isHarnessRoot(path) {
+			roots = append(roots, path)
+			return filepath.SkipDir
+		}
+		return nil
+	})
 	return roots
 }
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -33,7 +33,7 @@ If you author harnesses, convert your source trees:
 
 ```bash
 cd my-harnesses
-ynd migrate -r .
+ynd migrate .
 ```
 
 `ynd migrate` runs the full migration chain against every matching directory.
@@ -102,7 +102,7 @@ synthetic `local/unknown` namespace if provenance is missing.
 - **0.2.x** — `.harness.json` and `registry.json` continue to work via the
   migration chain. Old files are converted transparently on first read.
 - **0.3.x** — Legacy migrators are removed. `.harness.json` and
-  `registry.json` are no longer recognized. Run `ynd migrate -r` before
+  `registry.json` are no longer recognized. Run `ynd migrate` before
   upgrading to 0.3.
 
 Dropping support in 0.3 means removing the migrator files and unregistering

--- a/docs/tutorial/18-namespacing-and-migration.md
+++ b/docs/tutorial/18-namespacing-and-migration.md
@@ -184,7 +184,7 @@ cat > /tmp/ynh-ns-tutorial/bulk/h2/.harness.json << 'EOF'
 {"name":"h2","version":"0.1.0"}
 EOF
 
-ynd migrate -r /tmp/ynh-ns-tutorial/bulk
+ynd migrate /tmp/ynh-ns-tutorial/bulk
 ```
 
 Expected:

--- a/docs/ynd.md
+++ b/docs/ynd.md
@@ -242,7 +242,7 @@ the full 0.1 → 0.2 migration guide.
 ```bash
 ynd migrate                    # current directory
 ynd migrate ./my-harness       # specific directory
-ynd migrate -r ./harnesses     # recursive: walk tree, migrate every match
+ynd migrate ./harnesses        # walk tree, migrate every match
 ```
 
 Idempotent — safe to run twice. No-op if the target already uses the new
@@ -251,7 +251,6 @@ so manual invocation is rarely needed except for source trees.
 
 | Flag | Description |
 |------|-------------|
-| `-r, --recursive` | Walk the tree and migrate every matching dir |
 | `-h, --help` | Show help |
 
 **Output structure:**


### PR DESCRIPTION
Ensures ynd validate and ynd migrate commands automatically recurse through subdirectories when given a parent directory path, making batch operations consistent and intuitive.

## Testing
- Tutorial 18.6: Single directory migration ✓
- Tutorial 18.7: Recursive directory migration ✓  
- ynd validate: Auto-recurses through subdirectories ✓
- make check: All tests pass ✓
- Error cases (E14, E21): Validation still catches errors correctly ✓

## Related
Fixes inconsistent behavior where ynd commands required explicit recursion handling vs. ynh commands which auto-recurse.