### PR TITLE
fix(compose): pick filter now matches type/name paths from includes

### DIFF
--- a/cmd/ynd/compose.go
+++ b/cmd/ynd/compose.go
@@ -236,25 +236,25 @@ func buildComposeOutput(h *harness.Harness, srcDir string, resolved []resolver.R
 		}
 
 		for _, s := range incArts.Skills {
-			if len(pickSet) > 0 && !pickSet[s] {
+			if len(pickSet) > 0 && !pickSet["skills/"+s] {
 				continue
 			}
 			allSkills = append(allSkills, composeArtifact{Name: s, Source: incSource})
 		}
 		for _, a := range incArts.Agents {
-			if len(pickSet) > 0 && !pickSet[a] {
+			if len(pickSet) > 0 && !pickSet["agents/"+a] {
 				continue
 			}
 			allAgents = append(allAgents, composeArtifact{Name: a, Source: incSource})
 		}
 		for _, r := range incArts.Rules {
-			if len(pickSet) > 0 && !pickSet[r] {
+			if len(pickSet) > 0 && !pickSet["rules/"+r] {
 				continue
 			}
 			allRules = append(allRules, composeArtifact{Name: r, Source: incSource})
 		}
 		for _, c := range incArts.Commands {
-			if len(pickSet) > 0 && !pickSet[c] {
+			if len(pickSet) > 0 && !pickSet["commands/"+c] {
 				continue
 			}
 			allCommands = append(allCommands, composeArtifact{Name: c, Source: incSource})

--- a/cmd/ynd/compose_test.go
+++ b/cmd/ynd/compose_test.go
@@ -538,6 +538,61 @@ func TestCmdComposeHelp(t *testing.T) {
 	}
 }
 
+func TestCmdComposePickFilterWithLocalInclude(t *testing.T) {
+	// Regression: pickSet was built from "skills/name" paths but compared
+	// against bare "name" values returned by ScanArtifactsDir, so picked
+	// skills were always dropped.
+	dir := t.TempDir()
+
+	// Create include harness with two skills
+	incDir := filepath.Join(dir, "include-harness")
+	for _, name := range []string{"swift-lang", "go-lang"} {
+		skillDir := filepath.Join(incDir, "skills", name)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+			[]byte("---\nname: "+name+"\n---\n"+name+" skill.\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(incDir, ".harness.json"),
+		[]byte(`{"name":"inc","version":"0.1.0","default_vendor":"claude"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Main harness picks only swift-lang from the include
+	hj := map[string]any{
+		"name":           "main",
+		"version":        "1.0.0",
+		"default_vendor": "claude",
+		"includes": []map[string]any{
+			{"local": incDir, "pick": []string{"skills/swift-lang"}},
+		},
+	}
+	data, _ := json.MarshalIndent(hj, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, ".harness.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := cmdComposeTo([]string{dir}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdComposeTo: %v", err)
+	}
+
+	var got composeOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(got.Artifacts.Skills) != 1 {
+		t.Fatalf("skills = %v, want exactly [swift-lang]", got.Artifacts.Skills)
+	}
+	if got.Artifacts.Skills[0].Name != "swift-lang" {
+		t.Errorf("skill name = %q, want swift-lang", got.Artifacts.Skills[0].Name)
+	}
+}
+
 func TestCmdComposeTextWithMCPURL(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Problem

`ynd inspect`/`ynd compose` silently dropped all picked artifacts from includes. The `pickSet` was built from full paths like `"skills/swift-lang"` but compared against bare names returned by `ScanArtifactsDir` (`"swift-lang"`), so the check was always false.

Includes with no `pick` were unaffected (`len(pickSet) == 0`), which is why unfiltered includes worked fine.

## Fix

Prefix the bare artifact name with its type directory when checking the pick set (`"skills/"+s`, `"agents/"+a`, etc.), keeping the set in `type/name` form throughout.

## Test

Added `TestCmdComposePickFilterWithLocalInclude` — creates an include with two skills, picks one, asserts only the picked skill appears in compose output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)