### PR TITLE
fix(security): block path traversal in --path, includes, and marketplace entries

### DIFF
--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/harness"
 	"github.com/eyelock/ynh/internal/migration"
+	"github.com/eyelock/ynh/internal/pathutil"
 	"github.com/eyelock/ynh/internal/plugin"
 	"github.com/eyelock/ynh/internal/resolver"
 	"github.com/eyelock/ynh/internal/symlink"
@@ -243,6 +244,9 @@ func cmdInstall(args []string) error {
 
 	// Scope to subdirectory if --path was specified
 	if pathFlag != "" {
+		if err := pathutil.CheckSubpath(pathFlag); err != nil {
+			return fmt.Errorf("invalid --path: %w", err)
+		}
 		srcDir = filepath.Join(srcDir, pathFlag)
 		if _, err := os.Stat(srcDir); os.IsNotExist(err) {
 			return fmt.Errorf("path %q not found in source", pathFlag)

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -798,6 +798,23 @@ func TestCmdInstall_PathFlag_NoSource(t *testing.T) {
 	}
 }
 
+func TestCmdInstall_PathFlag_TraversalBlocked(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("YNH_HOME", "")
+
+	for _, p := range []string{"../../etc", "../secret", "/etc/passwd", "a/../../etc"} {
+		err := cmdInstall([]string{dir, "--path", p})
+		if err == nil {
+			t.Errorf("--path %q: expected error, got nil", p)
+			continue
+		}
+		if !strings.Contains(err.Error(), "invalid --path") {
+			t.Errorf("--path %q: unexpected error: %v", p, err)
+		}
+	}
+}
+
 func TestCmdInstall_SourceInsideHarnessesDir(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -116,7 +116,7 @@ the two must be set.
 | `git` | one of git/local | Git URL (see formats below) |
 | `local` | one of git/local | Local filesystem path. Absolute, or relative to the harness root. |
 | `ref` | no | Git tag, branch, or commit (Git sources only) |
-| `path` | no | Subdirectory within the resolved source |
+| `path` | no | Subdirectory within the resolved source. Must be a relative path with no `..` traversal. |
 | `pick` | no | Specific artifact paths to include. If omitted, includes all. |
 
 Local includes are useful when a harness ships bundled artifact directories
@@ -190,7 +190,7 @@ Other harnesses this one can invoke as subagents.
 |-------|----------|-------------|
 | `git` | yes | Git URL (same formats as includes) |
 | `ref` | no | Git tag/branch |
-| `path` | no | Subdirectory within the repo (monorepo support) |
+| `path` | no | Subdirectory within the repo (monorepo support). Must be a relative path with no `..` traversal. |
 
 When running as `david`, you can ask it to delegate a task to `team-dev`. The delegation happens through the vendor's native subagent system.
 

--- a/docs/schema/marketplace.schema.json
+++ b/docs/schema/marketplace.schema.json
@@ -86,7 +86,7 @@
           "type": "string",
           "description": "owner/repo shorthand"
         },
-        "path": { "type": "string" },
+        "path": { "type": "string", "pattern": "^(?!\\.\\./|\\.\\.($))[^/]" },
         "ref": { "type": "string" },
         "sha": {
           "type": "string",
@@ -102,7 +102,7 @@
       "properties": {
         "type": { "const": "url" },
         "url": { "type": "string" },
-        "path": { "type": "string" },
+        "path": { "type": "string", "pattern": "^(?!\\.\\./|\\.\\.($))[^/]" },
         "ref": { "type": "string" },
         "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
       }
@@ -116,7 +116,8 @@
         "url": { "type": "string" },
         "path": {
           "type": "string",
-          "description": "Subdirectory to sparse-clone. Required — no point in sparse clone of the root."
+          "pattern": "^(?!\\.\\./|\\.\\.($))[^/]",
+          "description": "Subdirectory to sparse-clone. Must be relative and must not traverse above the source root."
         },
         "ref": { "type": "string" },
         "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" }

--- a/docs/schema/plugin.schema.json
+++ b/docs/schema/plugin.schema.json
@@ -142,7 +142,8 @@
           },
           "path": {
             "type": "string",
-            "description": "Subdirectory within the resolved source."
+            "pattern": "^(?!\\.\\./|\\.\\.($))[^/]",
+            "description": "Subdirectory within the resolved source. Must be relative and must not traverse above the source root."
           },
           "pick": {
             "type": "array",
@@ -168,7 +169,7 @@
         "properties": {
           "git": { "type": "string" },
           "ref": { "type": "string" },
-          "path": { "type": "string" }
+          "path": { "type": "string", "pattern": "^(?!\\.\\./|\\.\\.($))[^/]" }
         }
       }
     }

--- a/docs/ynd.md
+++ b/docs/ynd.md
@@ -157,7 +157,7 @@ ynd export github.com/user/repo --path harnesses/david  # from a monorepo
 | `-o, --output <dir>` | Output directory. Default: `./dist/<harness-name>/` |
 | `-v, --vendor <names>` | Comma-separated vendors. Default: all registered (`claude,codex,cursor`) |
 | `--harness <dir>` | Harness source directory (alternative to positional arg) |
-| `--path <subdir>` | Subdirectory within source (for monorepos) |
+| `--path <subdir>` | Subdirectory within source (for monorepos). Must be a relative path with no `..` traversal. |
 | `--profile <name>` | Profile to apply during assembly |
 | `--merged` | Single output dir with all vendor manifests (for CI/marketplace use) |
 | `--clean` | Remove entire output dir before export |
@@ -281,7 +281,7 @@ See [Tutorial 11: Marketplace](tutorial/06-marketplace.md) for a guided walkthro
 | `--clean` | export, marketplace | Remove output directory before writing. |
 | `--merged` | export | Single output dir with dual vendor manifests. |
 | `--profile <name>` | preview, diff, export | Profile to apply during assembly. |
-| `--path <subdir>` | export | Subdirectory within source (for monorepos). |
+| `--path <subdir>` | export | Subdirectory within source (for monorepos). Must be a relative path with no `..` traversal. |
 | `--restore` | compress | Restore a file from its latest backup. |
 | `--list-backups` | compress | Show backup history for a file. |
 | `--pick <N>` | compress | With `--restore`, pick a specific backup by number from the list. |

--- a/internal/marketplace/marketplace.go
+++ b/internal/marketplace/marketplace.go
@@ -12,6 +12,7 @@ import (
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/exporter"
 	"github.com/eyelock/ynh/internal/migration"
+	"github.com/eyelock/ynh/internal/pathutil"
 	"github.com/eyelock/ynh/internal/plugin"
 	"github.com/eyelock/ynh/internal/resolver"
 	"github.com/eyelock/ynh/internal/vendor"
@@ -183,6 +184,9 @@ func Build(cfg *MarketplaceConfig, opts BuildOptions) error {
 
 		// Apply monorepo subdir
 		if entry.Path != "" {
+			if err := pathutil.CheckSubpath(entry.Path); err != nil {
+				return fmt.Errorf("entry %q: invalid path: %w", entry.Source, err)
+			}
 			srcDir = filepath.Join(srcDir, entry.Path)
 		}
 

--- a/internal/marketplace/marketplace_build_test.go
+++ b/internal/marketplace/marketplace_build_test.go
@@ -249,3 +249,24 @@ func TestMarketplaceVendorFiltering(t *testing.T) {
 	assertFileExists(t, filepath.Join(outputDir, ".claude-plugin", "marketplace.json"))
 	assertFileNotExists(t, filepath.Join(outputDir, ".cursor-plugin", "marketplace.json"))
 }
+
+func TestMarketplaceBuild_EntryPathTraversalBlocked(t *testing.T) {
+	dir := t.TempDir()
+	for _, badPath := range []string{"../../etc", "../secret", "/etc/passwd", "a/../../etc"} {
+		cfg := &MarketplaceConfig{
+			Name:  "test",
+			Owner: MarketplaceOwner{Name: "tester"},
+			Entries: []MarketplaceEntry{
+				{Type: "plugin", Source: "./plugins/foo", Path: badPath},
+			},
+		}
+		err := Build(cfg, BuildOptions{ConfigDir: dir, OutputDir: t.TempDir()})
+		if err == nil {
+			t.Errorf("path %q: expected error, got nil", badPath)
+			continue
+		}
+		if !strings.Contains(err.Error(), "invalid path") {
+			t.Errorf("path %q: unexpected error: %v", badPath, err)
+		}
+	}
+}

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -1,0 +1,22 @@
+// Package pathutil provides path safety helpers.
+package pathutil
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// CheckSubpath returns an error if p is not a safe relative subdirectory path.
+// Safe means: not absolute, and no ".." component that would escape the base
+// directory after cleaning.
+func CheckSubpath(p string) error {
+	if filepath.IsAbs(p) {
+		return fmt.Errorf("path %q must be relative, not absolute", p)
+	}
+	clean := filepath.Clean(p)
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path %q must not traverse above its base directory", p)
+	}
+	return nil
+}

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -1,0 +1,42 @@
+package pathutil_test
+
+import (
+	"testing"
+
+	"github.com/eyelock/ynh/internal/pathutil"
+)
+
+func TestCheckSubpath(t *testing.T) {
+	valid := []string{
+		"skills/dev",
+		"harnesses/reviewer",
+		"ynh/david",
+		"a",
+		"a/b/c",
+		".",
+		"some.dir/with-dashes_and.dots",
+	}
+	for _, p := range valid {
+		t.Run("valid:"+p, func(t *testing.T) {
+			if err := pathutil.CheckSubpath(p); err != nil {
+				t.Errorf("CheckSubpath(%q) unexpected error: %v", p, err)
+			}
+		})
+	}
+
+	invalid := []string{
+		"..",
+		"../etc/passwd",
+		"../",
+		"a/../../etc",
+		"/absolute/path",
+		"/etc/passwd",
+	}
+	for _, p := range invalid {
+		t.Run("invalid:"+p, func(t *testing.T) {
+			if err := pathutil.CheckSubpath(p); err == nil {
+				t.Errorf("CheckSubpath(%q) expected error, got nil", p)
+			}
+		})
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/pathutil"
 )
 
 // ResolvedContent represents files extracted from a Git source.
@@ -42,6 +43,9 @@ func resolveGitSourceWith(gs harness.GitSource, fetch repoFunc) (string, *RepoRe
 
 	basePath := result.Path
 	if gs.Path != "" {
+		if err := pathutil.CheckSubpath(gs.Path); err != nil {
+			return "", nil, fmt.Errorf("include path: %w", err)
+		}
 		basePath = filepath.Join(result.Path, gs.Path)
 		if _, err := os.Stat(basePath); os.IsNotExist(err) {
 			return "", nil, fmt.Errorf("path %q not found in %s", gs.Path, gs.Git)
@@ -57,6 +61,9 @@ func resolveGitSourceWith(gs harness.GitSource, fetch repoFunc) (string, *RepoRe
 func resolveLocalSource(gs harness.GitSource, harnessDir string) (string, error) {
 	local := gs.Local
 	if !filepath.IsAbs(local) {
+		if err := pathutil.CheckSubpath(local); err != nil {
+			return "", fmt.Errorf("local include: %w", err)
+		}
 		if harnessDir == "" {
 			return "", fmt.Errorf("local include %q: harness directory not known, cannot resolve relative path", local)
 		}
@@ -68,6 +75,9 @@ func resolveLocalSource(gs harness.GitSource, harnessDir string) (string, error)
 
 	basePath := local
 	if gs.Path != "" {
+		if err := pathutil.CheckSubpath(gs.Path); err != nil {
+			return "", fmt.Errorf("local include path: %w", err)
+		}
 		basePath = filepath.Join(local, gs.Path)
 		if _, err := os.Stat(basePath); os.IsNotExist(err) {
 			return "", fmt.Errorf("path %q not found in local source %q", gs.Path, gs.Local)

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -574,3 +574,53 @@ func TestResolve_LocalInclude_Missing(t *testing.T) {
 		t.Errorf("error should mention 'not found', got: %v", err)
 	}
 }
+
+func TestResolveLocalSource_TraversalBlocked(t *testing.T) {
+	base := t.TempDir()
+	// Create a real subdir so the local path resolves — the traversal in path should still be blocked.
+	subdir := filepath.Join(base, "subdir")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		local string
+		path  string
+	}{
+		// Relative local paths with .. are blocked
+		{local: "../../../etc", path: ""},
+		// Path component with .. is blocked even when local resolves
+		{local: "subdir", path: "../../etc"},
+		// Absolute path component is blocked
+		{local: "subdir", path: "/etc/passwd"},
+	} {
+		gs := harness.GitSource{Local: tc.local, Path: tc.path}
+		_, err := resolveLocalSource(gs, base)
+		if err == nil {
+			t.Errorf("local=%q path=%q: expected error, got nil", tc.local, tc.path)
+			continue
+		}
+		if !strings.Contains(err.Error(), "must not traverse") && !strings.Contains(err.Error(), "must be relative") {
+			t.Errorf("local=%q path=%q: unexpected error: %v", tc.local, tc.path, err)
+		}
+	}
+}
+
+func TestResolveGitSource_PathTraversalBlocked(t *testing.T) {
+	repoDir := t.TempDir()
+	fetch := func(url, ref string) (RepoResult, error) {
+		return RepoResult{Path: repoDir}, nil
+	}
+
+	for _, badPath := range []string{"../../etc", "../secret", "/etc/passwd"} {
+		gs := harness.GitSource{Git: "github.com/org/repo", Path: badPath}
+		_, _, err := resolveGitSourceWith(gs, fetch)
+		if err == nil {
+			t.Errorf("path %q: expected error, got nil", badPath)
+			continue
+		}
+		if !strings.Contains(err.Error(), "must not traverse") && !strings.Contains(err.Error(), "must be relative") {
+			t.Errorf("path %q: unexpected error: %v", badPath, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

User-controlled path values were joined directly into file system paths without sanitisation, allowing directory traversal attacks:

- `ynh install github.com/org/repo --path "../../etc/passwd"` — escapes the cloned repo
- `includes: [{"local": "../../../etc", "path": "passwd"}]` — escapes the harness directory
- `marketplace entries: {"source": "./foo", "path": "../../etc"}` — escapes the source directory

## Changes

**New `internal/pathutil` package** — `CheckSubpath(p string) error` rejects paths that are absolute or resolve above their base after `filepath.Clean`. Single implementation applied consistently at all vulnerable sites.

**Four vulnerable join sites fixed:**
- `cmd/ynh/main.go` — `--path` CLI flag
- `internal/marketplace/marketplace.go` — marketplace entry `path` field
- `internal/resolver/resolver.go` — `includes[].path` for git sources
- `internal/resolver/resolver.go` — `includes[].local` and `.path` for local sources

**Defence in depth:** added `pattern` constraint to all `path` fields in `plugin.schema.json` and `marketplace.schema.json` to reject traversal sequences at the schema validation layer too.

**Docs updated:** `--path` and `path` field descriptions in `docs/ynd.md` and `docs/harnesses.md` note the relative-only constraint.

## Testing

- `make check` passes — all tests green
- `ynh install <url> --path "../../etc"` → `Error: invalid --path: path "../../etc" must not traverse above its base directory`
- `ynh install <url> --path "harnesses/reviewer"` → works correctly
- `ynd preview` with `includes[].local "../../../etc"` → `Error: local include: path "../../../etc" must not traverse above its base directory`
- New tests: `pathutil` unit suite, `TestCmdInstall_PathFlag_TraversalBlocked`, `TestMarketplaceBuild_EntryPathTraversalBlocked`, `TestResolveLocalSource_TraversalBlocked`, `TestResolveGitSource_PathTraversalBlocked`
- Evals: PASS (18 tutorials, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)