### PR TITLE
fix(harness): ResolveEditTarget ignores namespaced install dirs

### DIFF
--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -38,6 +38,12 @@ func ResolveEditTarget(ref string) (dir string, installed bool, err error) {
 	if DetectFormat(installDir) == "plugin" {
 		return installDir, true, nil
 	}
+
+	// Not in flat layout — check namespaced dirs.
+	if h, nsErr := findInNamespacedDirs(ref); nsErr == nil {
+		return h.Dir, true, nil
+	}
+
 	return "", false, fmt.Errorf("harness %q: %w", ref, ErrNotFound)
 }
 

--- a/internal/harness/editor_test.go
+++ b/internal/harness/editor_test.go
@@ -57,6 +57,23 @@ func TestResolveEditTarget_InstalledName(t *testing.T) {
 	}
 }
 
+func TestResolveEditTarget_NamespacedName(t *testing.T) {
+	overrideHarnessesDir(t)
+	dir := InstalledDirNS("org/repo", "my-harness")
+	writeTestHarness(t, dir, "my-harness")
+
+	got, installed, err := ResolveEditTarget("my-harness")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != dir {
+		t.Errorf("dir = %q, want %q", got, dir)
+	}
+	if !installed {
+		t.Error("expected installed=true for namespaced harness")
+	}
+}
+
 func TestResolveEditTarget_Path(t *testing.T) {
 	dir := t.TempDir()
 	writeTestHarness(t, dir, "local")


### PR DESCRIPTION
## Summary

- `include add/remove/update` and `delegate add/remove/update` failed with `harness not found` for any harness installed under a namespace subdirectory (e.g. `~/.ynh/harnesses/eyelock--assistants/media-management`)
- Root cause: `ResolveEditTarget` only checked the flat `InstalledDir` path and never fell through to `findInNamespacedDirs`, unlike `Load` which handles both cases
- Fix: added the same fallback to `findInNamespacedDirs` in `ResolveEditTarget`, plus a new test `TestResolveEditTarget_NamespacedName`

## Test plan

- [ ] `make check` passes (format, lint, tests, build)
- [ ] Evals pass
- [ ] `ynh include add <name>` succeeds for a harness installed under a namespace subdirectory

🤖 Generated with [Claude Code](https://claude.com/claude-code)