### PR TITLE
fix(harness): forward-port hotfix v0.2.2

### DIFF
--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -38,6 +38,12 @@ func ResolveEditTarget(ref string) (dir string, installed bool, err error) {
 	if DetectFormat(installDir) == "plugin" {
 		return installDir, true, nil
 	}
+
+	// Not in flat layout — check namespaced dirs.
+	if h, nsErr := findInNamespacedDirs(ref); nsErr == nil {
+		return h.Dir, true, nil
+	}
+
 	return "", false, fmt.Errorf("harness %q: %w", ref, ErrNotFound)
 }
 

--- a/internal/harness/editor_test.go
+++ b/internal/harness/editor_test.go
@@ -57,6 +57,23 @@ func TestResolveEditTarget_InstalledName(t *testing.T) {
 	}
 }
 
+func TestResolveEditTarget_NamespacedName(t *testing.T) {
+	overrideHarnessesDir(t)
+	dir := InstalledDirNS("org/repo", "my-harness")
+	writeTestHarness(t, dir, "my-harness")
+
+	got, installed, err := ResolveEditTarget("my-harness")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != dir {
+		t.Errorf("dir = %q, want %q", got, dir)
+	}
+	if !installed {
+		t.Error("expected installed=true for namespaced harness")
+	}
+}
+
 func TestResolveEditTarget_Path(t *testing.T) {
 	dir := t.TempDir()
 	writeTestHarness(t, dir, "local")


### PR DESCRIPTION
Cherry-picks the v0.2.2 hotfix onto develop.

**Fix:** `ResolveEditTarget` now falls through to `findInNamespacedDirs` when the flat install path doesn't exist, matching the behaviour of `Load`. This fixes `include add/remove/update` and `delegate add/remove/update` for harnesses installed under a namespace subdirectory.

Closes the develop divergence introduced by hotfix #106.