### PR TITLE
feat(cli): live --check-updates probes for ynh info/ls

### DIFF
--- a/cmd/ynh/check_updates.go
+++ b/cmd/ynh/check_updates.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/eyelock/ynh/internal/config"
+	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/registry"
+	"github.com/eyelock/ynh/internal/resolver"
+)
+
+// updateProbe is the test seam for upstream lookups. Production code routes
+// through resolver.LsRemote and a registry walk; tests swap probeGit and
+// probeRegistry to avoid network I/O.
+type updateProbe struct {
+	git      func(gitURL, ref string) (sha string, ok bool)
+	registry func(name, source, path string) (version, sha string, ok bool)
+}
+
+// defaultProbe wires the production probe functions.
+//
+// git probe: a failed ls-remote returns ok=false so the caller omits the
+// _available field — failures degrade to the "unknown" three-state, never
+// to an error.
+//
+// registry probe: walks all configured registries (hitting network via
+// resolver.EnsureRepo inside registry.FetchAll) and looks for an entry
+// whose Repo+Path match the install. Lookup is best-effort: missing
+// registries, lookup misses, and parse failures all collapse to ok=false.
+func defaultProbe() updateProbe {
+	return updateProbe{
+		git: func(gitURL, ref string) (string, bool) {
+			sha, err := resolver.LsRemote(gitURL, ref)
+			if err != nil || sha == "" {
+				return "", false
+			}
+			return sha, true
+		},
+		registry: func(name, source, path string) (string, string, bool) {
+			cfg, err := config.Load()
+			if err != nil || len(cfg.Registries) == 0 {
+				return "", "", false
+			}
+			regs, err := registry.FetchAll(cfg.Registries)
+			if err != nil {
+				return "", "", false
+			}
+			for _, reg := range regs {
+				for _, entry := range reg.Entries {
+					if !registryEntryMatches(entry, name, source, path) {
+						continue
+					}
+					if entry.Version == "" {
+						return "", "", false
+					}
+					return entry.Version, "", true
+				}
+			}
+			return "", "", false
+		},
+	}
+}
+
+// registryEntryMatches identifies the upstream registry entry for an
+// installed harness. The install records `source` (the upstream URL) and
+// `path` (subdir within the repo); the registry entry's `Repo` and `Path`
+// must match. Name fallback handles older installs without a recorded
+// source.
+func registryEntryMatches(entry registry.Entry, name, source, path string) bool {
+	if source != "" {
+		entrySource := strings.TrimSuffix(entry.Repo, ".git")
+		installSource := strings.TrimSuffix(source, ".git")
+		if entrySource == installSource && entry.Path == path {
+			return true
+		}
+	}
+	return entry.Name == name && source == ""
+}
+
+// fillUpdates populates version_available / ref_available across one or
+// more harness entries by running probes concurrently. Bounded fan-out
+// keeps a 50-include harness from spawning 50 simultaneous ls-remotes.
+//
+// Per-probe failure is silent — the corresponding _available field stays
+// omitted ("unknown" state). The command itself never errors on probe
+// failure; --check-updates is best-effort by contract.
+func fillUpdates(entries []listEntry, probe updateProbe) {
+	const concurrency = 8
+
+	type job struct {
+		harnessIdx int
+		includeIdx int // -1 means harness-level
+	}
+
+	var jobs []job
+	for hi, e := range entries {
+		if shouldProbeHarness(e) {
+			jobs = append(jobs, job{harnessIdx: hi, includeIdx: -1})
+		}
+		for ii, inc := range e.Includes {
+			if inc.Git != "" {
+				jobs = append(jobs, job{harnessIdx: hi, includeIdx: ii})
+			}
+		}
+	}
+
+	if len(jobs) == 0 {
+		return
+	}
+
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	var mu sync.Mutex // guards entries during write-back
+
+	for _, j := range jobs {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(j job) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			if j.includeIdx == -1 {
+				probeHarness(&entries[j.harnessIdx], probe, &mu)
+				return
+			}
+			probeInclude(&entries[j.harnessIdx], j.includeIdx, probe, &mu)
+		}(j)
+	}
+	wg.Wait()
+}
+
+// shouldProbeHarness reports whether the harness has enough provenance to
+// look up upstream. Pure local installs (no installed_from, or only a
+// filesystem source) cannot be probed.
+func shouldProbeHarness(e listEntry) bool {
+	if e.InstalledFrom == nil {
+		return false
+	}
+	switch e.InstalledFrom.SourceType {
+	case "registry", "git":
+		return e.InstalledFrom.Source != ""
+	}
+	return false
+}
+
+func probeHarness(entry *listEntry, probe updateProbe, mu *sync.Mutex) {
+	prov := entry.InstalledFrom
+	switch prov.SourceType {
+	case "registry":
+		version, sha, ok := probe.registry(entry.Name, prov.Source, prov.Path)
+		if !ok {
+			return
+		}
+		mu.Lock()
+		if version != "" {
+			entry.VersionAvailable = version
+		}
+		if sha != "" {
+			entry.RefAvailable = sha
+		}
+		mu.Unlock()
+	case "git":
+		// A git-installed harness was tracked at a specific ref; "available"
+		// is the current SHA of the same ref upstream.
+		ref := entry.RefInstalled
+		if harness.IsPinnedRef(ref) {
+			// Pinned to a SHA — probe HEAD to surface "is there anything
+			// newer on the default branch" rather than re-resolving the SHA.
+			ref = ""
+		}
+		sha, ok := probe.git(prov.Source, ref)
+		if !ok {
+			return
+		}
+		mu.Lock()
+		entry.RefAvailable = sha
+		mu.Unlock()
+	}
+}
+
+func probeInclude(entry *listEntry, idx int, probe updateProbe, mu *sync.Mutex) {
+	inc := entry.Includes[idx]
+	ref := inc.RefInstalled
+	if harness.IsPinnedRef(ref) {
+		ref = ""
+	}
+	sha, ok := probe.git(inc.Git, ref)
+	if !ok {
+		return
+	}
+	mu.Lock()
+	entry.Includes[idx].RefAvailable = sha
+	mu.Unlock()
+}

--- a/cmd/ynh/check_updates_test.go
+++ b/cmd/ynh/check_updates_test.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/resolver"
+)
+
+// fakeProbe stubs both git and registry lookups for fillUpdates tests.
+// gitResults maps "url|ref" → (sha, ok).
+// registryResults maps "name|source|path" → (version, sha, ok).
+type fakeProbe struct {
+	gitResults map[string]struct {
+		sha string
+		ok  bool
+	}
+	registryResults map[string]struct {
+		version, sha string
+		ok           bool
+	}
+	gitCalls, regCalls atomic.Int64
+}
+
+func (f *fakeProbe) probe() updateProbe {
+	return updateProbe{
+		git: func(url, ref string) (string, bool) {
+			f.gitCalls.Add(1)
+			r, ok := f.gitResults[url+"|"+ref]
+			if !ok {
+				return "", false
+			}
+			return r.sha, r.ok
+		},
+		registry: func(name, source, path string) (string, string, bool) {
+			f.regCalls.Add(1)
+			r, ok := f.registryResults[name+"|"+source+"|"+path]
+			if !ok {
+				return "", "", false
+			}
+			return r.version, r.sha, r.ok
+		},
+	}
+}
+
+func TestFillUpdates_GitIncludeFloatingRef(t *testing.T) {
+	entries := []listEntry{{
+		Name: "demo",
+		Includes: []listInclude{
+			{Git: "github.com/example/repo", RefInstalled: "main"},
+		},
+	}}
+
+	fp := &fakeProbe{
+		gitResults: map[string]struct {
+			sha string
+			ok  bool
+		}{
+			"github.com/example/repo|main": {sha: "newsha123", ok: true},
+		},
+	}
+	fillUpdates(entries, fp.probe())
+
+	if entries[0].Includes[0].RefAvailable != "newsha123" {
+		t.Errorf("ref_available = %q, want newsha123", entries[0].Includes[0].RefAvailable)
+	}
+}
+
+func TestFillUpdates_GitIncludePinnedProbesHEAD(t *testing.T) {
+	// Pinned-to-SHA includes probe HEAD (empty ref) instead of re-resolving
+	// the SHA. Otherwise a pinned include can never appear behind upstream.
+	entries := []listEntry{{
+		Name: "demo",
+		Includes: []listInclude{
+			{Git: "github.com/example/repo", RefInstalled: "abc1234567890abcdef1234567890abcdef12345"},
+		},
+	}}
+
+	fp := &fakeProbe{
+		gitResults: map[string]struct {
+			sha string
+			ok  bool
+		}{
+			"github.com/example/repo|": {sha: "headsha", ok: true},
+		},
+	}
+	fillUpdates(entries, fp.probe())
+
+	if entries[0].Includes[0].RefAvailable != "headsha" {
+		t.Errorf("ref_available = %q, want headsha (probed via empty ref)", entries[0].Includes[0].RefAvailable)
+	}
+}
+
+func TestFillUpdates_ProbeFailureStaysOmitted(t *testing.T) {
+	// A failed probe leaves _available unset — the contractually-correct
+	// "unknown" three-state. The command must never error on probe failure.
+	entries := []listEntry{{
+		Name: "demo",
+		Includes: []listInclude{
+			{Git: "github.com/example/repo", RefInstalled: "main"},
+		},
+	}}
+
+	fp := &fakeProbe{
+		gitResults: map[string]struct {
+			sha string
+			ok  bool
+		}{
+			"github.com/example/repo|main": {sha: "", ok: false},
+		},
+	}
+	fillUpdates(entries, fp.probe())
+
+	if entries[0].Includes[0].RefAvailable != "" {
+		t.Errorf("expected ref_available omitted on probe failure, got %q", entries[0].Includes[0].RefAvailable)
+	}
+}
+
+func TestFillUpdates_RegistryHarnessVersion(t *testing.T) {
+	entries := []listEntry{{
+		Name:         "demo",
+		RefInstalled: "v0.1.0",
+		InstalledFrom: &listInstalledFrom{
+			SourceType: "registry",
+			Source:     "github.com/example/registry-harness",
+			Path:       "",
+		},
+	}}
+
+	fp := &fakeProbe{
+		registryResults: map[string]struct {
+			version, sha string
+			ok           bool
+		}{
+			"demo|github.com/example/registry-harness|": {version: "0.2.0", ok: true},
+		},
+	}
+	fillUpdates(entries, fp.probe())
+
+	if entries[0].VersionAvailable != "0.2.0" {
+		t.Errorf("version_available = %q, want 0.2.0", entries[0].VersionAvailable)
+	}
+}
+
+func TestFillUpdates_LocalHarnessNotProbed(t *testing.T) {
+	// Pure local installs (no installed_from) yield no probes — there is no
+	// upstream to query.
+	entries := []listEntry{{Name: "local"}}
+
+	fp := &fakeProbe{}
+	fillUpdates(entries, fp.probe())
+
+	if fp.gitCalls.Load() != 0 || fp.regCalls.Load() != 0 {
+		t.Errorf("expected zero probes for local-only harness, got git=%d reg=%d",
+			fp.gitCalls.Load(), fp.regCalls.Load())
+	}
+}
+
+func TestFillUpdates_GitHarnessProbesSource(t *testing.T) {
+	entries := []listEntry{{
+		Name:         "demo",
+		RefInstalled: "v1.0",
+		InstalledFrom: &listInstalledFrom{
+			SourceType: "git",
+			Source:     "github.com/example/harness-repo",
+		},
+	}}
+
+	fp := &fakeProbe{
+		gitResults: map[string]struct {
+			sha string
+			ok  bool
+		}{
+			"github.com/example/harness-repo|v1.0": {sha: "headsha", ok: true},
+		},
+	}
+	fillUpdates(entries, fp.probe())
+
+	if entries[0].RefAvailable != "headsha" {
+		t.Errorf("harness ref_available = %q, want headsha", entries[0].RefAvailable)
+	}
+}
+
+func TestCmdListCheckUpdatesEndToEnd(t *testing.T) {
+	// Full path through cmdListTo with --check-updates: stub the git ls-remote
+	// shellout so the test is hermetic, then confirm version_available /
+	// ref_available appear in the JSON.
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	hj := `{
+		"name": "demo",
+		"version": "0.1.0",
+		"default_vendor": "claude",
+		"includes": [
+			{"git": "github.com/example/repo", "ref": "main"}
+		]
+	}`
+	dir := filepath.Join(home, "harnesses", "demo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".harness.json"), []byte(hj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stub the network primitive — cmdListTo → defaultProbe() routes
+	// through resolver.LsRemoteFunc. Force failure so the test is hermetic
+	// (no real network call to github.com/example/repo).
+	originalLsRemote := resolver.LsRemoteFunc
+	resolver.LsRemoteFunc = func(string, string) (string, error) {
+		return "", fmt.Errorf("stubbed: probe failure")
+	}
+	t.Cleanup(func() { resolver.LsRemoteFunc = originalLsRemote })
+
+	var stdout bytes.Buffer
+	if err := cmdListTo([]string{"--format", "json", "--check-updates"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdListTo: %v", err)
+	}
+
+	var env listEnvelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+	}
+	if len(env.Harnesses) != 1 {
+		t.Fatalf("expected 1 harness, got %d", len(env.Harnesses))
+	}
+	// Stubbed probe fails ⇒ _available fields stay omitted. The assertion is
+	// that the command emits the envelope cleanly and does not error on
+	// probe failure — the contractually-correct "unknown" three-state.
+	if strings.Contains(stdout.String(), `"version_available"`) {
+		t.Errorf("version_available should be omitted when probe fails; got: %s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), `"ref_available"`) {
+		t.Errorf("ref_available should be omitted when probe fails; got: %s", stdout.String())
+	}
+}
+
+func TestCmdListCheckUpdatesEndToEndSuccess(t *testing.T) {
+	// Same harness, stubbed probe succeeds — confirms the success path
+	// surfaces ref_available on the include.
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	hj := `{
+		"name": "demo",
+		"version": "0.1.0",
+		"default_vendor": "claude",
+		"includes": [
+			{"git": "github.com/example/repo", "ref": "main"}
+		]
+	}`
+	dir := filepath.Join(home, "harnesses", "demo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".harness.json"), []byte(hj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalLsRemote := resolver.LsRemoteFunc
+	resolver.LsRemoteFunc = func(string, string) (string, error) {
+		return "deadbeef0123456789abcdef0123456789abcdef", nil
+	}
+	t.Cleanup(func() { resolver.LsRemoteFunc = originalLsRemote })
+
+	var stdout bytes.Buffer
+	if err := cmdListTo([]string{"--format", "json", "--check-updates"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdListTo: %v", err)
+	}
+
+	var env listEnvelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(env.Harnesses) != 1 || len(env.Harnesses[0].Includes) != 1 {
+		t.Fatalf("unexpected envelope shape: %+v", env)
+	}
+	if got := env.Harnesses[0].Includes[0].RefAvailable; got != "deadbeef0123456789abcdef0123456789abcdef" {
+		t.Errorf("ref_available = %q, want deadbeef…", got)
+	}
+}

--- a/cmd/ynh/info.go
+++ b/cmd/ynh/info.go
@@ -263,10 +263,7 @@ func printInfoText(w io.Writer, name string) error {
 	return nil
 }
 
-func printInfoJSON(stdout, stderr io.Writer, name string, _ bool) error {
-	// checkUpdates is accepted but not yet wired to network probes — version_available
-	// and ref_available remain omitted (the "unknown" state per the three-state contract).
-	// Network probes land in a follow-up PR.
+func printInfoJSON(stdout, stderr io.Writer, name string, checkUpdates bool) error {
 	p, err := harness.Load(name)
 	if err != nil {
 		code := errCodeNotFound
@@ -294,6 +291,11 @@ func printInfoJSON(stdout, stderr io.Writer, name string, _ bool) error {
 	}
 
 	base := buildListEntry(p, name)
+	if checkUpdates {
+		single := []listEntry{base}
+		fillUpdates(single, defaultProbe())
+		base = single[0]
+	}
 	entry := infoEntry{
 		Name:             base.Name,
 		VersionInstalled: base.VersionInstalled,

--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -169,10 +169,7 @@ func printListText(w io.Writer) error {
 	return tw.Flush()
 }
 
-func printListJSON(w io.Writer, _ bool) error {
-	// checkUpdates is accepted but not yet wired to network probes — version_available
-	// and ref_available remain omitted (the "unknown" state per the three-state contract).
-	// Network probes land in a follow-up PR.
+func printListJSON(w io.Writer, checkUpdates bool) error {
 	names, err := harness.List()
 	if err != nil {
 		return err
@@ -185,6 +182,10 @@ func printListJSON(w io.Writer, _ bool) error {
 			continue
 		}
 		entries = append(entries, buildListEntry(p, name))
+	}
+
+	if checkUpdates {
+		fillUpdates(entries, defaultProbe())
 	}
 
 	envelope := listEnvelope{

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -127,7 +127,20 @@ Per-harness fields:
 
 `ynh info` and `ynh ls` accept `--check-updates` together with `--format json`. The flag opts in to upstream lookups for `version_available` and `ref_available`. Without it, those fields are always omitted (the "unknown" three-state).
 
-> Note: `--check-updates` performs network calls. Failures degrade silently — fields are simply omitted, the command does not error. Default `info` and `ls` calls (without the flag) remain offline, fast, and deterministic.
+What gets probed:
+
+- **Includes** (per `git`, with a remote URL): `git ls-remote` against the upstream URL, returning the current SHA on `ref_installed`. **Pinned includes** (`is_pinned: true`) probe `HEAD` instead of re-resolving the pinned SHA — otherwise a pinned include could never appear behind upstream.
+- **Registry-installed harnesses**: configured registries are walked and the matching entry's version becomes `version_available`.
+- **Git-installed harnesses**: same as include probing, against the harness's own `installed_from.source`.
+- **Local-only harnesses** (no `installed_from`, or `source_type: "local"` without a remote): no probe possible — fields stay omitted.
+
+> Note: `--check-updates` performs network calls. Failures degrade silently — fields are simply omitted, the command does not error. Default `info` and `ls` calls (without the flag) remain offline, fast, and deterministic. Probes run concurrently (bounded fan-out) so a multi-include harness does not serialize the network.
+
+Three-state rendering on the consumer side (TermQ and similar):
+
+- Field omitted ⇒ **unknown** (probe failed, not requested, or no upstream)
+- Field present and equal to `*_installed` ⇒ **up-to-date**
+- Field present and different from `*_installed` ⇒ **update available**
 
 The `is_pinned` rule is the same on harnesses and includes:
 

--- a/docs/tutorial/16-structured-output.md
+++ b/docs/tutorial/16-structured-output.md
@@ -288,7 +288,30 @@ Expected (truncated):
 ynh install /tmp/ynh-tutorial/my-harness
 ```
 
-## T16.11: YNH_HOME override
+## T16.11: Check for updates — `--check-updates`
+
+By default `ynh ls` and `ynh info` are **offline** — they read installed manifests and emit local provenance only. To learn whether an installed harness or include is behind upstream, opt in with `--check-updates`:
+
+```bash
+ynh ls --format json --check-updates | jq '.harnesses[0]'
+```
+
+The flag adds two optional fields per harness and per include:
+
+- `version_available` — the latest version known upstream (registry-installed harnesses only)
+- `ref_available` — the latest Git SHA known upstream (anything with a remote)
+
+The fields are **omitted entirely** when:
+
+- `--check-updates` was not passed
+- The probe failed (network down, repo gone, lookup miss)
+- The harness has no upstream (pure local install)
+
+This is the "unknown" arm of a three-state contract — consumers must distinguish *unknown* from *up-to-date* (field present and equal to `*_installed`) from *update available* (field present and different).
+
+> Note: `--check-updates` does network I/O. Probes run concurrently with a bounded fan-out and per-probe failures degrade silently — the command never errors on probe failure. Default calls (without the flag) stay fast and deterministic.
+
+## T16.12: YNH_HOME override
 
 Paths reflect the active `YNH_HOME`, which is useful for testing or multi-environment setups:
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -327,6 +327,39 @@ var gitCmdFunc = func(args ...string) error {
 
 func gitCmd(args ...string) error { return gitCmdFunc(args...) }
 
+// LsRemote queries the upstream SHA for ref on gitURL via `git ls-remote`,
+// without cloning. Empty ref resolves to HEAD. Returns the resolved SHA or
+// an error if the network probe fails or the ref is not present upstream.
+//
+// Replaceable in tests via LsRemoteFunc.
+func LsRemote(gitURL, ref string) (string, error) {
+	return LsRemoteFunc(gitURL, ref)
+}
+
+// LsRemoteFunc is the implementation behind LsRemote, broken out so tests
+// can stub network behaviour without shelling out to git.
+var LsRemoteFunc = func(gitURL, ref string) (string, error) {
+	fullURL := NormalizeGitURL(gitURL)
+	args := []string{"ls-remote", "--exit-code", fullURL}
+	if ref != "" {
+		args = append(args, ref)
+	} else {
+		args = append(args, "HEAD")
+	}
+	cmd := exec.Command(gitBin, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git ls-remote %s: %w", fullURL, err)
+	}
+	// First whitespace-separated token of the first line is the SHA.
+	line := strings.SplitN(strings.TrimSpace(string(out)), "\n", 2)[0]
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return "", fmt.Errorf("git ls-remote %s: no output", fullURL)
+	}
+	return fields[0], nil
+}
+
 // PurgeCacheDirsForURL removes all cache directories associated with the given
 // Git URL (all refs). It derives the org--repo name prefix from the URL and
 // deletes every subdirectory of the cache that starts with that prefix.


### PR DESCRIPTION
## Summary

Second of three planned PRs in the harness-management YNH stack. Wires `--check-updates` (added in #99) to real upstream probes for `version_available` and `ref_available`. With this in, TermQ Track B's `UpdateAvailabilityService` can read live three-state values; without it Track B has been working against perpetually-omitted fields.

Probes are concurrent (bounded fan-out of 8 workers) and best-effort — failures degrade silently, the command never errors on a probe failure, and default `info` / `ls` calls (without the flag) remain offline and deterministic.

## Probe paths

| Harness/include source | Probe |
|---|---|
| Include with `git` URL | `git ls-remote` on `ref_installed`. **Pinned-to-SHA** includes probe `HEAD` instead — otherwise a pinned include could never appear behind upstream |
| Registry-installed harness | Walk configured registries, match entry by repo+path, surface entry version |
| Git-installed harness | Same as include probing, against `installed_from.source` |
| Local-only harness | No probe — fields stay omitted by design |

## Changes

- `internal/resolver`: new exported `LsRemote(url, ref) (sha, err)` primitive (replaceable in tests via `LsRemoteFunc`). Uses `git ls-remote --exit-code` so a missing ref is a clean error rather than empty success.
- `cmd/ynh/check_updates.go`: probe layer with concurrent worker pool, per-source dispatch, and an `updateProbe` test seam.
- `cmd/ynh/list.go` / `cmd/ynh/info.go`: thread `checkUpdates` through the JSON emitters and call `fillUpdates` when set.
- `docs/reference.md`: per-source probe semantics and explicit three-state rendering rules for consumers.
- `docs/tutorial/16-structured-output.md`: new T16.11 demonstrating `--check-updates` and the local-only "unknown" case (existing T16.11 → T16.12).

## Testing

- [x] `make check` clean
- [x] Unit tests covering: floating-ref include probe, pinned include probes HEAD, probe failure stays omitted, registry harness version surfaced, git harness probes source, local-only harness yields zero probes
- [x] Hermetic end-to-end tests stub `resolver.LsRemoteFunc` to confirm both success and failure paths through `cmdListTo --check-updates`
- [x] Live network smoke test: `ynh ls --format json --check-updates` against a real public repo correctly returns the upstream HEAD SHA in `ref_available`
- [x] Tutorial 16 re-run end-to-end with the new T16.11 section

## Open follow-ups

- `ynh fork` + `installed_from.forked_from` population — PR #3 in this stack
- `ynh delegate add/remove/update` — PR #4, gates the delegate editor