### PR TITLE
feat(cli): ynh fork command with forked_from provenance

### DIFF
--- a/cmd/ynh/fork.go
+++ b/cmd/ynh/fork.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/eyelock/ynh/internal/assembler"
+	"github.com/eyelock/ynh/internal/config"
+	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// forkResult is the JSON shape for a successful ynh fork operation.
+type forkResult struct {
+	Capabilities  string             `json:"capabilities"`
+	YnhVersion    string             `json:"ynh_version"`
+	Name          string             `json:"name"`
+	Path          string             `json:"path"`
+	InstalledFrom *listInstalledFrom `json:"installed_from,omitempty"`
+}
+
+func cmdFork(args []string) error {
+	return cmdForkTo(args, os.Stdout, os.Stderr)
+}
+
+func cmdForkTo(args []string, stdout, stderr io.Writer) error {
+	structured := detectJSONFormat(args)
+
+	format := "text"
+	var toPath string
+	var name string
+	i := 0
+	for i < len(args) {
+		switch args[i] {
+		case "--format":
+			if i+1 >= len(args) {
+				return cliError(stderr, structured, errCodeInvalidInput, "--format requires a value")
+			}
+			i++
+			format = args[i]
+		case "--to":
+			if i+1 >= len(args) {
+				return cliError(stderr, structured, errCodeInvalidInput, "--to requires a value")
+			}
+			i++
+			toPath = args[i]
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return cliError(stderr, structured, errCodeInvalidInput,
+					fmt.Sprintf("unknown flag: %s", args[i]))
+			}
+			if name != "" {
+				return cliError(stderr, structured, errCodeInvalidInput,
+					fmt.Sprintf("unexpected argument: %s", args[i]))
+			}
+			name = args[i]
+		}
+		i++
+	}
+
+	if name == "" {
+		return cliError(stderr, structured, errCodeInvalidInput, "usage: ynh fork <harness-name> [--to <path>]")
+	}
+
+	switch format {
+	case "text", "json":
+		// both handled below
+	default:
+		return cliError(stderr, structured, errCodeInvalidInput,
+			fmt.Sprintf("invalid --format value %q (want text or json)", format))
+	}
+
+	// Load source harness
+	p, err := harness.Load(name)
+	if err != nil {
+		code := errCodeNotFound
+		if !strings.Contains(err.Error(), "not found") {
+			code = errCodeIOError
+		}
+		return cliError(stderr, structured, code, err.Error())
+	}
+
+	// Resolve destination directory
+	destDir := toPath
+	if destDir == "" {
+		cwd, cwdErr := os.Getwd()
+		if cwdErr != nil {
+			return cliError(stderr, structured, errCodeIOError,
+				fmt.Sprintf("getting working directory: %v", cwdErr))
+		}
+		destDir = filepath.Join(cwd, name)
+	}
+	absDestDir, absErr := filepath.Abs(destDir)
+	if absErr != nil {
+		return cliError(stderr, structured, errCodeIOError,
+			fmt.Sprintf("resolving destination path: %v", absErr))
+	}
+
+	// Refuse to overwrite an existing directory
+	if _, statErr := os.Stat(absDestDir); statErr == nil {
+		return cliError(stderr, structured, errCodeInvalidInput,
+			fmt.Sprintf("destination already exists: %s", absDestDir))
+	}
+
+	installDir := harness.InstalledDir(name)
+
+	// Copy harness files to destination
+	if mkErr := os.MkdirAll(absDestDir, 0o755); mkErr != nil {
+		return cliError(stderr, structured, errCodeIOError,
+			fmt.Sprintf("creating destination directory: %v", mkErr))
+	}
+	if copyErr := assembler.CopyDir(installDir, absDestDir); copyErr != nil {
+		_ = os.RemoveAll(absDestDir)
+		return cliError(stderr, structured, errCodeIOError,
+			fmt.Sprintf("copying harness: %v", copyErr))
+	}
+
+	// Build forked_from from source provenance
+	ff := buildForkedFrom(p)
+
+	// Write installed.json marking this as a local fork
+	ins := &plugin.InstalledJSON{
+		SourceType:  "local",
+		Source:      absDestDir,
+		InstalledAt: time.Now().UTC().Format(time.RFC3339),
+		ForkedFrom:  ff,
+	}
+	if saveErr := plugin.SaveInstalledJSON(absDestDir, ins); saveErr != nil {
+		_ = os.RemoveAll(absDestDir)
+		return cliError(stderr, structured, errCodeIOError,
+			fmt.Sprintf("saving provenance: %v", saveErr))
+	}
+
+	if format == "json" {
+		result := forkResult{
+			Capabilities: config.CapabilitiesVersion,
+			YnhVersion:   config.Version,
+			Name:         p.Name,
+			Path:         absDestDir,
+			InstalledFrom: &listInstalledFrom{
+				SourceType:  "local",
+				Source:      absDestDir,
+				InstalledAt: ins.InstalledAt,
+				ForkedFrom:  buildListForkedFrom(ff),
+			},
+		}
+		data, jsonErr := json.MarshalIndent(result, "", "  ")
+		if jsonErr != nil {
+			return fmt.Errorf("encoding fork result: %w", jsonErr)
+		}
+		_, err = fmt.Fprintln(stdout, string(data))
+		return err
+	}
+
+	// Text output
+	_, _ = fmt.Fprintf(stdout, "Forked harness %q to %s\n", p.Name, absDestDir)
+	if p.InstalledFrom != nil {
+		_, _ = fmt.Fprintf(stdout, "  Source:  %s (%s)\n", p.InstalledFrom.Source, p.InstalledFrom.SourceType)
+	}
+	if p.Version != "" {
+		_, _ = fmt.Fprintf(stdout, "  Version: %s\n", p.Version)
+	}
+	return nil
+}
+
+// buildForkedFrom derives the ForkedFromJSON record from a loaded source harness.
+func buildForkedFrom(p *harness.Harness) *plugin.ForkedFromJSON {
+	if p.InstalledFrom == nil {
+		return &plugin.ForkedFromJSON{
+			SourceType: "local",
+			Source:     harness.InstalledDir(p.Name),
+			Version:    p.Version,
+		}
+	}
+	return &plugin.ForkedFromJSON{
+		SourceType:   p.InstalledFrom.SourceType,
+		Source:       p.InstalledFrom.Source,
+		Ref:          p.InstalledFrom.Ref,
+		SHA:          p.InstalledFrom.SHA,
+		Path:         p.InstalledFrom.Path,
+		RegistryName: p.InstalledFrom.RegistryName,
+		Version:      p.Version,
+	}
+}
+
+// buildListForkedFrom converts a plugin.ForkedFromJSON to its list.go wire shape.
+func buildListForkedFrom(ff *plugin.ForkedFromJSON) *listForkedFrom {
+	if ff == nil {
+		return nil
+	}
+	return &listForkedFrom{
+		SourceType:   ff.SourceType,
+		Source:       ff.Source,
+		Ref:          ff.Ref,
+		SHA:          ff.SHA,
+		Path:         ff.Path,
+		RegistryName: ff.RegistryName,
+		Version:      ff.Version,
+	}
+}

--- a/cmd/ynh/fork_test.go
+++ b/cmd/ynh/fork_test.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// installForkTestHarness writes a minimal harness into YNH_HOME/harnesses/<name>.
+// Returns the installed directory path.
+func installForkTestHarness(t *testing.T, home, name string, ins *plugin.InstalledJSON) string {
+	t.Helper()
+	dir := filepath.Join(home, "harnesses", name)
+	if err := os.MkdirAll(filepath.Join(dir, plugin.PluginDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hj := `{"name":"` + name + `","version":"0.1.0","default_vendor":"claude"}`
+	if err := os.WriteFile(filepath.Join(dir, plugin.PluginDir, plugin.PluginFile), []byte(hj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if ins != nil {
+		if err := plugin.SaveInstalledJSON(dir, ins); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestCmdFork_BasicText(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installForkTestHarness(t, home, "demo", &plugin.InstalledJSON{
+		SourceType:  "git",
+		Source:      "github.com/example/demo",
+		Ref:         "main",
+		SHA:         "abc123",
+		InstalledAt: "2026-01-01T00:00:00Z",
+	})
+
+	dest := filepath.Join(t.TempDir(), "my-demo")
+	var stdout bytes.Buffer
+	if err := cmdForkTo([]string{"demo", "--to", dest}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdForkTo: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Forked harness") {
+		t.Errorf("expected 'Forked harness' in output, got: %s", out)
+	}
+	if !strings.Contains(out, dest) {
+		t.Errorf("expected dest path in output, got: %s", out)
+	}
+
+	// Destination must exist with plugin.json
+	if _, err := os.Stat(filepath.Join(dest, plugin.PluginDir, plugin.PluginFile)); err != nil {
+		t.Errorf("plugin.json not found in dest: %v", err)
+	}
+}
+
+func TestCmdFork_DefaultDestination(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installForkTestHarness(t, home, "demo", nil)
+
+	// Override cwd to a temp dir so the default --to lands predictably
+	cwd := t.TempDir()
+	if err := os.Chdir(cwd); err != nil {
+		t.Skip("cannot chdir in test environment")
+	}
+	t.Cleanup(func() { _ = os.Chdir("/") })
+
+	var stdout bytes.Buffer
+	if err := cmdForkTo([]string{"demo"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdForkTo: %v", err)
+	}
+
+	expected := filepath.Join(cwd, "demo")
+	if _, err := os.Stat(filepath.Join(expected, plugin.PluginDir, plugin.PluginFile)); err != nil {
+		t.Errorf("plugin.json not at expected default dest %s: %v", expected, err)
+	}
+}
+
+func TestCmdFork_DestAlreadyExists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installForkTestHarness(t, home, "demo", nil)
+
+	dest := t.TempDir() // already exists
+	err := cmdForkTo([]string{"demo", "--to", dest}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected error for existing destination, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected 'already exists' in error, got: %v", err)
+	}
+}
+
+func TestCmdFork_NotFound(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	dest := filepath.Join(t.TempDir(), "nowhere")
+	err := cmdForkTo([]string{"nonexistent", "--to", dest}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected error for non-existent harness")
+	}
+}
+
+func TestCmdFork_ForkedFromPopulated(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installForkTestHarness(t, home, "demo", &plugin.InstalledJSON{
+		SourceType:   "registry",
+		Source:       "github.com/org/demo",
+		Ref:          "v0.1.0",
+		SHA:          "deadbeef",
+		RegistryName: "org-registry",
+		InstalledAt:  "2026-01-01T00:00:00Z",
+	})
+
+	dest := filepath.Join(t.TempDir(), "my-demo")
+	if err := cmdForkTo([]string{"demo", "--to", dest}, io.Discard, io.Discard); err != nil {
+		t.Fatalf("cmdForkTo: %v", err)
+	}
+
+	ins, err := plugin.LoadInstalledJSON(dest)
+	if err != nil {
+		t.Fatalf("LoadInstalledJSON: %v", err)
+	}
+	if ins.SourceType != "local" {
+		t.Errorf("source_type = %q, want local", ins.SourceType)
+	}
+	if ins.ForkedFrom == nil {
+		t.Fatal("forked_from is nil")
+	}
+	if ins.ForkedFrom.SourceType != "registry" {
+		t.Errorf("forked_from.source_type = %q, want registry", ins.ForkedFrom.SourceType)
+	}
+	if ins.ForkedFrom.Source != "github.com/org/demo" {
+		t.Errorf("forked_from.source = %q, want github.com/org/demo", ins.ForkedFrom.Source)
+	}
+	if ins.ForkedFrom.SHA != "deadbeef" {
+		t.Errorf("forked_from.sha = %q, want deadbeef", ins.ForkedFrom.SHA)
+	}
+	if ins.ForkedFrom.RegistryName != "org-registry" {
+		t.Errorf("forked_from.registry_name = %q, want org-registry", ins.ForkedFrom.RegistryName)
+	}
+}
+
+func TestCmdFork_ForkedFromLocalFallback(t *testing.T) {
+	// Harness with no installed.json — forked_from.source_type should be "local"
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installForkTestHarness(t, home, "demo", nil) // no provenance
+
+	dest := filepath.Join(t.TempDir(), "my-demo")
+	if err := cmdForkTo([]string{"demo", "--to", dest}, io.Discard, io.Discard); err != nil {
+		t.Fatalf("cmdForkTo: %v", err)
+	}
+
+	ins, err := plugin.LoadInstalledJSON(dest)
+	if err != nil {
+		t.Fatalf("LoadInstalledJSON: %v", err)
+	}
+	if ins.ForkedFrom == nil {
+		t.Fatal("forked_from is nil")
+	}
+	if ins.ForkedFrom.SourceType != "local" {
+		t.Errorf("forked_from.source_type = %q, want local", ins.ForkedFrom.SourceType)
+	}
+}
+
+func TestCmdFork_JSONOutput(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installForkTestHarness(t, home, "demo", &plugin.InstalledJSON{
+		SourceType:  "git",
+		Source:      "github.com/example/demo",
+		InstalledAt: "2026-01-01T00:00:00Z",
+	})
+
+	dest := filepath.Join(t.TempDir(), "my-demo")
+	var stdout bytes.Buffer
+	if err := cmdForkTo([]string{"demo", "--to", dest, "--format", "json"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdForkTo: %v", err)
+	}
+
+	var result forkResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+	}
+	if result.Name != "demo" {
+		t.Errorf("name = %q, want demo", result.Name)
+	}
+	if result.Path != dest {
+		t.Errorf("path = %q, want %s", result.Path, dest)
+	}
+	if result.Capabilities == "" {
+		t.Errorf("capabilities missing")
+	}
+	if result.InstalledFrom == nil {
+		t.Fatal("installed_from is nil")
+	}
+	if result.InstalledFrom.SourceType != "local" {
+		t.Errorf("installed_from.source_type = %q, want local", result.InstalledFrom.SourceType)
+	}
+	if result.InstalledFrom.ForkedFrom == nil {
+		t.Errorf("installed_from.forked_from is nil")
+	}
+}
+
+func TestCmdFork_UnknownFlag(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	err := cmdForkTo([]string{"demo", "--nope"}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected error for unknown flag")
+	}
+	if !strings.Contains(err.Error(), "--nope") {
+		t.Errorf("expected flag name in error, got: %v", err)
+	}
+}
+
+func TestCmdFork_MissingToValue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	err := cmdForkTo([]string{"demo", "--to"}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected error for missing --to value")
+	}
+}
+
+func TestCmdUpdate_ForkBlocked(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installForkTestHarness(t, home, "forked-demo", &plugin.InstalledJSON{
+		SourceType:  "local",
+		Source:      "/some/local/path",
+		InstalledAt: "2026-01-01T00:00:00Z",
+		ForkedFrom: &plugin.ForkedFromJSON{
+			SourceType: "git",
+			Source:     "github.com/example/demo",
+		},
+	})
+
+	err := cmdUpdate([]string{"forked-demo"})
+	if err == nil {
+		t.Fatal("expected error for ynh update on a fork")
+	}
+	if !strings.Contains(err.Error(), "fork") {
+		t.Errorf("expected 'fork' in error message, got: %v", err)
+	}
+}
+
+func TestCmdInstall_PreservesForkedFrom(t *testing.T) {
+	// When installing a local dir that has a forked_from in its installed.json,
+	// the installed harness should carry the forked_from forward.
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Create a local harness directory that looks like it was forked
+	srcDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(srcDir, plugin.PluginDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hj := `{"name":"myfork","version":"0.1.0","default_vendor":"claude"}`
+	if err := os.WriteFile(filepath.Join(srcDir, plugin.PluginDir, plugin.PluginFile), []byte(hj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcIns := &plugin.InstalledJSON{
+		SourceType:  "local",
+		Source:      srcDir,
+		InstalledAt: "2026-01-01T00:00:00Z",
+		ForkedFrom: &plugin.ForkedFromJSON{
+			SourceType: "git",
+			Source:     "github.com/example/upstream",
+			Version:    "0.1.0",
+		},
+	}
+	if err := plugin.SaveInstalledJSON(srcDir, srcIns); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdInstall([]string{srcDir}); err != nil {
+		t.Fatalf("cmdInstall: %v", err)
+	}
+
+	installDir := filepath.Join(home, "harnesses", "myfork")
+	ins, err := plugin.LoadInstalledJSON(installDir)
+	if err != nil {
+		t.Fatalf("LoadInstalledJSON after install: %v", err)
+	}
+	if ins.ForkedFrom == nil {
+		t.Fatal("forked_from not preserved after ynh install")
+	}
+	if ins.ForkedFrom.Source != "github.com/example/upstream" {
+		t.Errorf("forked_from.source = %q, want github.com/example/upstream", ins.ForkedFrom.Source)
+	}
+}

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -58,6 +58,8 @@ func main() {
 		err = cmdSearch(os.Args[2:])
 	case "registry":
 		err = cmdRegistry(os.Args[2:])
+	case "fork":
+		err = cmdFork(os.Args[2:])
 	case "include":
 		err = cmdInclude(os.Args[2:])
 	case "image":
@@ -105,6 +107,7 @@ Commands:
   sources add <path>           Add a local harness source directory
   sources list                 Show configured sources (supports --format json)
   sources remove <name>        Remove a source
+  fork <name> [--to <path>]    Fork an installed harness to a local directory
   include add <harness> <url>  Add a Git include to a harness
   include remove <harness> <url>  Remove a Git include from a harness
   include update <harness> <url>  Update a Git include's options
@@ -301,6 +304,13 @@ func cmdInstall(args []string) error {
 	} else if resolved.localPath != "" {
 		provSource = resolved.localPath
 	}
+
+	// Carry forward forked_from when installing from a previously forked local directory.
+	var forkedFrom *plugin.ForkedFromJSON
+	if srcIns, loadErr := plugin.LoadInstalledJSON(srcDir); loadErr == nil && srcIns.ForkedFrom != nil {
+		forkedFrom = srcIns.ForkedFrom
+	}
+
 	ins := &plugin.InstalledJSON{
 		SourceType:   resolved.sourceType,
 		Source:       provSource,
@@ -308,6 +318,7 @@ func cmdInstall(args []string) error {
 		Namespace:    resolved.namespace,
 		RegistryName: resolved.registryName,
 		InstalledAt:  time.Now().UTC().Format(time.RFC3339),
+		ForkedFrom:   forkedFrom,
 	}
 	if err := plugin.SaveInstalledJSON(installDir, ins); err != nil {
 		return fmt.Errorf("saving provenance: %w", err)
@@ -423,6 +434,12 @@ func cmdUpdate(args []string) error {
 	p, err := harness.Load(name)
 	if err != nil {
 		return err
+	}
+
+	if p.InstalledFrom != nil && p.InstalledFrom.ForkedFrom != nil {
+		return fmt.Errorf("harness %q is a fork — ynh update cannot pull upstream changes for a fork\n"+
+			"  To update includes within the fork, edit .ynh-plugin/plugin.json directly\n"+
+			"  To incorporate upstream changes, fork again from the re-installed original", name)
 	}
 
 	if len(p.Includes) == 0 && len(p.DelegatesTo) == 0 {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -35,6 +35,7 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | `ynh run [harness]` | `-v`, `--profile`, `--install`, `--clean` |
 | `ynh uninstall <harness>` | |
 | `ynh update [harness]` | |
+| `ynh fork <name>` | `--to <path>`, `--format <text\|json>` |
 | `ynh ls` | `--format <text\|json>` |
 | `ynh info <harness>` | `--format <text\|json>` |
 | `ynh vendors` | `--format <text\|json>` |
@@ -79,6 +80,7 @@ Commands that take `--format json` emit machine-readable output conforming to [S
 | Command | Structured fields |
 |---------|-------------------|
 | `ynd compose` | Composed harness: `name`, `version`, `description`, `default_vendor`, `artifacts` (with source), `includes`, `delegates_to`, `hooks`, `mcp_servers`, `profiles`, `focuses`, `counts` |
+| `ynh fork <name>` | Envelope (`capabilities`, `ynh_version`, `name`, `path`, `installed_from`) — see [ynh fork output](#ynh-fork-output) below |
 | `ynh info <name>` | Envelope (`capabilities`, `ynh_version`, `harness`) wrapping a single harness object — see [Envelope and harness fields](#envelope-and-harness-fields) below |
 | `ynh ls` | Envelope (`capabilities`, `ynh_version`, `harnesses`) wrapping an array of harness objects — same shape as `ynh info`, plus `artifacts`, minus `manifest` |
 | `ynh paths` | `home`, `config`, `harnesses`, `symlinks`, `cache`, `run`, `bin` — all absolute paths resolved for the current `$YNH_HOME` |
@@ -146,3 +148,33 @@ The `is_pinned` rule is the same on harnesses and includes:
 
 - `ref_installed` matches `^[0-9a-f]{7,40}$` ⇒ `"is_pinned": true` (a resolved SHA)
 - Anything else (tag, branch, `main`, `HEAD`, empty) ⇒ `"is_pinned": false`
+
+### ynh fork output
+
+`ynh fork <name> --format json` returns a single result object (not an array):
+
+```json
+{
+  "capabilities": "0.3.0",
+  "ynh_version": "0.x.y",
+  "name": "demo",
+  "path": "/absolute/path/to/fork",
+  "installed_from": {
+    "source_type": "local",
+    "source": "/absolute/path/to/fork",
+    "installed_at": "<timestamp>",
+    "forked_from": {
+      "source_type": "git",
+      "source": "github.com/org/demo",
+      "sha": "abc123",
+      "version": "0.1.0"
+    }
+  }
+}
+```
+
+`forked_from` captures the upstream provenance of the harness at the time of the fork. If the source harness had no upstream (a bare local install), `forked_from.source_type` is `"local"` and `forked_from.source` is the installed directory path.
+
+`ynh update` refuses to run on a fork and prints an explanatory error. To incorporate upstream changes, re-install the original and fork again.
+
+`ynh install <fork-path>` preserves `forked_from` when installing a forked harness into `~/.ynh/harnesses/`, so `ynh ls` surfaces the upstream provenance.


### PR DESCRIPTION
## Summary
- Adds `ynh fork <name> [--to <path>] [--format json]` — copies an installed harness to a local directory and writes `installed.json` with `forked_from` pointing at the upstream
- `ynh install <fork-path>` preserves `forked_from` so it survives round-trips through the install flow and surfaces in `ynh ls`
- `ynh update` blocks on forks with an explanatory error hint

## Changes
- `cmd/ynh/fork.go` — new command (`cmdFork`, `cmdForkTo`, `buildForkedFrom`, `buildListForkedFrom`, `forkResult`)
- `cmd/ynh/fork_test.go` — 10 tests covering text/JSON output, default dest, dest-exists guard, not-found, forked_from population (git/registry/local fallback), update-blocked, install-preserves
- `cmd/ynh/main.go` — wired `fork` into switch/usage; added update guard for forks; added `forked_from` carry-forward in `cmdInstall`
- `docs/reference.md` — added `ynh fork` to command table, structured output table, and a new `ynh fork output` section

## Testing
- [x] `make check` passes
- [x] 10 new tests all passing
- [x] `forked_from` preserved through install round-trip (test + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)