### PR TITLE
ci: fix release branch pattern (release-* not release/*)

### DIFF
--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -9,15 +9,15 @@ jobs:
     name: Verify PR source branch
     runs-on: ubuntu-latest
     steps:
-      - name: Check that PR targets main only from develop, hotfix/*, or release/*
+      - name: Check that PR targets main only from develop, hotfix/*, or release-*
         run: |
           SOURCE="${{ github.head_ref }}"
           echo "PR source branch: $SOURCE"
 
-          if [[ "$SOURCE" == "develop" ]] || [[ "$SOURCE" == hotfix/* ]] || [[ "$SOURCE" == release/* ]]; then
+          if [[ "$SOURCE" == "develop" ]] || [[ "$SOURCE" == hotfix/* ]] || [[ "$SOURCE" == release-* ]]; then
             echo "✅ Source branch '$SOURCE' is allowed to target main"
           else
-            echo "❌ PRs to main must come from 'develop', 'hotfix/*', or 'release/*'"
+            echo "❌ PRs to main must come from 'develop', 'hotfix/*', or 'release-*'"
             echo "   Source branch '$SOURCE' is not allowed."
             echo "   Open your PR against 'develop' instead."
             exit 1


### PR DESCRIPTION
The glob pattern release/* requires a slash — our branch is release-0.2.0 (hyphen). Fix to release-*.