### PR TITLE
ci: allow release/* branches to target main

### DIFF
--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -9,15 +9,15 @@ jobs:
     name: Verify PR source branch
     runs-on: ubuntu-latest
     steps:
-      - name: Check that PR targets main only from develop or hotfix/*
+      - name: Check that PR targets main only from develop, hotfix/*, or release/*
         run: |
           SOURCE="${{ github.head_ref }}"
           echo "PR source branch: $SOURCE"
 
-          if [[ "$SOURCE" == "develop" ]] || [[ "$SOURCE" == hotfix/* ]]; then
+          if [[ "$SOURCE" == "develop" ]] || [[ "$SOURCE" == hotfix/* ]] || [[ "$SOURCE" == release/* ]]; then
             echo "✅ Source branch '$SOURCE' is allowed to target main"
           else
-            echo "❌ PRs to main must come from 'develop' or 'hotfix/*'"
+            echo "❌ PRs to main must come from 'develop', 'hotfix/*', or 'release/*'"
             echo "   Source branch '$SOURCE' is not allowed."
             echo "   Open your PR against 'develop' instead."
             exit 1


### PR DESCRIPTION
Fixes the branch guard so `release/*` branches can promote to `main`. The original workflow only allowed `develop` and `hotfix/*`, which broke the v0.2.0 release PR (#93).

🤖 Generated with [Claude Code](https://claude.com/claude-code)