### PR TITLE
feat(cli): JSON envelope and provenance fields for info/ls

### DIFF
--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -16,17 +16,19 @@ Every change goes through a branch and PR — no exceptions.
 
 ## Branch naming
 
-Use hyphens for all branches except hotfixes, which must use a slash (CI enforces `hotfix/*`):
+Use slashes for all branches:
 
 ```
-feat-<description>
-fix-<description>
-docs-<description>
-ci-<description>
-refactor-<description>
-test-<description>
+feat/<description>
+fix/<description>
+docs/<description>
+ci/<description>
+refactor/<description>
+test/<description>
 hotfix/<description>
 ```
+
+CI enforces `hotfix/*` for hotfixes targeting `main`. There are no release branches — release is tag-driven.
 
 ## Workflow
 

--- a/cmd/ynh/info.go
+++ b/cmd/ynh/info.go
@@ -9,20 +9,36 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/harness"
 	"github.com/eyelock/ynh/internal/plugin"
 )
 
+// infoEnvelope wraps a single harness with the wire-contract version
+// (capabilities) and the ynh release version. Mirrors listEnvelope so
+// consumers can decode either response with the same outer shape.
+type infoEnvelope struct {
+	Capabilities string    `json:"capabilities"`
+	YnhVersion   string    `json:"ynh_version"`
+	Harness      infoEntry `json:"harness"`
+}
+
 // infoEntry is the JSON shape for `ynh info` structured output.
-// Identity fields at the top, provenance next, then the raw manifest.
+// Carries the same per-harness fields as listEntry, plus the raw manifest.
 type infoEntry struct {
-	Name          string             `json:"name"`
-	Version       string             `json:"version"`
-	Description   string             `json:"description,omitempty"`
-	DefaultVendor string             `json:"default_vendor"`
-	Path          string             `json:"path"`
-	InstalledFrom *listInstalledFrom `json:"installed_from,omitempty"`
-	Manifest      json.RawMessage    `json:"manifest"`
+	Name             string             `json:"name"`
+	VersionInstalled string             `json:"version_installed"`
+	VersionAvailable string             `json:"version_available,omitempty"`
+	Description      string             `json:"description,omitempty"`
+	DefaultVendor    string             `json:"default_vendor"`
+	Path             string             `json:"path"`
+	RefInstalled     string             `json:"ref_installed,omitempty"`
+	RefAvailable     string             `json:"ref_available,omitempty"`
+	IsPinned         bool               `json:"is_pinned"`
+	InstalledFrom    *listInstalledFrom `json:"installed_from,omitempty"`
+	Includes         []listInclude      `json:"includes"`
+	DelegatesTo      []listDelegate     `json:"delegates_to"`
+	Manifest         json.RawMessage    `json:"manifest"`
 }
 
 func cmdInfo(args []string) error {
@@ -33,6 +49,7 @@ func cmdInfoTo(args []string, stdout, stderr io.Writer) error {
 	structured := detectJSONFormat(args)
 
 	format := "text"
+	checkUpdates := false
 	var name string
 	i := 0
 	for i < len(args) {
@@ -43,6 +60,8 @@ func cmdInfoTo(args []string, stdout, stderr io.Writer) error {
 			}
 			i++
 			format = args[i]
+		case "--check-updates":
+			checkUpdates = true
 		default:
 			if strings.HasPrefix(args[i], "-") {
 				return cliError(stderr, structured, errCodeInvalidInput,
@@ -63,9 +82,13 @@ func cmdInfoTo(args []string, stdout, stderr io.Writer) error {
 
 	switch format {
 	case "text":
+		if checkUpdates {
+			return cliError(stderr, structured, errCodeInvalidInput,
+				"--check-updates requires --format json")
+		}
 		return printInfoText(stdout, name)
 	case "json":
-		return printInfoJSON(stdout, stderr, name)
+		return printInfoJSON(stdout, stderr, name, checkUpdates)
 	default:
 		return cliError(stderr, structured, errCodeInvalidInput,
 			fmt.Sprintf("invalid --format value %q (want text or json)", format))
@@ -240,7 +263,10 @@ func printInfoText(w io.Writer, name string) error {
 	return nil
 }
 
-func printInfoJSON(stdout, stderr io.Writer, name string) error {
+func printInfoJSON(stdout, stderr io.Writer, name string, _ bool) error {
+	// checkUpdates is accepted but not yet wired to network probes — version_available
+	// and ref_available remain omitted (the "unknown" state per the three-state contract).
+	// Network probes land in a follow-up PR.
 	p, err := harness.Load(name)
 	if err != nil {
 		code := errCodeNotFound
@@ -267,26 +293,30 @@ func printInfoJSON(stdout, stderr io.Writer, name string) error {
 			fmt.Sprintf("parsing manifest: %v", err))
 	}
 
+	base := buildListEntry(p, name)
 	entry := infoEntry{
-		Name:          p.Name,
-		Version:       p.Version,
-		Description:   p.Description,
-		DefaultVendor: p.DefaultVendor,
-		Path:          harness.InstalledDir(name),
-		Manifest:      compacted,
+		Name:             base.Name,
+		VersionInstalled: base.VersionInstalled,
+		VersionAvailable: base.VersionAvailable,
+		Description:      base.Description,
+		DefaultVendor:    base.DefaultVendor,
+		Path:             base.Path,
+		RefInstalled:     base.RefInstalled,
+		RefAvailable:     base.RefAvailable,
+		IsPinned:         base.IsPinned,
+		InstalledFrom:    base.InstalledFrom,
+		Includes:         base.Includes,
+		DelegatesTo:      base.DelegatesTo,
+		Manifest:         compacted,
 	}
 
-	if p.InstalledFrom != nil {
-		entry.InstalledFrom = &listInstalledFrom{
-			SourceType:   p.InstalledFrom.SourceType,
-			Source:       p.InstalledFrom.Source,
-			Path:         p.InstalledFrom.Path,
-			RegistryName: p.InstalledFrom.RegistryName,
-			InstalledAt:  p.InstalledFrom.InstalledAt,
-		}
+	envelope := infoEnvelope{
+		Capabilities: config.CapabilitiesVersion,
+		YnhVersion:   config.Version,
+		Harness:      entry,
 	}
 
-	data, err := json.MarshalIndent(entry, "", "  ")
+	data, err := json.MarshalIndent(envelope, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encoding info: %w", err)
 	}

--- a/cmd/ynh/info_test.go
+++ b/cmd/ynh/info_test.go
@@ -75,16 +75,20 @@ func TestCmdInfoJSONBasic(t *testing.T) {
 		t.Fatalf("cmdInfoTo: %v", err)
 	}
 
-	var got infoEntry
-	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+	var env infoEnvelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
 		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
 	}
+	got := env.Harness
 
+	if env.Capabilities == "" {
+		t.Errorf("envelope missing capabilities; output: %s", stdout.String())
+	}
 	if got.Name != "test-harness" {
 		t.Errorf("name = %q, want test-harness", got.Name)
 	}
-	if got.Version != "2.0.0" {
-		t.Errorf("version = %q, want 2.0.0", got.Version)
+	if got.VersionInstalled != "2.0.0" {
+		t.Errorf("version_installed = %q, want 2.0.0", got.VersionInstalled)
 	}
 	if got.Description != "A test harness" {
 		t.Errorf("description = %q, want 'A test harness'", got.Description)
@@ -154,12 +158,12 @@ func TestCmdInfoJSONFormatBeforeName(t *testing.T) {
 		t.Fatalf("cmdInfoTo: %v", err)
 	}
 
-	var got infoEntry
-	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+	var env infoEnvelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
 		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
 	}
-	if got.Name != "demo" {
-		t.Errorf("name = %q, want demo", got.Name)
+	if env.Harness.Name != "demo" {
+		t.Errorf("name = %q, want demo", env.Harness.Name)
 	}
 }
 
@@ -282,10 +286,11 @@ func TestCmdInfoManifestPreservesAllFields(t *testing.T) {
 		t.Fatalf("cmdInfoTo: %v", err)
 	}
 
-	var got infoEntry
-	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+	var env infoEnvelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
+	got := env.Harness
 
 	// The manifest field should contain all the raw fields
 	var manifest map[string]interface{}

--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -8,29 +8,58 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/harness"
 )
+
+// listEnvelope wraps the array of harnesses with the wire-contract version
+// (capabilities) and the ynh release version. Every structured response from
+// ls and info follows this envelope shape so consumers can gate behaviour
+// without re-parsing the per-command body.
+type listEnvelope struct {
+	Capabilities string      `json:"capabilities"`
+	YnhVersion   string      `json:"ynh_version"`
+	Harnesses    []listEntry `json:"harnesses"`
+}
 
 // listEntry is the JSON shape for a single harness in the `ynh ls` output.
 // Field order drives JSON key order via MarshalIndent.
 type listEntry struct {
-	Name          string             `json:"name"`
-	Version       string             `json:"version"`
-	Description   string             `json:"description,omitempty"`
-	DefaultVendor string             `json:"default_vendor"`
-	Path          string             `json:"path"`
-	InstalledFrom *listInstalledFrom `json:"installed_from,omitempty"`
-	Artifacts     listArtifacts      `json:"artifacts"`
-	Includes      []listInclude      `json:"includes"`
-	DelegatesTo   []listDelegate     `json:"delegates_to"`
+	Name             string             `json:"name"`
+	VersionInstalled string             `json:"version_installed"`
+	VersionAvailable string             `json:"version_available,omitempty"`
+	Description      string             `json:"description,omitempty"`
+	DefaultVendor    string             `json:"default_vendor"`
+	Path             string             `json:"path"`
+	RefInstalled     string             `json:"ref_installed,omitempty"`
+	RefAvailable     string             `json:"ref_available,omitempty"`
+	IsPinned         bool               `json:"is_pinned"`
+	InstalledFrom    *listInstalledFrom `json:"installed_from,omitempty"`
+	Artifacts        listArtifacts      `json:"artifacts"`
+	Includes         []listInclude      `json:"includes"`
+	DelegatesTo      []listDelegate     `json:"delegates_to"`
 }
 
 type listInstalledFrom struct {
+	SourceType   string          `json:"source_type"`
+	Source       string          `json:"source"`
+	Path         string          `json:"path,omitempty"`
+	RegistryName string          `json:"registry_name,omitempty"`
+	InstalledAt  string          `json:"installed_at"`
+	ForkedFrom   *listForkedFrom `json:"forked_from,omitempty"`
+}
+
+// listForkedFrom is the JSON shape of installed_from.forked_from — the
+// upstream a local harness was forked from. Populated by `ynh fork`; absent
+// otherwise.
+type listForkedFrom struct {
 	SourceType   string `json:"source_type"`
 	Source       string `json:"source"`
+	Ref          string `json:"ref,omitempty"`
+	SHA          string `json:"sha,omitempty"`
 	Path         string `json:"path,omitempty"`
 	RegistryName string `json:"registry_name,omitempty"`
-	InstalledAt  string `json:"installed_at"`
+	Version      string `json:"version,omitempty"`
 }
 
 type listArtifacts struct {
@@ -41,16 +70,19 @@ type listArtifacts struct {
 }
 
 type listInclude struct {
-	Git  string   `json:"git"`
-	Ref  string   `json:"ref,omitempty"`
-	Path string   `json:"path,omitempty"`
-	Pick []string `json:"pick,omitempty"`
+	Git          string   `json:"git"`
+	RefInstalled string   `json:"ref_installed,omitempty"`
+	RefAvailable string   `json:"ref_available,omitempty"`
+	IsPinned     bool     `json:"is_pinned"`
+	Path         string   `json:"path,omitempty"`
+	Pick         []string `json:"pick,omitempty"`
 }
 
 type listDelegate struct {
-	Git  string `json:"git"`
-	Ref  string `json:"ref,omitempty"`
-	Path string `json:"path,omitempty"`
+	Git          string `json:"git"`
+	RefInstalled string `json:"ref_installed,omitempty"`
+	IsPinned     bool   `json:"is_pinned"`
+	Path         string `json:"path,omitempty"`
 }
 
 func cmdList(args []string) error {
@@ -61,6 +93,7 @@ func cmdListTo(args []string, stdout, stderr io.Writer) error {
 	structured := detectJSONFormat(args)
 
 	format := "text"
+	checkUpdates := false
 	i := 0
 	for i < len(args) {
 		switch args[i] {
@@ -70,6 +103,8 @@ func cmdListTo(args []string, stdout, stderr io.Writer) error {
 			}
 			i++
 			format = args[i]
+		case "--check-updates":
+			checkUpdates = true
 		default:
 			if strings.HasPrefix(args[i], "-") {
 				return cliError(stderr, structured, errCodeInvalidInput,
@@ -83,9 +118,13 @@ func cmdListTo(args []string, stdout, stderr io.Writer) error {
 
 	switch format {
 	case "text":
+		if checkUpdates {
+			return cliError(stderr, structured, errCodeInvalidInput,
+				"--check-updates requires --format json")
+		}
 		return printListText(stdout)
 	case "json":
-		return printListJSON(stdout)
+		return printListJSON(stdout, checkUpdates)
 	default:
 		return cliError(stderr, structured, errCodeInvalidInput,
 			fmt.Sprintf("invalid --format value %q (want text or json)", format))
@@ -130,7 +169,10 @@ func printListText(w io.Writer) error {
 	return tw.Flush()
 }
 
-func printListJSON(w io.Writer) error {
+func printListJSON(w io.Writer, _ bool) error {
+	// checkUpdates is accepted but not yet wired to network probes — version_available
+	// and ref_available remain omitted (the "unknown" state per the three-state contract).
+	// Network probes land in a follow-up PR.
 	names, err := harness.List()
 	if err != nil {
 		return err
@@ -142,37 +184,66 @@ func printListJSON(w io.Writer) error {
 		if loadErr != nil {
 			continue
 		}
-
-		entry := listEntry{
-			Name:          p.Name,
-			Version:       p.Version,
-			Description:   p.Description,
-			DefaultVendor: p.DefaultVendor,
-			Path:          harness.InstalledDir(name),
-			Artifacts:     scanArtifactCounts(name),
-			Includes:      buildIncludes(p.Includes),
-			DelegatesTo:   buildDelegates(p.DelegatesTo),
-		}
-
-		if p.InstalledFrom != nil {
-			entry.InstalledFrom = &listInstalledFrom{
-				SourceType:   p.InstalledFrom.SourceType,
-				Source:       p.InstalledFrom.Source,
-				Path:         p.InstalledFrom.Path,
-				RegistryName: p.InstalledFrom.RegistryName,
-				InstalledAt:  p.InstalledFrom.InstalledAt,
-			}
-		}
-
-		entries = append(entries, entry)
+		entries = append(entries, buildListEntry(p, name))
 	}
 
-	data, err := json.MarshalIndent(entries, "", "  ")
+	envelope := listEnvelope{
+		Capabilities: config.CapabilitiesVersion,
+		YnhVersion:   config.Version,
+		Harnesses:    entries,
+	}
+
+	data, err := json.MarshalIndent(envelope, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encoding list: %w", err)
 	}
 	_, err = fmt.Fprintln(w, string(data))
 	return err
+}
+
+// buildListEntry assembles the structured-output entry for a loaded harness.
+// Shared by cmdListTo and cmdInfoTo so the per-harness shape stays uniform
+// between the two commands.
+func buildListEntry(p *harness.Harness, name string) listEntry {
+	entry := listEntry{
+		Name:             p.Name,
+		VersionInstalled: p.Version,
+		Description:      p.Description,
+		DefaultVendor:    p.DefaultVendor,
+		Path:             harness.InstalledDir(name),
+		Artifacts:        scanArtifactCounts(name),
+		Includes:         buildIncludes(p.Includes),
+		DelegatesTo:      buildDelegates(p.DelegatesTo),
+	}
+
+	if p.InstalledFrom != nil {
+		entry.RefInstalled = p.InstalledFrom.SHA
+		if entry.RefInstalled == "" {
+			entry.RefInstalled = p.InstalledFrom.Ref
+		}
+		entry.IsPinned = harness.IsPinnedRef(entry.RefInstalled)
+		entry.InstalledFrom = &listInstalledFrom{
+			SourceType:   p.InstalledFrom.SourceType,
+			Source:       p.InstalledFrom.Source,
+			Path:         p.InstalledFrom.Path,
+			RegistryName: p.InstalledFrom.RegistryName,
+			InstalledAt:  p.InstalledFrom.InstalledAt,
+		}
+		if p.InstalledFrom.ForkedFrom != nil {
+			ff := p.InstalledFrom.ForkedFrom
+			entry.InstalledFrom.ForkedFrom = &listForkedFrom{
+				SourceType:   ff.SourceType,
+				Source:       ff.Source,
+				Ref:          ff.Ref,
+				SHA:          ff.SHA,
+				Path:         ff.Path,
+				RegistryName: ff.RegistryName,
+				Version:      ff.Version,
+			}
+		}
+	}
+
+	return entry
 }
 
 func scanArtifactCounts(name string) listArtifacts {
@@ -189,9 +260,10 @@ func buildIncludes(includes []harness.Include) []listInclude {
 	result := make([]listInclude, 0, len(includes))
 	for _, inc := range includes {
 		li := listInclude{
-			Git:  inc.Git,
-			Ref:  inc.Ref,
-			Path: inc.Path,
+			Git:          inc.Git,
+			RefInstalled: inc.Ref,
+			IsPinned:     harness.IsPinnedRef(inc.Ref),
+			Path:         inc.Path,
 		}
 		if len(inc.Pick) > 0 {
 			li.Pick = inc.Pick
@@ -205,9 +277,10 @@ func buildDelegates(delegates []harness.Delegate) []listDelegate {
 	result := make([]listDelegate, 0, len(delegates))
 	for _, del := range delegates {
 		result = append(result, listDelegate{
-			Git:  del.Git,
-			Ref:  del.Ref,
-			Path: del.Path,
+			Git:          del.Git,
+			RefInstalled: del.Ref,
+			IsPinned:     harness.IsPinnedRef(del.Ref),
+			Path:         del.Path,
 		})
 	}
 	return result

--- a/cmd/ynh/list_test.go
+++ b/cmd/ynh/list_test.go
@@ -77,18 +77,21 @@ func TestCmdListJSONEmpty(t *testing.T) {
 		t.Fatalf("cmdListTo: %v", err)
 	}
 
-	var got []listEntry
+	var got listEnvelope
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
 	}
-	if len(got) != 0 {
-		t.Errorf("expected empty array, got %d entries", len(got))
+	if got.Capabilities == "" {
+		t.Errorf("envelope missing capabilities; output: %s", stdout.String())
 	}
-
-	// Must be "[]" not "null"
-	trimmed := strings.TrimSpace(stdout.String())
-	if trimmed != "[]" {
-		t.Errorf("expected literal [], got: %s", trimmed)
+	if got.Harnesses == nil {
+		t.Errorf("envelope harnesses is null, expected []; output: %s", stdout.String())
+	}
+	if len(got.Harnesses) != 0 {
+		t.Errorf("expected empty harnesses, got %d", len(got.Harnesses))
+	}
+	if !strings.Contains(stdout.String(), `"harnesses": []`) {
+		t.Errorf("expected literal \"harnesses\": [], got: %s", stdout.String())
 	}
 }
 
@@ -129,21 +132,21 @@ func TestCmdListJSONPopulated(t *testing.T) {
 		t.Fatalf("cmdListTo: %v", err)
 	}
 
-	var got []listEntry
+	var got listEnvelope
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
 	}
 
-	if len(got) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(got))
+	if len(got.Harnesses) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got.Harnesses))
 	}
 
-	e := got[0]
+	e := got.Harnesses[0]
 	if e.Name != "test-harness" {
 		t.Errorf("name = %q, want test-harness", e.Name)
 	}
-	if e.Version != "1.2.3" {
-		t.Errorf("version = %q, want 1.2.3", e.Version)
+	if e.VersionInstalled != "1.2.3" {
+		t.Errorf("version_installed = %q, want 1.2.3", e.VersionInstalled)
 	}
 	if e.Description != "A test harness" {
 		t.Errorf("description = %q, want 'A test harness'", e.Description)
@@ -321,20 +324,122 @@ func TestCmdListMultipleHarnesses(t *testing.T) {
 		t.Fatalf("cmdListTo: %v", err)
 	}
 
-	var got []listEntry
+	var got listEnvelope
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(got) != 2 {
-		t.Fatalf("expected 2 entries, got %d", len(got))
+	if len(got.Harnesses) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got.Harnesses))
 	}
 
 	// Entries are sorted by name (harness.List reads directory entries)
-	names := []string{got[0].Name, got[1].Name}
+	names := []string{got.Harnesses[0].Name, got.Harnesses[1].Name}
 	if names[0] != "alpha" || names[1] != "beta" {
 		t.Errorf("names = %v, want [alpha beta]", names)
 	}
-	if got[1].DefaultVendor != "codex" {
-		t.Errorf("beta vendor = %q, want codex", got[1].DefaultVendor)
+	if got.Harnesses[1].DefaultVendor != "codex" {
+		t.Errorf("beta vendor = %q, want codex", got.Harnesses[1].DefaultVendor)
+	}
+}
+
+func TestCmdListJSONEnvelopeShape(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, "harnesses"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := cmdListTo([]string{"--format", "json"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdListTo: %v", err)
+	}
+
+	out := stdout.String()
+	for _, key := range []string{`"capabilities"`, `"ynh_version"`, `"harnesses"`} {
+		if !strings.Contains(out, key) {
+			t.Errorf("envelope missing %s; output: %s", key, out)
+		}
+	}
+}
+
+func TestCmdListJSONIsPinnedSemantics(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Include with a SHA-style ref → pinned. Include with a tag-style ref → floating.
+	hj := `{
+		"name": "demo",
+		"version": "1.0.0",
+		"default_vendor": "claude",
+		"includes": [
+			{"git": "github.com/example/a", "ref": "abc1234567890abcdef1234567890abcdef12345"},
+			{"git": "github.com/example/b", "ref": "v1.2.3"},
+			{"git": "github.com/example/c", "ref": "main"}
+		]
+	}`
+	installListTestHarness(t, home, "demo", hj)
+
+	var stdout bytes.Buffer
+	if err := cmdListTo([]string{"--format", "json"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdListTo: %v", err)
+	}
+
+	var env listEnvelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+	}
+	if len(env.Harnesses) != 1 {
+		t.Fatalf("expected 1 harness, got %d", len(env.Harnesses))
+	}
+	incs := env.Harnesses[0].Includes
+	if len(incs) != 3 {
+		t.Fatalf("expected 3 includes, got %d", len(incs))
+	}
+	if !incs[0].IsPinned {
+		t.Errorf("SHA ref %q must be pinned", incs[0].RefInstalled)
+	}
+	if incs[1].IsPinned {
+		t.Errorf("tag ref %q must not be pinned", incs[1].RefInstalled)
+	}
+	if incs[2].IsPinned {
+		t.Errorf("branch ref %q must not be pinned", incs[2].RefInstalled)
+	}
+}
+
+func TestCmdListCheckUpdatesFlagAccepted(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, "harnesses"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Network probes are not yet wired in this PR — the flag must be accepted
+	// but version_available / ref_available must remain omitted (the "unknown"
+	// state of the three-state contract).
+	var stdout bytes.Buffer
+	if err := cmdListTo([]string{"--format", "json", "--check-updates"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdListTo: %v", err)
+	}
+	for _, forbidden := range []string{`"version_available"`, `"ref_available"`} {
+		if strings.Contains(stdout.String(), forbidden) {
+			t.Errorf("output must omit %s until network probes land; got: %s", forbidden, stdout.String())
+		}
+	}
+}
+
+func TestCmdListCheckUpdatesRequiresJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, "harnesses"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := cmdListTo([]string{"--check-updates"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error for --check-updates without --format json")
+	}
+	if !strings.Contains(stderr.String()+err.Error(), "--check-updates") {
+		t.Errorf("expected error to mention --check-updates; stderr: %s; err: %v", stderr.String(), err)
 	}
 }

--- a/docs/cli-structured.md
+++ b/docs/cli-structured.md
@@ -86,8 +86,8 @@ Both `ynh version --format json` and `ynd version --format json` emit:
 
 ```json
 {
-  "version": "0.2.0",
-  "capabilities": "0.2.0"
+  "version": "0.3.0",
+  "capabilities": "0.3.0"
 }
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -79,8 +79,8 @@ Commands that take `--format json` emit machine-readable output conforming to [S
 | Command | Structured fields |
 |---------|-------------------|
 | `ynd compose` | Composed harness: `name`, `version`, `description`, `default_vendor`, `artifacts` (with source), `includes`, `delegates_to`, `hooks`, `mcp_servers`, `profiles`, `focuses`, `counts` |
-| `ynh info <name>` | Single harness object: `name`, `version`, `description`, `default_vendor`, `path`, `installed_from`, `manifest` (raw `.ynh-plugin/plugin.json` body) |
-| `ynh ls` | Array of harness objects: `name`, `version`, `description`, `default_vendor`, `path`, `installed_from`, `artifacts`, `includes`, `delegates_to` |
+| `ynh info <name>` | Envelope (`capabilities`, `ynh_version`, `harness`) wrapping a single harness object — see [Envelope and harness fields](#envelope-and-harness-fields) below |
+| `ynh ls` | Envelope (`capabilities`, `ynh_version`, `harnesses`) wrapping an array of harness objects — same shape as `ynh info`, plus `artifacts`, minus `manifest` |
 | `ynh paths` | `home`, `config`, `harnesses`, `symlinks`, `cache`, `run`, `bin` — all absolute paths resolved for the current `$YNH_HOME` |
 | `ynh search [query]` | Array of result objects: `name`, `description`, `keywords`, `repo`, `path`, `vendors`, `version`, `from` (`type`, `name`) |
 | `ynh vendors` | Array of vendor objects: `name`, `display_name`, `cli`, `config_dir`, `available` (bool) |
@@ -88,3 +88,48 @@ Commands that take `--format json` emit machine-readable output conforming to [S
 | `ynh sources list` | Array of source objects: `name`, `path`, `description`, `harnesses` (discovery count) |
 
 Human-readable tabwriter output remains the default for every command. Structured mode is strictly opt-in.
+
+### Envelope and harness fields
+
+`ynh ls --format json` and `ynh info <name> --format json` share the same envelope shape:
+
+```json
+{
+  "capabilities": "0.3.0",
+  "ynh_version": "0.x.y",
+  "harnesses": [ /* ynh ls — array */ ]
+}
+```
+
+`ynh info` returns `"harness": { … }` (singular) instead of `"harnesses"`, with the same per-harness fields plus `manifest` (the raw `.ynh-plugin/plugin.json` body).
+
+Per-harness fields:
+
+| Field | Description |
+|-------|-------------|
+| `name` | Harness name |
+| `version_installed` | Version recorded in the harness manifest |
+| `version_available` | Latest version known upstream — **omitted** if `--check-updates` was not passed or the upstream check failed (the "unknown" state) |
+| `description` | Optional human description |
+| `default_vendor` | Vendor for `ynh run` without `-v` |
+| `path` | Absolute path to the installed harness directory |
+| `ref_installed` | Currently installed Git ref or SHA — omitted when there is no Git provenance |
+| `ref_available` | Latest Git SHA known upstream — same omission rules as `version_available` |
+| `is_pinned` | `true` iff `ref_installed` matches `^[0-9a-f]{7,40}$` (resolved SHA). Tags and branches are floating |
+| `installed_from` | Provenance object — `source_type`, `source`, `installed_at`, optional `path`, `registry_name`, `forked_from` |
+| `installed_from.forked_from` | Upstream a forked harness was copied from — `source_type`, `source`, `version`, `sha`, optional `ref`, `path`, `registry_name`. Absent on non-fork installs |
+| `artifacts` | (`ynh ls` only) Counts: `skills`, `agents`, `rules`, `commands` |
+| `includes` | Array of include objects: `git`, `ref_installed`, `ref_available`, `is_pinned`, optional `path`, `pick` |
+| `delegates_to` | Array of delegate objects: `git`, `ref_installed`, `is_pinned`, optional `path` |
+| `manifest` | (`ynh info` only) Raw `.ynh-plugin/plugin.json` body, JSON-compacted |
+
+#### `--check-updates` flag
+
+`ynh info` and `ynh ls` accept `--check-updates` together with `--format json`. The flag opts in to upstream lookups for `version_available` and `ref_available`. Without it, those fields are always omitted (the "unknown" three-state).
+
+> Note: `--check-updates` performs network calls. Failures degrade silently — fields are simply omitted, the command does not error. Default `info` and `ls` calls (without the flag) remain offline, fast, and deterministic.
+
+The `is_pinned` rule is the same on harnesses and includes:
+
+- `ref_installed` matches `^[0-9a-f]{7,40}$` ⇒ `"is_pinned": true` (a resolved SHA)
+- Anything else (tag, branch, `main`, `HEAD`, empty) ⇒ `"is_pinned": false`

--- a/docs/tutorial/16-structured-output.md
+++ b/docs/tutorial/16-structured-output.md
@@ -202,32 +202,39 @@ ynh ls --format json
 
 Expected (timestamps and paths will differ):
 ```json
-[
-  {
-    "name": "my-harness",
-    "version": "0.1.0",
-    "description": "Tutorial harness",
-    "default_vendor": "claude",
-    "path": "/Users/<you>/.ynh/harnesses/my-harness",
-    "installed_from": {
-      "source_type": "local",
-      "source": "/tmp/ynh-tutorial/my-harness",
-      "installed_at": "<timestamp>"
-    },
-    "artifacts": {
-      "skills": 1,
-      "agents": 0,
-      "rules": 0,
-      "commands": 0
-    },
-    "includes": [],
-    "delegates_to": []
-  }
-]
+{
+  "capabilities": "0.3.0",
+  "ynh_version": "<version>",
+  "harnesses": [
+    {
+      "name": "my-harness",
+      "version_installed": "0.1.0",
+      "description": "Tutorial harness",
+      "default_vendor": "claude",
+      "path": "/Users/<you>/.ynh/harnesses/my-harness",
+      "is_pinned": false,
+      "installed_from": {
+        "source_type": "local",
+        "source": "/tmp/ynh-tutorial/my-harness",
+        "installed_at": "<timestamp>"
+      },
+      "artifacts": {
+        "skills": 1,
+        "agents": 0,
+        "rules": 0,
+        "commands": 0
+      },
+      "includes": [],
+      "delegates_to": []
+    }
+  ]
+}
 ```
 
 Key points:
-- Output is a JSON **array** — even with one harness.
+- Output is wrapped in an **envelope**: `capabilities` (wire-contract version), `ynh_version` (release), and `harnesses` (the array).
+- `version_installed` is the version recorded in the harness manifest. Pass `--check-updates` to add `version_available` (and `ref_available`) by querying the upstream.
+- `is_pinned` is `true` when the installed Git ref is a resolved SHA (matches `^[0-9a-f]{7,40}$`); `false` for tags, branches, or local-only installs.
 - `path` is the absolute path to the installed harness directory.
 - `artifacts` always includes all four counts (never omitted when zero).
 - `includes` and `delegates_to` are always present, even when empty (`[]`).
@@ -238,7 +245,7 @@ Key points:
 Get just the names:
 
 ```bash
-ynh ls --format json | jq -r '.[].name'
+ynh ls --format json | jq -r '.harnesses[].name'
 ```
 
 Expected:
@@ -249,7 +256,7 @@ my-harness
 Check if a specific harness is installed:
 
 ```bash
-ynh ls --format json | jq -e '.[] | select(.name == "my-harness")' > /dev/null && echo "installed" || echo "not installed"
+ynh ls --format json | jq -e '.harnesses[] | select(.name == "my-harness")' > /dev/null && echo "installed" || echo "not installed"
 ```
 
 Expected:
@@ -259,19 +266,23 @@ installed
 
 ## T16.10: Empty list — JSON
 
-With no harnesses installed, the JSON output is an empty array:
+With no harnesses installed, `harnesses` is an empty array — but the envelope (with `capabilities` and `ynh_version`) is still present:
 
 ```bash
 ynh uninstall my-harness
 ynh ls --format json
 ```
 
-Expected:
+Expected (truncated):
 ```json
-[]
+{
+  "capabilities": "0.3.0",
+  "ynh_version": "<version>",
+  "harnesses": []
+}
 ```
 
-Not `null`, not omitted — a clean empty array. Reinstall for subsequent tutorials:
+`harnesses` is never `null`, never omitted — always at least a clean empty array. Reinstall for subsequent tutorials:
 
 ```bash
 ynh install /tmp/ynh-tutorial/my-harness
@@ -311,7 +322,7 @@ rm -rf /tmp/ynh-tutorial
 
 - `--format json` gives machine-readable JSON on stdout; `--format text` is the default
 - The flag is space-separated only (`--format json`, not `--format=json`)
-- `ynh paths --format json` emits a single object; `ynh ls --format json` emits an array
+- `ynh paths --format json` emits a single object; `ynh ls --format json` emits an envelope object with a `harnesses` array
 - Empty arrays are `[]`, never `null` or omitted
 - Optional fields like `description` are omitted when unset, never serialised as `""`
 - Pipe to `jq` for extraction — names, paths, counts, install status checks

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,7 @@ var Version = "dev"
 //
 // Consumers (e.g. TermQ) read this via `ynh version --format json` and gate
 // features on it with their own `minimumYNHCapabilities` constant.
-const CapabilitiesVersion = "0.2.0"
+const CapabilitiesVersion = "0.3.0"
 
 const (
 	DefaultDirName = ".ynh"

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -53,6 +53,29 @@ type Provenance struct {
 	Namespace    string
 	RegistryName string
 	InstalledAt  string
+	ForkedFrom   *ForkedFrom
+}
+
+// ForkedFrom records the upstream that a local harness was forked from.
+type ForkedFrom struct {
+	SourceType   string
+	Source       string
+	Ref          string
+	SHA          string
+	Path         string
+	RegistryName string
+	Version      string
+}
+
+// pinnedRefRe matches a Git SHA (full or short) — 7 to 40 lowercase hex chars.
+// Used to classify an include's ref as pinned (SHA) vs floating (tag/branch).
+var pinnedRefRe = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+
+// IsPinnedRef reports whether ref looks like a resolved Git SHA.
+// Pinned refs identify a single immutable commit; floating refs (tags,
+// branches, "main", "HEAD") track moving targets. Empty refs are floating.
+func IsPinnedRef(ref string) bool {
+	return ref != "" && pinnedRefRe.MatchString(ref)
 }
 
 type Harness struct {
@@ -298,6 +321,18 @@ func LoadDir(dir string) (*Harness, error) {
 			Namespace:    ins.Namespace,
 			RegistryName: ins.RegistryName,
 			InstalledAt:  ins.InstalledAt,
+		}
+		if ins.ForkedFrom != nil {
+			ff := ins.ForkedFrom
+			p.InstalledFrom.ForkedFrom = &ForkedFrom{
+				SourceType:   ff.SourceType,
+				Source:       ff.Source,
+				Ref:          ff.Ref,
+				SHA:          ff.SHA,
+				Path:         ff.Path,
+				RegistryName: ff.RegistryName,
+				Version:      ff.Version,
+			}
 		}
 		if p.Namespace == "" && ins.Namespace != "" {
 			p.Namespace = ins.Namespace

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -752,3 +752,27 @@ func TestResolveProfile_AppendsIncludes(t *testing.T) {
 		t.Errorf("base harness mutated: includes = %d, want 1", len(h.Includes))
 	}
 }
+
+func TestIsPinnedRef(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want bool
+	}{
+		{"", false},
+		{"main", false},
+		{"HEAD", false},
+		{"v1.2.3", false},
+		{"release-1.0", false},
+		{"abc1234", true}, // 7-char short SHA
+		{"abc1234567890abcdef1234567890abcdef12345", true}, // 40-char full SHA
+		{"abc123", false},  // 6 chars — too short
+		{"ABC1234", false}, // uppercase rejected (git emits lowercase)
+		{"feature/branch", false},
+		{"abc1234x", false}, // non-hex
+	}
+	for _, tc := range cases {
+		if got := IsPinnedRef(tc.ref); got != tc.want {
+			t.Errorf("IsPinnedRef(%q) = %v, want %v", tc.ref, got, tc.want)
+		}
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -187,14 +187,27 @@ const InstalledFile = "installed.json"
 // InstalledJSON records where a harness was installed from.
 // It lives at .ynh-plugin/installed.json, separate from the author-controlled plugin.json.
 type InstalledJSON struct {
+	SourceType   string          `json:"source_type"`
+	Source       string          `json:"source"`
+	Ref          string          `json:"ref,omitempty"`
+	SHA          string          `json:"sha,omitempty"`
+	Path         string          `json:"path,omitempty"`
+	Namespace    string          `json:"namespace,omitempty"`
+	RegistryName string          `json:"registry_name,omitempty"`
+	InstalledAt  string          `json:"installed_at"`
+	ForkedFrom   *ForkedFromJSON `json:"forked_from,omitempty"`
+}
+
+// ForkedFromJSON records the upstream a local harness was forked from.
+// Populated by `ynh fork`; absent on installs that were not forked.
+type ForkedFromJSON struct {
 	SourceType   string `json:"source_type"`
 	Source       string `json:"source"`
 	Ref          string `json:"ref,omitempty"`
 	SHA          string `json:"sha,omitempty"`
 	Path         string `json:"path,omitempty"`
-	Namespace    string `json:"namespace,omitempty"`
 	RegistryName string `json:"registry_name,omitempty"`
-	InstalledAt  string `json:"installed_at"`
+	Version      string `json:"version,omitempty"`
 }
 
 // IsHarnessDir returns true if the directory contains a .harness.json manifest.


### PR DESCRIPTION
## Summary

First of three planned PRs landing the YNH-side CLI surface for the harness-management work coordinated in parallel with TermQ. This PR is the JSON-shape foundation: envelope, renamed and added per-harness/per-include fields, and the `--check-updates` flag plumbing.

Network probes for `--check-updates` are intentionally deferred to a follow-up PR so this one stays small and reviewable. Until then the `*_available` fields stay omitted, which is the contractually-correct "unknown" state of the three-state contract.

## Changes

- Wraps `ynh info --format json` and `ynh ls --format json` in an envelope: `capabilities`, `ynh_version`, `harness` (info) or `harnesses` (ls). Reuses the existing `capabilities` wire-contract version rather than introducing a parallel `schema_version` field.
- Bumps `internal/config.CapabilitiesVersion` `0.2.0` → `0.3.0` to signal the envelope reshape and the `version` → `version_installed` rename.
- Per harness and per include: adds `version_installed` (renamed from `version`), `version_available` (omitted), `ref_installed`, `ref_available` (omitted), `is_pinned`. Pinning rule is precise: `^[0-9a-f]{7,40}$` ⇒ `is_pinned: true`, anything else floating.
- Adds `installed_from.forked_from` to `plugin.InstalledJSON` and threads it through `harness.Provenance` so the `ynh fork` PR can populate it without re-shaping the contract.
- Accepts `--check-updates` on info and ls together with `--format json`. Errors when paired with text format. Today the flag is a no-op for the available fields; network probes land in a follow-up.
- Updates `docs/reference.md` with the full per-harness field reference and three-state rendering rules; updates `docs/cli-structured.md`'s wire-contract example to `0.3.0`; updates `docs/tutorial/16-structured-output.md` to the new envelope shape including jq queries.
- Drive-by: `.claude/rules/branching.md` updated to slash-style branch names — the codified rule disagreed with actual project practice.

## Open follow-ups (deliberately out of scope)

These were flagged during plan review and are tracked for the next PRs in the stack:

- `--check-updates` network probes (registry version lookup, `git ls-remote` for git includes). PR #1b in this stack.
- `ynh fork` command + populating `installed_from.forked_from`. PR #2.
- `ynh delegate add/remove/update`. PR #3, gates the delegate editor.
- `ref_installed` / `ref_available` semantics for non-git local installs (currently omitted via `omitempty`; worth a doc note).
- `--re-fork` flag spec — referenced in some draft docs but unspecified; defer until `ynh fork` lands.

## Testing

- [x] `make check` clean (format, lint, test, build)
- [x] New tests: envelope shape, `is_pinned` semantics for SHA / tag / branch refs, `--check-updates` accepted but `*_available` fields omitted, `--check-updates` rejected without `--format json`, `IsPinnedRef` unit table
- [x] Smoke-tested `ynh ls --format json` and `ynh info --format json` against a fresh local install with mixed SHA/tag/branch includes
- [x] Tutorial 16 (the only tutorial that exercises `--format json` for ls/info) re-run end-to-end against updated shape; tutorials using text-mode ls/info spot-checked unchanged