### PR TITLE
fix: registry harnesses report wrong path in ls/info; uninstall fails by name

### DIFF
--- a/cmd/ynh/image.go
+++ b/cmd/ynh/image.go
@@ -194,7 +194,7 @@ func cmdImageTo(args []string, stdout, stderr io.Writer) error {
 		if err != nil {
 			return err
 		}
-		harnessSrcDir = harness.InstalledDir(ia.name)
+		harnessSrcDir = p.Dir
 	}
 
 	// Create temp build context

--- a/cmd/ynh/info.go
+++ b/cmd/ynh/info.go
@@ -73,7 +73,7 @@ func cmdInfoTo(args []string, stdout, stderr io.Writer) error {
 }
 
 func printInfoText(w io.Writer, name string) error {
-	p, err := harness.Load(name)
+	p, err := harness.LoadQualified(name)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func printInfoText(w io.Writer, name string) error {
 	}
 
 	// Local artifacts
-	arts, _ := harness.ScanArtifacts(name)
+	arts, _ := harness.ScanArtifactsDir(p.Dir)
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, "Artifacts:")
 	if arts.Total() == 0 {
@@ -241,7 +241,7 @@ func printInfoText(w io.Writer, name string) error {
 }
 
 func printInfoJSON(stdout, stderr io.Writer, name string) error {
-	p, err := harness.Load(name)
+	p, err := harness.LoadQualified(name)
 	if err != nil {
 		code := errCodeNotFound
 		if !strings.Contains(err.Error(), "not found") {
@@ -252,8 +252,7 @@ func printInfoJSON(stdout, stderr io.Writer, name string) error {
 
 	// Migration chain has run (harness.Load was called above), so the manifest
 	// is always at the new path.
-	installDir := harness.InstalledDir(name)
-	manifestPath := filepath.Join(installDir, plugin.PluginDir, plugin.PluginFile)
+	manifestPath := filepath.Join(p.Dir, plugin.PluginDir, plugin.PluginFile)
 	raw, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return cliError(stderr, true, errCodeIOError,
@@ -272,7 +271,7 @@ func printInfoJSON(stdout, stderr io.Writer, name string) error {
 		Version:       p.Version,
 		Description:   p.Description,
 		DefaultVendor: p.DefaultVendor,
-		Path:          harness.InstalledDir(name),
+		Path:          p.Dir,
 		Manifest:      compacted,
 	}
 

--- a/cmd/ynh/info_test.go
+++ b/cmd/ynh/info_test.go
@@ -492,6 +492,32 @@ func TestCmdInfoTextNoProvenance(t *testing.T) {
 	}
 }
 
+func TestCmdInfoJSONNamespacedPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	installListTestHarnessNS(t, home, "eyelock/assistants", "planner",
+		`{"name":"planner","version":"1.0.0","default_vendor":"claude"}`)
+
+	var stdout bytes.Buffer
+	if err := cmdInfoTo([]string{"planner", "--format", "json"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdInfoTo: %v", err)
+	}
+
+	var got infoEntry
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+	}
+
+	wantPath := filepath.Join(home, "harnesses", "eyelock--assistants", "planner")
+	if got.Path != wantPath {
+		t.Errorf("path = %q, want %q", got.Path, wantPath)
+	}
+	if got.Manifest == nil {
+		t.Fatal("manifest is nil")
+	}
+}
+
 func TestCmdInfoTextNoVendor(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("YNH_HOME", home)

--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -131,14 +131,14 @@ func printListText(w io.Writer) error {
 }
 
 func printListJSON(w io.Writer) error {
-	names, err := harness.List()
+	all, err := harness.ListAll()
 	if err != nil {
 		return err
 	}
 
-	entries := make([]listEntry, 0, len(names))
-	for _, name := range names {
-		p, loadErr := harness.Load(name)
+	entries := make([]listEntry, 0, len(all))
+	for _, e := range all {
+		p, loadErr := harness.LoadDir(e.Dir)
 		if loadErr != nil {
 			continue
 		}
@@ -148,8 +148,8 @@ func printListJSON(w io.Writer) error {
 			Version:       p.Version,
 			Description:   p.Description,
 			DefaultVendor: p.DefaultVendor,
-			Path:          harness.InstalledDir(name),
-			Artifacts:     scanArtifactCounts(name),
+			Path:          p.Dir,
+			Artifacts:     scanArtifactCounts(p.Dir),
 			Includes:      buildIncludes(p.Includes),
 			DelegatesTo:   buildDelegates(p.DelegatesTo),
 		}
@@ -175,8 +175,8 @@ func printListJSON(w io.Writer) error {
 	return err
 }
 
-func scanArtifactCounts(name string) listArtifacts {
-	arts, _ := harness.ScanArtifacts(name)
+func scanArtifactCounts(dir string) listArtifacts {
+	arts, _ := harness.ScanArtifactsDir(dir)
 	return listArtifacts{
 		Skills:   len(arts.Skills),
 		Agents:   len(arts.Agents),

--- a/cmd/ynh/list_test.go
+++ b/cmd/ynh/list_test.go
@@ -309,6 +309,46 @@ func TestCmdListMissingFormatValue(t *testing.T) {
 	}
 }
 
+// installListTestHarnessNS creates a harness under a namespace subdirectory,
+// mirroring what `ynh install` does for registry harnesses.
+func installListTestHarnessNS(t *testing.T, home, ns, name, harnessJSON string) {
+	t.Helper()
+	fsNS := strings.ReplaceAll(ns, "/", "--")
+	dir := filepath.Join(home, "harnesses", fsNS, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".harness.json"), []byte(harnessJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCmdListJSONNamespacedPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	installListTestHarnessNS(t, home, "eyelock/assistants", "planner",
+		`{"name":"planner","version":"1.0.0","default_vendor":"claude"}`)
+
+	var stdout bytes.Buffer
+	if err := cmdListTo([]string{"--format", "json"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdListTo: %v", err)
+	}
+
+	var got []listEntry
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+
+	wantPath := filepath.Join(home, "harnesses", "eyelock--assistants", "planner")
+	if got[0].Path != wantPath {
+		t.Errorf("path = %q, want %q", got[0].Path, wantPath)
+	}
+}
+
 func TestCmdListMultipleHarnesses(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("YNH_HOME", home)

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -374,13 +374,16 @@ func cmdUninstall(args []string) error {
 		return fmt.Errorf("usage: ynh uninstall <harness-name>")
 	}
 
-	name := args[0]
+	ref := args[0]
 
-	// Verify harness exists (either format)
-	installDir := harness.InstalledDir(name)
-	if harness.DetectFormat(installDir) == "" {
-		return fmt.Errorf("harness %q is not installed", name)
+	// Load to resolve the actual on-disk directory (may be namespaced).
+	// Accepts plain "name" or qualified "name@org/repo".
+	p, err := harness.LoadQualified(ref)
+	if err != nil {
+		return fmt.Errorf("harness %q is not installed", ref)
 	}
+	installDir := p.Dir
+	bareName := p.Name // bare name for launcher/run/sources cleanup
 
 	// Remove harness directory
 	if err := os.RemoveAll(installDir); err != nil {
@@ -388,18 +391,18 @@ func cmdUninstall(args []string) error {
 	}
 
 	// Remove launcher script
-	launcherPath := filepath.Join(config.BinDir(), name)
+	launcherPath := filepath.Join(config.BinDir(), bareName)
 	_ = os.Remove(launcherPath) // ignore error if launcher doesn't exist
 
 	// Remove run directory
-	runDir := filepath.Join(config.RunDir(), name)
+	runDir := filepath.Join(config.RunDir(), bareName)
 	_ = os.RemoveAll(runDir) // ignore error if not present
 
 	// Remove matching sources entry if present
 	if cfg, err := config.Load(); err == nil {
 		remaining := make([]config.Source, 0, len(cfg.Sources))
 		for _, s := range cfg.Sources {
-			if s.Name != name {
+			if s.Name != bareName {
 				remaining = append(remaining, s)
 			}
 		}
@@ -409,7 +412,7 @@ func cmdUninstall(args []string) error {
 		}
 	}
 
-	fmt.Printf("Uninstalled harness %q\n", name)
+	fmt.Printf("Uninstalled harness %q\n", bareName)
 	return nil
 }
 
@@ -522,7 +525,7 @@ func cmdRun(args []string) error {
 		if err != nil {
 			return err
 		}
-		harnessDir = harness.InstalledDir(name)
+		harnessDir = p.Dir
 
 	case ra.HarnessFile != "":
 		p, err = harness.LoadFile(ra.HarnessFile)
@@ -1137,7 +1140,7 @@ func cmdPrune() error {
 			if name == "ynh" || name == "ynd" {
 				continue
 			}
-			if harness.DetectFormat(harness.InstalledDir(name)) == "plugin" {
+			if _, err := harness.Load(name); err == nil {
 				continue
 			}
 			launcherPath := filepath.Join(binDir, name)
@@ -1161,7 +1164,7 @@ func cmdPrune() error {
 	if err == nil {
 		for _, entry := range runEntries {
 			name := entry.Name()
-			if harness.DetectFormat(harness.InstalledDir(name)) == "plugin" {
+			if _, err := harness.Load(name); err == nil {
 				continue
 			}
 			staleRun := filepath.Join(runDir, name)

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -398,6 +398,34 @@ func TestCmdUninstall_RemovesEverything(t *testing.T) {
 	}
 }
 
+func TestCmdUninstall_NamespacedHarness(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("YNH_HOME", "")
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install harness at namespaced path (eyelock/assistants → eyelock--assistants)
+	nsDir := filepath.Join(config.HarnessesDir(), "eyelock--assistants", "planner")
+	if err := os.MkdirAll(nsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	harnessJSON := `{"name":"planner","version":"1.0.0","default_vendor":"claude"}`
+	if err := os.WriteFile(filepath.Join(nsDir, ".harness.json"), []byte(harnessJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdUninstall([]string{"planner"}); err != nil {
+		t.Fatalf("cmdUninstall failed: %v", err)
+	}
+
+	if _, err := os.Stat(nsDir); !os.IsNotExist(err) {
+		t.Error("namespaced harness directory still exists after uninstall")
+	}
+}
+
 func TestCmdUninstall_NotInstalled(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/docs/tutorial/07-registry-and-discovery.md
+++ b/docs/tutorial/07-registry-and-discovery.md
@@ -140,13 +140,23 @@ Expected: all three harnesses from `tutorial-registry` (david, planner, media-ma
 ynh install david
 ```
 
-Expected: resolves `david` from the registry to `github.com/eyelock/assistants` with `--path ynh/david`, then installs normally.
+Expected: resolves `david` from the registry to `github.com/eyelock/assistants` with `--path ynh/david`, then installs normally. The namespace is derived from the registry URL (`ynh-tutorial/my-registry`), so the harness is installed under a namespaced directory:
 
 ```
 Installed harness "david"
-  Location: /Users/<you>/.ynh/harnesses/david
+  Location: /Users/<you>/.ynh/harnesses/ynh-tutorial--my-registry/david
   Launcher: /Users/<you>/.ynh/bin/david
   Vendor:   claude
+```
+
+Verify the roundtrip — `ynh ls`, `ynh info`, and `ynh uninstall` all resolve by short name:
+
+```bash
+ynh ls --format json | grep '"path"'
+# Expected: contains "ynh-tutorial--my-registry/david"
+
+ynh info david --format json | grep '"path"'
+# Expected: contains "ynh-tutorial--my-registry/david"
 ```
 
 ## T7.6: Install — with registry qualifier

--- a/docs/tutorial/18-namespacing-and-migration.md
+++ b/docs/tutorial/18-namespacing-and-migration.md
@@ -132,6 +132,46 @@ launcher is only created when the name is unambiguous — installing a second
 `david` removes the short launcher and requires the namespaced launcher
 (`ynh-ns-tutorial--reg-a--david`) or `ynh run david@<namespace>`.
 
+## T18.5a: Verify namespaced paths in JSON output
+
+```bash
+ynh ls --format json | grep '"path"'
+```
+
+Expected: both entries show their namespaced install directories:
+
+```
+  "path": "/Users/<you>/.ynh/harnesses/ynh-ns-tutorial--reg-a/david",
+  "path": "/Users/<you>/.ynh/harnesses/ynh-ns-tutorial--reg-b/david",
+```
+
+## T18.5b: Verify info works by qualified name
+
+```bash
+ynh info "david@ynh-ns-tutorial/reg-a" --format json | grep '"path"'
+```
+
+Expected: the path field shows the namespaced directory:
+
+```
+  "path": "/Users/<you>/.ynh/harnesses/ynh-ns-tutorial--reg-a/david",
+```
+
+## T18.5c: Verify uninstall works when name is unambiguous
+
+Uninstall one of the two `david` harnesses to make the remaining one unambiguous, then verify that short-name uninstall works:
+
+```bash
+ynh uninstall "david@ynh-ns-tutorial/reg-b"
+ynh uninstall david
+```
+
+Expected: both succeed without error. Reinstall for the remaining tutorial steps:
+
+```bash
+ynh install "david@ynh-ns-tutorial/reg-b"
+```
+
 ## T18.6: Migrate a legacy harness with ynd migrate
 
 Create a harness in the legacy 0.1 format:
@@ -224,8 +264,8 @@ intentionally — for example when cleaning up a source repo before publishing.
 ## Clean up
 
 ```bash
-ynh uninstall david@ynh-ns-tutorial/reg-a 2>/dev/null
-ynh uninstall david@ynh-ns-tutorial/reg-b 2>/dev/null
+ynh uninstall "david@ynh-ns-tutorial/reg-a"
+ynh uninstall "david@ynh-ns-tutorial/reg-b"
 ynh uninstall legacy-demo transparent h1 h2 2>/dev/null
 ynh registry remove /tmp/ynh-ns-tutorial/reg-a 2>/dev/null
 ynh registry remove /tmp/ynh-ns-tutorial/reg-b 2>/dev/null

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -113,6 +113,20 @@ func Load(name string) (*Harness, error) {
 	return findInNamespacedDirs(name)
 }
 
+// LoadQualified loads an installed harness by an optionally namespace-qualified
+// ref ("name" or "name@org/repo"). Dispatches to LoadNS when a namespace is
+// present, Load otherwise.
+func LoadQualified(ref string) (*Harness, error) {
+	name, ns, err := namespace.ParseQualified(ref)
+	if err != nil {
+		return nil, err
+	}
+	if ns != "" {
+		return LoadNS(ns, name)
+	}
+	return Load(name)
+}
+
 // LoadNS loads an installed harness by namespace-qualified name.
 func LoadNS(ns, name string) (*Harness, error) {
 	dir := InstalledDirNS(ns, name)


### PR DESCRIPTION
## Summary

- Registry-installed harnesses land at `~/.ynh/harnesses/<ns>--<org>/<name>` (namespaced) but `ls`, `info`, `uninstall`, `run`, `image`, and `prune` all recomputed the path using `InstalledDir()` which always returns the flat `~/.ynh/harnesses/<name>` path
- `printListJSON` used `List()+Load()` instead of `ListAll()+LoadDir()`, so harnesses sharing a name across namespaces all reported the first match's path
- `info` and `uninstall` did not parse `name@org/repo` qualified refs — added `LoadQualified()` to the harness package to handle this
- Prune incorrectly flagged namespaced harnesses as stale launchers/run-dirs

## What changed

**`internal/harness/harness.go`** — adds `LoadQualified(ref)` which parses `name@org/repo` syntax and dispatches to `LoadNS` or `Load`

**`cmd/ynh/list.go`** — `printListJSON` now uses `ListAll()+LoadDir()` (same as `printListText`); `scanArtifactCounts` takes a dir instead of a name

**`cmd/ynh/info.go`** — `printInfoText` and `printInfoJSON` use `LoadQualified`; manifest path and `path` field use `p.Dir`

**`cmd/ynh/main.go`** — `cmdUninstall` uses `LoadQualified` + `p.Dir`; `cmdRun` uses `p.Dir`; prune stale checks use `harness.Load` instead of `DetectFormat(InstalledDir(name))`

**`cmd/ynh/image.go`** — `harnessSrcDir` uses `p.Dir`

**Tutorial docs** — corrected Tutorial 7's `Location:` expected output (was showing flat path); added T18.5a/b/c to Tutorial 18 so evals catch this regression

## Test plan

- [ ] `TestCmdListJSONNamespacedPath` — `ls --format json` reports namespaced path
- [ ] `TestCmdInfoJSONNamespacedPath` — `info --format json` reports namespaced path and reads manifest
- [ ] `TestCmdUninstall_NamespacedHarness` — `uninstall <name>` removes a registry-installed harness
- [ ] Evals: PASS (18 tutorials, 0 failures)
- [ ] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)