### PR TITLE
feat(sensors): declare observation surfaces (v0.3.0)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,16 @@
 # Contributing to ynh
 
+## Design Stance
+
+These principles constrain what gets accepted into ynh. Read them before proposing a feature; they explain why some natural-looking ideas are out of scope.
+
+- **Declarative-first.** Manifests describe; they do not execute. Proposals that require ynh to run code at agent runtime, mutate state mid-session, or own the agent loop belong in a runtime project, not here.
+- **Vendor-neutral.** Every feature must translate cleanly into every supported vendor. A capability that exists in only one vendor either gets a portable abstraction or stays out.
+- **Restraint over richness.** The canonical hook vocabulary, the freeform sensor `format` string, the absence of a `passed` boolean on `ynh sensors run` — these are not gaps. They are deliberate refusals to take on responsibility that belongs to the layer above (the loop driver) or below (the vendor runtime).
+- **Structure where the layer above needs to discover.** When an external consumer needs to know about something — a sensor, a focus, a hook event — it goes in the manifest as structured data with CLI discovery. When the *agent* needs to know about something, it goes in `instructions.md` as prose. The two channels are complementary.
+
+See [Harness Engineering §"Design Stance"](../docs/harness-engineering.md#design-stance--declarative-first-vendor-neutral) for the user-facing version of this rationale.
+
 ## Architecture
 
 ynh is a packaging and distribution tool. It has no runtime component - the AI vendor CLI (Claude, Codex, Cursor) handles all interaction. ynh's job is to resolve, assemble, and launch.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ynh manages the **guide layer** of that harness: the proactive steering that hap
 
 ## What you can do
 
-**Build** — Create harnesses with skills, agents, rules, and commands. Pull artifacts from any Git repo with cherry-picking (`pick`). Declare hooks, MCP servers, and environment-specific profiles.
+**Build** — Create harnesses with skills, agents, rules, and commands. Pull artifacts from any Git repo with cherry-picking (`pick`). Declare hooks, MCP servers, environment-specific profiles, and [sensors](docs/sensors.md) — observation surfaces that loop drivers consume between agent turns.
 
 **Refine** — Scaffold with `ynd create`, lint and validate with `ynd lint`/`ynd validate`, compress prompts with `ynd compress`, preview assembled output with `ynd preview`, diff across vendors with `ynd diff`.
 

--- a/cmd/ynd/compose.go
+++ b/cmd/ynd/compose.go
@@ -32,6 +32,7 @@ type composeOutput struct {
 
 type composeSensor struct {
 	Category string              `json:"category,omitempty"`
+	Role     string              `json:"role,omitempty"`
 	Source   composeSensorSource `json:"source"`
 	Output   composeSensorOutput `json:"output"`
 }
@@ -392,6 +393,7 @@ func buildComposeOutput(h *harness.Harness, srcDir string, resolved []resolver.R
 		for name, s := range h.Sensors {
 			cs := composeSensor{
 				Category: s.Category,
+				Role:     s.Role,
 				Output: composeSensorOutput{
 					Format:  s.Output.Format,
 					Channel: s.Output.Channel,

--- a/cmd/ynd/compose.go
+++ b/cmd/ynd/compose.go
@@ -26,7 +26,34 @@ type composeOutput struct {
 	MCPServers    map[string]composeMCP    `json:"mcp_servers,omitempty"`
 	Profiles      []string                 `json:"profiles"`
 	Focuses       map[string]composeFocus  `json:"focuses,omitempty"`
+	Sensors       map[string]composeSensor `json:"sensors,omitempty"`
 	Counts        composeCounts            `json:"counts"`
+}
+
+type composeSensor struct {
+	Category string              `json:"category,omitempty"`
+	Source   composeSensorSource `json:"source"`
+	Output   composeSensorOutput `json:"output"`
+}
+
+type composeSensorSource struct {
+	Files   []string                  `json:"files,omitempty"`
+	Command string                    `json:"command,omitempty"`
+	Focus   *composeSensorSourceFocus `json:"focus,omitempty"`
+}
+
+type composeSensorSourceFocus struct {
+	// Either a name reference to a top-level focus, OR an inline focus.
+	Name    string `json:"name,omitempty"`
+	Profile string `json:"profile,omitempty"`
+	Prompt  string `json:"prompt,omitempty"`
+	Inline  bool   `json:"inline,omitempty"`
+}
+
+type composeSensorOutput struct {
+	Format  string `json:"format"`
+	Channel string `json:"channel,omitempty"`
+	Path    string `json:"path,omitempty"`
 }
 
 type composeArtifacts struct {
@@ -357,6 +384,36 @@ func buildComposeOutput(h *harness.Harness, srcDir string, resolved []resolver.R
 			}
 		}
 		out.Focuses = focuses
+	}
+
+	// Sensors — root harness only (included harnesses' sensors are dropped by design)
+	if len(h.Sensors) > 0 {
+		sensors := make(map[string]composeSensor)
+		for name, s := range h.Sensors {
+			cs := composeSensor{
+				Category: s.Category,
+				Output: composeSensorOutput{
+					Format:  s.Output.Format,
+					Channel: s.Output.Channel,
+					Path:    s.Output.Path,
+				},
+			}
+			cs.Source.Files = s.Source.Files
+			cs.Source.Command = s.Source.Command
+			if s.Source.Focus != nil {
+				if s.Source.Focus.Inline != nil {
+					cs.Source.Focus = &composeSensorSourceFocus{
+						Profile: s.Source.Focus.Inline.Profile,
+						Prompt:  s.Source.Focus.Inline.Prompt,
+						Inline:  true,
+					}
+				} else {
+					cs.Source.Focus = &composeSensorSourceFocus{Name: s.Source.Focus.Name}
+				}
+			}
+			sensors[name] = cs
+		}
+		out.Sensors = sensors
 	}
 
 	// Counts

--- a/cmd/ynd/compose_test.go
+++ b/cmd/ynd/compose_test.go
@@ -620,3 +620,57 @@ func TestCmdComposeTextWithMCPURL(t *testing.T) {
 		t.Error("expected URL MCP server in text output")
 	}
 }
+
+func TestCompose_Sensors(t *testing.T) {
+	dir := t.TempDir()
+	hj := map[string]any{
+		"name":    "sensor-h",
+		"version": "0.1.0",
+		"focus": map[string]any{
+			"audit": map[string]any{"prompt": "audit the diff"},
+		},
+		"sensors": map[string]any{
+			"build": map[string]any{
+				"category": "maintainability",
+				"source":   map[string]any{"command": "make check"},
+				"output":   map[string]any{"format": "text"},
+			},
+			"sec": map[string]any{
+				"source": map[string]any{"focus": "audit"},
+				"output": map[string]any{"format": "markdown"},
+			},
+			"inline-judge": map[string]any{
+				"source": map[string]any{
+					"focus": map[string]any{"prompt": "judge coverage"},
+				},
+				"output": map[string]any{"format": "markdown"},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(hj, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, ".harness.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := cmdComposeTo([]string{dir}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdComposeTo: %v", err)
+	}
+	var got composeOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+	}
+	if len(got.Sensors) != 3 {
+		t.Fatalf("expected 3 sensors, got %d: %+v", len(got.Sensors), got.Sensors)
+	}
+	if got.Sensors["build"].Source.Command != "make check" {
+		t.Errorf("build sensor command = %q", got.Sensors["build"].Source.Command)
+	}
+	if got.Sensors["sec"].Source.Focus == nil || got.Sensors["sec"].Source.Focus.Name != "audit" {
+		t.Errorf("sec sensor focus = %+v", got.Sensors["sec"].Source.Focus)
+	}
+	inline := got.Sensors["inline-judge"].Source.Focus
+	if inline == nil || !inline.Inline || inline.Prompt != "judge coverage" {
+		t.Errorf("inline-judge focus = %+v", inline)
+	}
+}

--- a/cmd/ynd/schema/plugin.schema.json
+++ b/cmd/ynd/schema/plugin.schema.json
@@ -80,6 +80,11 @@
           "type": "string",
           "enum": ["maintainability", "architecture", "behaviour"]
         },
+        "role": {
+          "description": "Optional role hint for loop drivers. regular = run between turns; convergence-verifier = the loop's done-check; stuck-recovery = invoked when the stuckness watchdog fires. Pure metadata — ynh does not enforce semantics.",
+          "type": "string",
+          "enum": ["regular", "convergence-verifier", "stuck-recovery"]
+        },
         "source": { "$ref": "#/$defs/sensor_source" },
         "output": { "$ref": "#/$defs/sensor_output" }
       }

--- a/cmd/ynd/schema/plugin.schema.json
+++ b/cmd/ynd/schema/plugin.schema.json
@@ -62,9 +62,78 @@
           "prompt": { "type": "string", "minLength": 1 }
         }
       }
+    },
+    "sensors": {
+      "description": "Named observation surfaces declared by the harness. ynh declares; loop drivers run them. Each sensor is a role declaration over existing primitives — no new artifact type.",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/sensor" }
     }
   },
   "$defs": {
+    "sensor": {
+      "type": "object",
+      "required": ["source", "output"],
+      "additionalProperties": false,
+      "properties": {
+        "category": {
+          "description": "Fowler bucket — free metadata for loop-driver triage.",
+          "type": "string",
+          "enum": ["maintainability", "architecture", "behaviour"]
+        },
+        "source": { "$ref": "#/$defs/sensor_source" },
+        "output": { "$ref": "#/$defs/sensor_output" }
+      }
+    },
+    "sensor_source": {
+      "description": "Strict one-of: files | command | focus. The set field discriminates the sensor type.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "files": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "command": { "type": "string", "minLength": 1 },
+        "focus": {
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            {
+              "type": "object",
+              "required": ["prompt"],
+              "additionalProperties": false,
+              "properties": {
+                "profile": { "type": "string" },
+                "prompt": { "type": "string", "minLength": 1 }
+              }
+            }
+          ]
+        }
+      },
+      "oneOf": [
+        { "required": ["files"] },
+        { "required": ["command"] },
+        { "required": ["focus"] }
+      ]
+    },
+    "sensor_output": {
+      "type": "object",
+      "required": ["format"],
+      "additionalProperties": false,
+      "properties": {
+        "format": {
+          "description": "Freeform format identifier — pass-through to loop driver. Conventional names: json, junit-xml, lcov-summary, sarif, markdown, text, ndjson.",
+          "type": "string",
+          "minLength": 1
+        },
+        "channel": {
+          "description": "Where the result emerges. Conventional values: stdout, stdout+exit, file, files. Defaults are inferable from source.",
+          "type": "string",
+          "minLength": 1
+        },
+        "path": { "type": "string" }
+      }
+    },
     "hooks": {
       "type": "object",
       "propertyNames": {

--- a/cmd/ynd/validate.go
+++ b/cmd/ynd/validate.go
@@ -564,6 +564,9 @@ func validateHarnessSensors(hj map[string]any) []string {
 		if cat, ok := entry["category"].(string); ok && cat != "" && !plugin.ValidSensorCategories[cat] {
 			issues = append(issues, fmt.Sprintf("%s category %q must be one of maintainability, architecture, behaviour", prefix, cat))
 		}
+		if role, ok := entry["role"].(string); ok && role != "" && !plugin.ValidSensorRoles[role] {
+			issues = append(issues, fmt.Sprintf("%s role %q must be one of regular, convergence-verifier, stuck-recovery", prefix, role))
+		}
 		if out, ok := entry["output"].(map[string]any); ok {
 			if format, _ := out["format"].(string); format == "" {
 				issues = append(issues, fmt.Sprintf("%s output.format must not be empty", prefix))

--- a/cmd/ynd/validate.go
+++ b/cmd/ynd/validate.go
@@ -227,6 +227,7 @@ func validateHarness(dir string) error {
 			issues = append(issues, validateHarnessMCPServers(hj)...)
 			issues = append(issues, validateHarnessProfiles(hj)...)
 			issues = append(issues, validateHarnessFocus(hj)...)
+			issues = append(issues, validateHarnessSensors(hj)...)
 		}
 	}
 
@@ -517,6 +518,91 @@ func validateHarnessFocus(hj map[string]any) []string {
 		profile, _ := entryMap["profile"].(string)
 		if profile != "" && !profileNames[profile] {
 			issues = append(issues, fmt.Sprintf("focus.%s: references unknown profile %q", name, profile))
+		}
+	}
+
+	return issues
+}
+
+// validateHarnessSensors validates the sensors section inside plugin.json.
+// Schema covers structural rules; this layer enforces cross-field rules
+// (focus references resolve, inline-focus profile references resolve)
+// and emits sensor-name-prefixed errors.
+func validateHarnessSensors(hj map[string]any) []string {
+	var issues []string
+
+	sensors, ok := hj["sensors"]
+	if !ok {
+		return issues
+	}
+	sensorsMap, ok := sensors.(map[string]any)
+	if !ok {
+		issues = append(issues, "'sensors' must be an object")
+		return issues
+	}
+
+	profileNames := map[string]bool{}
+	if profiles, ok := hj["profiles"].(map[string]any); ok {
+		for name := range profiles {
+			profileNames[name] = true
+		}
+	}
+	focusNames := map[string]bool{}
+	if focuses, ok := hj["focus"].(map[string]any); ok {
+		for name := range focuses {
+			focusNames[name] = true
+		}
+	}
+
+	for name, raw := range sensorsMap {
+		prefix := fmt.Sprintf("sensor %q:", name)
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			issues = append(issues, fmt.Sprintf("%s must be an object", prefix))
+			continue
+		}
+		if cat, ok := entry["category"].(string); ok && cat != "" && !plugin.ValidSensorCategories[cat] {
+			issues = append(issues, fmt.Sprintf("%s category %q must be one of maintainability, architecture, behaviour", prefix, cat))
+		}
+		if out, ok := entry["output"].(map[string]any); ok {
+			if format, _ := out["format"].(string); format == "" {
+				issues = append(issues, fmt.Sprintf("%s output.format must not be empty", prefix))
+			}
+		} else {
+			issues = append(issues, fmt.Sprintf("%s output is required", prefix))
+		}
+		src, ok := entry["source"].(map[string]any)
+		if !ok {
+			issues = append(issues, fmt.Sprintf("%s source is required", prefix))
+			continue
+		}
+		count := 0
+		if _, has := src["files"]; has {
+			count++
+		}
+		if _, has := src["command"]; has {
+			count++
+		}
+		if focus, has := src["focus"]; has {
+			count++
+			switch fv := focus.(type) {
+			case string:
+				if fv == "" {
+					issues = append(issues, fmt.Sprintf("%s source.focus reference must not be empty", prefix))
+				} else if !focusNames[fv] {
+					issues = append(issues, fmt.Sprintf("%s source.focus references undefined focus %q", prefix, fv))
+				}
+			case map[string]any:
+				if prompt, _ := fv["prompt"].(string); prompt == "" {
+					issues = append(issues, fmt.Sprintf("%s source.focus.prompt must not be empty", prefix))
+				}
+				if profile, _ := fv["profile"].(string); profile != "" && !profileNames[profile] {
+					issues = append(issues, fmt.Sprintf("%s source.focus references unknown profile %q", prefix, profile))
+				}
+			}
+		}
+		if count != 1 {
+			issues = append(issues, fmt.Sprintf("%s source must have exactly one of files, command, focus", prefix))
 		}
 	}
 

--- a/cmd/ynd/validate_test.go
+++ b/cmd/ynd/validate_test.go
@@ -1086,3 +1086,87 @@ func TestValidateDir_NoRootMarketplace(t *testing.T) {
 		t.Errorf("expected valid (no marketplace.json is fine), got: %v", err)
 	}
 }
+
+func TestValidateHarnessSensors_Valid(t *testing.T) {
+	hj := map[string]any{
+		"focus": map[string]any{
+			"infer-vulns": map[string]any{"prompt": "find vulns"},
+		},
+		"profiles": map[string]any{
+			"ci": map[string]any{},
+		},
+		"sensors": map[string]any{
+			"build": map[string]any{
+				"category": "maintainability",
+				"source":   map[string]any{"command": "make check"},
+				"output":   map[string]any{"format": "text"},
+			},
+			"sec": map[string]any{
+				"source": map[string]any{"focus": "infer-vulns"},
+				"output": map[string]any{"format": "markdown"},
+			},
+			"inline": map[string]any{
+				"source": map[string]any{
+					"focus": map[string]any{"profile": "ci", "prompt": "judge"},
+				},
+				"output": map[string]any{"format": "markdown"},
+			},
+		},
+	}
+	if issues := validateHarnessSensors(hj); len(issues) != 0 {
+		t.Errorf("expected no issues, got %v", issues)
+	}
+}
+
+func TestValidateHarnessSensors_Issues(t *testing.T) {
+	hj := map[string]any{
+		"sensors": map[string]any{
+			"two-source": map[string]any{
+				"source": map[string]any{
+					"command": "x",
+					"files":   []any{"a"},
+				},
+				"output": map[string]any{"format": "text"},
+			},
+			"missing-format": map[string]any{
+				"source": map[string]any{"command": "x"},
+				"output": map[string]any{"format": ""},
+			},
+			"unknown-focus": map[string]any{
+				"source": map[string]any{"focus": "missing"},
+				"output": map[string]any{"format": "markdown"},
+			},
+			"bad-category": map[string]any{
+				"category": "wrong",
+				"source":   map[string]any{"command": "x"},
+				"output":   map[string]any{"format": "text"},
+			},
+			"inline-bad-profile": map[string]any{
+				"source": map[string]any{
+					"focus": map[string]any{"profile": "missing", "prompt": "x"},
+				},
+				"output": map[string]any{"format": "markdown"},
+			},
+		},
+	}
+	issues := validateHarnessSensors(hj)
+	wants := []string{
+		`"two-source": source must have exactly one`,
+		`"missing-format": output.format must not be empty`,
+		`"unknown-focus": source.focus references undefined focus "missing"`,
+		`"bad-category": category "wrong"`,
+		`"inline-bad-profile": source.focus references unknown profile "missing"`,
+	}
+	for _, want := range wants {
+		found := false
+		for _, got := range issues {
+			if strings.Contains(got, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing expected issue %q in %v", want, issues)
+		}
+	}
+}

--- a/cmd/ynh/info.go
+++ b/cmd/ynh/info.go
@@ -263,6 +263,30 @@ func printInfoText(w io.Writer, name string) error {
 		}
 	}
 
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "Sensors:")
+	if len(p.Sensors) == 0 {
+		_, _ = fmt.Fprintln(w, "  (none)")
+	} else {
+		names := make([]string, 0, len(p.Sensors))
+		for n := range p.Sensors {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			s := p.Sensors[n]
+			cat := s.Category
+			if cat == "" {
+				cat = "-"
+			}
+			kind := s.Source.Kind()
+			if s.Source.Focus != nil && s.Source.Focus.Inline != nil {
+				kind = "focus*" // * = inline focus
+			}
+			_, _ = fmt.Fprintf(w, "  %s    %s    %s    %s\n", n, cat, kind, s.Output.Format)
+		}
+	}
+
 	return nil
 }
 

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -64,6 +64,8 @@ func main() {
 		err = cmdFork(os.Args[2:])
 	case "include":
 		err = cmdInclude(os.Args[2:])
+	case "sensors":
+		err = cmdSensors(os.Args[2:])
 	case "image":
 		err = cmdImage(os.Args[2:])
 	case "prune":
@@ -116,6 +118,8 @@ Commands:
   include add <harness> <url>  Add a Git include to a harness
   include remove <harness> <url>  Remove a Git include from a harness
   include update <harness> <url>  Update a Git include's options
+  sensors ls <harness>         List declared sensors (supports --format json)
+  sensors show <harness> <name>  Resolve a sensor declaration (supports --format text|json)
   registry add <url>           Add a harness registry
   registry list                Show configured registries (supports --format json)
   registry remove <url>        Remove a registry

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -120,6 +120,7 @@ Commands:
   include update <harness> <url>  Update a Git include's options
   sensors ls <harness>         List declared sensors (supports --format json)
   sensors show <harness> <name>  Resolve a sensor declaration (supports --format text|json)
+  sensors run <harness> <name>   Run a sensor and emit a JSON result (loop drivers consume this)
   registry add <url>           Add a harness registry
   registry list                Show configured registries (supports --format json)
   registry remove <url>        Remove a registry

--- a/cmd/ynh/sensors.go
+++ b/cmd/ynh/sensors.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// sensorListEntry is the summary shape for `ynh sensors ls --format json`.
+type sensorListEntry struct {
+	Name        string `json:"name"`
+	Category    string `json:"category,omitempty"`
+	SourceKind  string `json:"source_kind"`
+	Format      string `json:"format"`
+	InlineFocus bool   `json:"inline_focus,omitempty"`
+}
+
+// sensorShowEntry is the resolved shape for `ynh sensors show --format json`.
+// Inline focuses appear under source.focus.inline; named focuses are expanded
+// from the harness's top-level focus map so consumers get a self-contained
+// payload.
+type sensorShowEntry struct {
+	Name     string           `json:"name"`
+	Category string           `json:"category,omitempty"`
+	Source   sensorShowSource `json:"source"`
+	Output   sensorShowOutput `json:"output"`
+}
+
+type sensorShowSource struct {
+	Files   []string         `json:"files,omitempty"`
+	Command string           `json:"command,omitempty"`
+	Focus   *sensorShowFocus `json:"focus,omitempty"`
+}
+
+type sensorShowFocus struct {
+	Name    string `json:"name,omitempty"`
+	Profile string `json:"profile,omitempty"`
+	Prompt  string `json:"prompt"`
+	Inline  bool   `json:"inline"`
+}
+
+type sensorShowOutput struct {
+	Format  string `json:"format"`
+	Channel string `json:"channel,omitempty"`
+	Path    string `json:"path,omitempty"`
+}
+
+func cmdSensors(args []string) error {
+	return cmdSensorsTo(args, os.Stdout, os.Stderr)
+}
+
+func cmdSensorsTo(args []string, stdout, stderr io.Writer) error {
+	if len(args) < 1 {
+		return cliError(stderr, false, errCodeInvalidInput,
+			"usage: ynh sensors <ls|show> [args]")
+	}
+	switch args[0] {
+	case "ls", "list":
+		return cmdSensorsLs(args[1:], stdout, stderr)
+	case "show":
+		return cmdSensorsShow(args[1:], stdout, stderr)
+	default:
+		return cliError(stderr, false, errCodeInvalidInput,
+			fmt.Sprintf("unknown sensors subcommand: %s", args[0]))
+	}
+}
+
+func cmdSensorsLs(args []string, stdout, stderr io.Writer) error {
+	structured := detectJSONFormat(args)
+	format := "text"
+	var harnessName string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--format":
+			if i+1 >= len(args) {
+				return cliError(stderr, structured, errCodeInvalidInput, "--format requires a value")
+			}
+			i++
+			format = args[i]
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return cliError(stderr, structured, errCodeInvalidInput,
+					fmt.Sprintf("unknown flag: %s", args[i]))
+			}
+			if harnessName != "" {
+				return cliError(stderr, structured, errCodeInvalidInput,
+					fmt.Sprintf("unexpected argument: %s", args[i]))
+			}
+			harnessName = args[i]
+		}
+	}
+	if harnessName == "" {
+		return cliError(stderr, structured, errCodeInvalidInput,
+			"usage: ynh sensors ls <harness-name> [--format text|json]")
+	}
+
+	p, err := harness.LoadQualified(harnessName)
+	if err != nil {
+		return cliError(stderr, structured, errCodeNotFound, err.Error())
+	}
+
+	entries := buildSensorList(p)
+
+	switch format {
+	case "text":
+		return printSensorListText(stdout, entries)
+	case "json":
+		data, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encoding sensors: %w", err)
+		}
+		_, err = fmt.Fprintln(stdout, string(data))
+		return err
+	default:
+		return cliError(stderr, structured, errCodeInvalidInput,
+			fmt.Sprintf("invalid --format value %q (want text or json)", format))
+	}
+}
+
+func cmdSensorsShow(args []string, stdout, stderr io.Writer) error {
+	structured := detectJSONFormat(args)
+	format := "json" // show defaults to JSON — the deep view is intended for machine consumption
+	var harnessName, sensorName string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--format":
+			if i+1 >= len(args) {
+				return cliError(stderr, structured, errCodeInvalidInput, "--format requires a value")
+			}
+			i++
+			format = args[i]
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return cliError(stderr, structured, errCodeInvalidInput,
+					fmt.Sprintf("unknown flag: %s", args[i]))
+			}
+			switch {
+			case harnessName == "":
+				harnessName = args[i]
+			case sensorName == "":
+				sensorName = args[i]
+			default:
+				return cliError(stderr, structured, errCodeInvalidInput,
+					fmt.Sprintf("unexpected argument: %s", args[i]))
+			}
+		}
+	}
+	if harnessName == "" || sensorName == "" {
+		return cliError(stderr, structured, errCodeInvalidInput,
+			"usage: ynh sensors show <harness-name> <sensor-name> [--format text|json]")
+	}
+
+	p, err := harness.LoadQualified(harnessName)
+	if err != nil {
+		return cliError(stderr, structured, errCodeNotFound, err.Error())
+	}
+
+	entry, ok := buildSensorShow(p, sensorName)
+	if !ok {
+		return cliError(stderr, structured, errCodeNotFound,
+			fmt.Sprintf("sensor %q not declared in harness %q", sensorName, p.Name))
+	}
+
+	switch format {
+	case "json":
+		data, err := json.MarshalIndent(entry, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encoding sensor: %w", err)
+		}
+		_, err = fmt.Fprintln(stdout, string(data))
+		return err
+	case "text":
+		return printSensorShowText(stdout, entry)
+	default:
+		return cliError(stderr, structured, errCodeInvalidInput,
+			fmt.Sprintf("invalid --format value %q (want text or json)", format))
+	}
+}
+
+func buildSensorList(p *harness.Harness) []sensorListEntry {
+	entries := make([]sensorListEntry, 0, len(p.Sensors))
+	names := make([]string, 0, len(p.Sensors))
+	for n := range p.Sensors {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		s := p.Sensors[n]
+		e := sensorListEntry{
+			Name:       n,
+			Category:   s.Category,
+			SourceKind: s.Source.Kind(),
+			Format:     s.Output.Format,
+		}
+		if s.Source.Focus != nil && s.Source.Focus.Inline != nil {
+			e.InlineFocus = true
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+func buildSensorShow(p *harness.Harness, name string) (sensorShowEntry, bool) {
+	s, ok := p.Sensors[name]
+	if !ok {
+		return sensorShowEntry{}, false
+	}
+	entry := sensorShowEntry{
+		Name:     name,
+		Category: s.Category,
+		Output: sensorShowOutput{
+			Format:  s.Output.Format,
+			Channel: s.Output.Channel,
+			Path:    s.Output.Path,
+		},
+	}
+	entry.Source.Files = s.Source.Files
+	entry.Source.Command = s.Source.Command
+	if s.Source.Focus != nil {
+		entry.Source.Focus = resolveSensorFocus(p, s.Source.Focus)
+	}
+	return entry, true
+}
+
+// resolveSensorFocus expands a string focus reference against the harness's
+// top-level focuses so consumers get a self-contained payload. Inline focuses
+// pass through unchanged.
+func resolveSensorFocus(p *harness.Harness, fr *plugin.FocusRef) *sensorShowFocus {
+	if fr.Inline != nil {
+		return &sensorShowFocus{
+			Profile: fr.Inline.Profile,
+			Prompt:  fr.Inline.Prompt,
+			Inline:  true,
+		}
+	}
+	resolved, ok := p.Focuses[fr.Name]
+	if !ok {
+		// Validation should have caught this, but emit a stub so the consumer
+		// can still see what reference was unresolvable.
+		return &sensorShowFocus{Name: fr.Name}
+	}
+	return &sensorShowFocus{
+		Name:    fr.Name,
+		Profile: resolved.Profile,
+		Prompt:  resolved.Prompt,
+	}
+}
+
+func printSensorListText(w io.Writer, entries []sensorListEntry) error {
+	if len(entries) == 0 {
+		_, err := fmt.Fprintln(w, "(no sensors declared)")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "NAME\tCATEGORY\tSOURCE\tFORMAT")
+	for _, e := range entries {
+		cat := e.Category
+		if cat == "" {
+			cat = "-"
+		}
+		kind := e.SourceKind
+		if e.InlineFocus {
+			kind = "focus*"
+		}
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", e.Name, cat, kind, e.Format)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	if hasInline(entries) {
+		_, _ = fmt.Fprintln(w, "\n* = inline focus")
+	}
+	return nil
+}
+
+func hasInline(entries []sensorListEntry) bool {
+	for _, e := range entries {
+		if e.InlineFocus {
+			return true
+		}
+	}
+	return false
+}
+
+func printSensorShowText(w io.Writer, entry sensorShowEntry) error {
+	_, _ = fmt.Fprintf(w, "Name:      %s\n", entry.Name)
+	if entry.Category != "" {
+		_, _ = fmt.Fprintf(w, "Category:  %s\n", entry.Category)
+	}
+	_, _ = fmt.Fprintln(w, "Source:")
+	switch {
+	case len(entry.Source.Files) > 0:
+		_, _ = fmt.Fprintf(w, "  files:   %s\n", strings.Join(entry.Source.Files, ", "))
+	case entry.Source.Command != "":
+		_, _ = fmt.Fprintf(w, "  command: %s\n", entry.Source.Command)
+	case entry.Source.Focus != nil:
+		f := entry.Source.Focus
+		label := "(inline)"
+		if !f.Inline && f.Name != "" {
+			label = "→ focus " + f.Name
+		}
+		_, _ = fmt.Fprintf(w, "  focus:   %s\n", label)
+		if f.Profile != "" {
+			_, _ = fmt.Fprintf(w, "    profile: %s\n", f.Profile)
+		}
+		_, _ = fmt.Fprintf(w, "    prompt:  %q\n", f.Prompt)
+	}
+	_, _ = fmt.Fprintln(w, "Output:")
+	_, _ = fmt.Fprintf(w, "  format:  %s\n", entry.Output.Format)
+	if entry.Output.Channel != "" {
+		_, _ = fmt.Fprintf(w, "  channel: %s\n", entry.Output.Channel)
+	}
+	if entry.Output.Path != "" {
+		_, _ = fmt.Fprintf(w, "  path:    %s\n", entry.Output.Path)
+	}
+	return nil
+}

--- a/cmd/ynh/sensors.go
+++ b/cmd/ynh/sensors.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/eyelock/ynh/internal/harness"
 	"github.com/eyelock/ynh/internal/plugin"
@@ -17,6 +21,7 @@ import (
 type sensorListEntry struct {
 	Name        string `json:"name"`
 	Category    string `json:"category,omitempty"`
+	Role        string `json:"role,omitempty"`
 	SourceKind  string `json:"source_kind"`
 	Format      string `json:"format"`
 	InlineFocus bool   `json:"inline_focus,omitempty"`
@@ -29,6 +34,7 @@ type sensorListEntry struct {
 type sensorShowEntry struct {
 	Name     string           `json:"name"`
 	Category string           `json:"category,omitempty"`
+	Role     string           `json:"role,omitempty"`
 	Source   sensorShowSource `json:"source"`
 	Output   sensorShowOutput `json:"output"`
 }
@@ -66,6 +72,8 @@ func cmdSensorsTo(args []string, stdout, stderr io.Writer) error {
 		return cmdSensorsLs(args[1:], stdout, stderr)
 	case "show":
 		return cmdSensorsShow(args[1:], stdout, stderr)
+	case "run":
+		return cmdSensorsRun(args[1:], stdout, stderr)
 	default:
 		return cliError(stderr, false, errCodeInvalidInput,
 			fmt.Sprintf("unknown sensors subcommand: %s", args[0]))
@@ -196,6 +204,7 @@ func buildSensorList(p *harness.Harness) []sensorListEntry {
 		e := sensorListEntry{
 			Name:       n,
 			Category:   s.Category,
+			Role:       s.Role,
 			SourceKind: s.Source.Kind(),
 			Format:     s.Output.Format,
 		}
@@ -215,6 +224,7 @@ func buildSensorShow(p *harness.Harness, name string) (sensorShowEntry, bool) {
 	entry := sensorShowEntry{
 		Name:     name,
 		Category: s.Category,
+		Role:     s.Role,
 		Output: sensorShowOutput{
 			Format:  s.Output.Format,
 			Channel: s.Output.Channel,
@@ -321,4 +331,195 @@ func printSensorShowText(w io.Writer, entry sensorShowEntry) error {
 		_, _ = fmt.Fprintf(w, "  path:    %s\n", entry.Output.Path)
 	}
 	return nil
+}
+
+// sensorRunResult is the payload returned by `ynh sensors run`.
+//
+// Contract notes for loop drivers consuming this:
+//   - There is NO `passed` field. ynh runs the sensor mechanically and
+//     returns raw signal (exit_code, output, files). Whether a result counts
+//     as pass or fail is loop-driver policy — per-team thresholds, severity
+//     filters, and convergence judgments belong above ynh, not inside it.
+//   - For focus-sourced sensors ynh resolves the focus declaration and
+//     returns it under output.focus. The loop driver invokes the agent
+//     runtime; ynh owns no agent-invocation surface.
+type sensorRunResult struct {
+	Name       string          `json:"name"`
+	Kind       string          `json:"kind"` // files | command | focus
+	Role       string          `json:"role,omitempty"`
+	Category   string          `json:"category,omitempty"`
+	ExitCode   int             `json:"exit_code"`
+	DurationMS int64           `json:"duration_ms"`
+	Output     sensorRunOutput `json:"output"`
+}
+
+type sensorRunOutput struct {
+	Format  string           `json:"format"`
+	Channel string           `json:"channel,omitempty"`
+	Stdout  string           `json:"stdout,omitempty"`
+	Stderr  string           `json:"stderr,omitempty"`
+	Files   []sensorRunFile  `json:"files,omitempty"`
+	Focus   *sensorShowFocus `json:"focus,omitempty"`
+	Note    string           `json:"note,omitempty"`
+}
+
+type sensorRunFile struct {
+	Path    string `json:"path"`
+	Size    int64  `json:"size"`
+	Content string `json:"content,omitempty"`
+}
+
+func cmdSensorsRun(args []string, stdout, stderr io.Writer) error {
+	structured := true // run only emits JSON
+	cwd := ""
+	includeContent := true
+	var harnessName, sensorName string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--cwd":
+			if i+1 >= len(args) {
+				return cliError(stderr, structured, errCodeInvalidInput, "--cwd requires a value")
+			}
+			i++
+			cwd = args[i]
+		case "--no-content":
+			includeContent = false
+		case "--format":
+			if i+1 >= len(args) {
+				return cliError(stderr, structured, errCodeInvalidInput, "--format requires a value")
+			}
+			i++
+			if args[i] != "json" {
+				return cliError(stderr, structured, errCodeInvalidInput,
+					"ynh sensors run only supports --format json")
+			}
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return cliError(stderr, structured, errCodeInvalidInput,
+					fmt.Sprintf("unknown flag: %s", args[i]))
+			}
+			switch {
+			case harnessName == "":
+				harnessName = args[i]
+			case sensorName == "":
+				sensorName = args[i]
+			default:
+				return cliError(stderr, structured, errCodeInvalidInput,
+					fmt.Sprintf("unexpected argument: %s", args[i]))
+			}
+		}
+	}
+	if harnessName == "" || sensorName == "" {
+		return cliError(stderr, structured, errCodeInvalidInput,
+			"usage: ynh sensors run <harness-name> <sensor-name> [--cwd dir] [--no-content]")
+	}
+
+	p, err := harness.LoadQualified(harnessName)
+	if err != nil {
+		return cliError(stderr, structured, errCodeNotFound, err.Error())
+	}
+	s, ok := p.Sensors[sensorName]
+	if !ok {
+		return cliError(stderr, structured, errCodeNotFound,
+			fmt.Sprintf("sensor %q not declared in harness %q", sensorName, p.Name))
+	}
+
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+
+	result, err := runSensor(p, sensorName, s, cwd, includeContent)
+	if err != nil {
+		return cliError(stderr, structured, errCodeIOError, err.Error())
+	}
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding sensor result: %w", err)
+	}
+	_, err = fmt.Fprintln(stdout, string(data))
+	return err
+}
+
+func runSensor(p *harness.Harness, name string, s plugin.Sensor, cwd string, includeContent bool) (*sensorRunResult, error) {
+	r := &sensorRunResult{
+		Name:     name,
+		Kind:     s.Source.Kind(),
+		Role:     s.Role,
+		Category: s.Category,
+		Output: sensorRunOutput{
+			Format:  s.Output.Format,
+			Channel: s.Output.Channel,
+		},
+	}
+	start := time.Now()
+	defer func() { r.DurationMS = time.Since(start).Milliseconds() }()
+
+	switch s.Source.Kind() {
+	case "command":
+		if r.Output.Channel == "" {
+			r.Output.Channel = "stdout+exit"
+		}
+		var stdoutBuf, stderrBuf bytes.Buffer
+		cmd := exec.Command("/bin/sh", "-c", s.Source.Command)
+		cmd.Dir = cwd
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+		runErr := cmd.Run()
+		r.Output.Stdout = stdoutBuf.String()
+		r.Output.Stderr = stderrBuf.String()
+		if runErr != nil {
+			if ee, ok := runErr.(*exec.ExitError); ok {
+				r.ExitCode = ee.ExitCode()
+			} else {
+				// Couldn't even start the command — treat as a runner failure
+				// and surface via stderr; loop driver decides what to do.
+				r.ExitCode = -1
+				r.Output.Stderr = runErr.Error()
+			}
+		}
+
+	case "files":
+		if r.Output.Channel == "" {
+			r.Output.Channel = "files"
+		}
+		for _, pat := range s.Source.Files {
+			abs := pat
+			if !filepath.IsAbs(abs) {
+				abs = filepath.Join(cwd, pat)
+			}
+			matches, err := filepath.Glob(abs)
+			if err != nil {
+				return nil, fmt.Errorf("glob %q: %w", pat, err)
+			}
+			sort.Strings(matches)
+			for _, m := range matches {
+				info, err := os.Stat(m)
+				if err != nil || info.IsDir() {
+					continue
+				}
+				f := sensorRunFile{Path: m, Size: info.Size()}
+				if includeContent {
+					content, err := os.ReadFile(m)
+					if err != nil {
+						return nil, fmt.Errorf("reading %s: %w", m, err)
+					}
+					f.Content = string(content)
+				}
+				r.Output.Files = append(r.Output.Files, f)
+			}
+		}
+
+	case "focus":
+		if r.Output.Channel == "" {
+			r.Output.Channel = "stdout"
+		}
+		r.Output.Focus = resolveSensorFocus(p, s.Source.Focus)
+		r.Output.Note = "ynh resolves the focus declaration; the loop driver invokes the agent runtime"
+
+	default:
+		return nil, fmt.Errorf("sensor %q has no source variant set", name)
+	}
+
+	return r, nil
 }

--- a/cmd/ynh/sensors_test.go
+++ b/cmd/ynh/sensors_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+const sensorHarnessJSON = `{
+  "name": "sh",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "focus": {
+    "audit": {"prompt": "audit the diff"}
+  },
+  "sensors": {
+    "build": {
+      "category": "maintainability",
+      "source": {"command": "make check"},
+      "output": {"format": "text"}
+    },
+    "tests": {
+      "category": "behaviour",
+      "source": {"files": ["test-reports/**/*.xml"]},
+      "output": {"format": "junit-xml"}
+    },
+    "sec": {
+      "source": {"focus": "audit"},
+      "output": {"format": "markdown"}
+    },
+    "judge": {
+      "source": {"focus": {"prompt": "judge coverage"}},
+      "output": {"format": "markdown"}
+    }
+  }
+}`
+
+func TestCmdSensors_Ls_JSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installListTestHarness(t, home, "sh", sensorHarnessJSON)
+
+	var stdout bytes.Buffer
+	err := cmdSensorsTo([]string{"ls", "sh", "--format", "json"}, &stdout, io.Discard)
+	if err != nil {
+		t.Fatalf("cmdSensorsTo: %v", err)
+	}
+	var entries []sensorListEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+	}
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+	// Sorted alphabetically
+	wantOrder := []string{"build", "judge", "sec", "tests"}
+	for i, w := range wantOrder {
+		if entries[i].Name != w {
+			t.Errorf("entry[%d].Name = %q, want %q", i, entries[i].Name, w)
+		}
+	}
+	for _, e := range entries {
+		switch e.Name {
+		case "build":
+			if e.SourceKind != "command" || e.Format != "text" {
+				t.Errorf("build entry = %+v", e)
+			}
+		case "tests":
+			if e.SourceKind != "files" || e.Category != "behaviour" {
+				t.Errorf("tests entry = %+v", e)
+			}
+		case "sec":
+			if e.SourceKind != "focus" || e.InlineFocus {
+				t.Errorf("sec entry = %+v (InlineFocus should be false)", e)
+			}
+		case "judge":
+			if e.SourceKind != "focus" || !e.InlineFocus {
+				t.Errorf("judge entry = %+v (InlineFocus should be true)", e)
+			}
+		}
+	}
+}
+
+func TestCmdSensors_Ls_Text(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installListTestHarness(t, home, "sh", sensorHarnessJSON)
+
+	var stdout bytes.Buffer
+	if err := cmdSensorsTo([]string{"ls", "sh"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdSensorsTo: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "build") || !strings.Contains(out, "tests") {
+		t.Errorf("expected sensor names in text output: %s", out)
+	}
+	if !strings.Contains(out, "* = inline focus") {
+		t.Errorf("expected inline focus footnote, got: %s", out)
+	}
+}
+
+func TestCmdSensors_Show_FocusReferenceExpanded(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installListTestHarness(t, home, "sh", sensorHarnessJSON)
+
+	var stdout bytes.Buffer
+	if err := cmdSensorsTo([]string{"show", "sh", "sec"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdSensorsTo: %v", err)
+	}
+	var entry sensorShowEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+	}
+	if entry.Source.Focus == nil {
+		t.Fatal("expected focus in source")
+	}
+	if entry.Source.Focus.Inline {
+		t.Error("string-ref focus should not be marked inline")
+	}
+	if entry.Source.Focus.Name != "audit" {
+		t.Errorf("focus.name = %q, want audit", entry.Source.Focus.Name)
+	}
+	if entry.Source.Focus.Prompt != "audit the diff" {
+		t.Errorf("focus.prompt = %q (expected expanded prompt)", entry.Source.Focus.Prompt)
+	}
+}
+
+func TestCmdSensors_Show_InlineFocus(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installListTestHarness(t, home, "sh", sensorHarnessJSON)
+
+	var stdout bytes.Buffer
+	if err := cmdSensorsTo([]string{"show", "sh", "judge"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdSensorsTo: %v", err)
+	}
+	var entry sensorShowEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+	}
+	if entry.Source.Focus == nil || !entry.Source.Focus.Inline {
+		t.Fatalf("expected inline focus, got %+v", entry.Source.Focus)
+	}
+	if entry.Source.Focus.Prompt != "judge coverage" {
+		t.Errorf("inline prompt = %q", entry.Source.Focus.Prompt)
+	}
+}
+
+func TestCmdSensors_Show_NotFound(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installListTestHarness(t, home, "sh", sensorHarnessJSON)
+
+	var stdout, stderr bytes.Buffer
+	err := cmdSensorsTo([]string{"show", "sh", "nope", "--format", "json"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error for unknown sensor")
+	}
+	if !strings.Contains(stderr.String(), "not_found") {
+		t.Errorf("expected not_found code in stderr, got: %s", stderr.String())
+	}
+}
+
+func TestCmdSensors_Ls_NoSensors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installListTestHarness(t, home, "empty", `{"name":"empty","version":"0.1.0"}`)
+
+	var stdout bytes.Buffer
+	if err := cmdSensorsTo([]string{"ls", "empty"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdSensorsTo: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "no sensors declared") {
+		t.Errorf("expected empty message, got: %s", stdout.String())
+	}
+}
+
+func TestCmdSensors_UsageErrors(t *testing.T) {
+	tests := []struct {
+		args []string
+		want string
+	}{
+		{nil, "usage:"},
+		{[]string{"unknown"}, "unknown sensors subcommand"},
+		{[]string{"ls"}, "usage: ynh sensors ls"},
+		{[]string{"show"}, "usage: ynh sensors show"},
+		{[]string{"show", "h"}, "usage: ynh sensors show"},
+	}
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			err := cmdSensorsTo(tt.args, &stdout, &stderr)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) && !strings.Contains(stderr.String(), tt.want) {
+				t.Errorf("expected %q in error, got err=%q stderr=%q", tt.want, err.Error(), stderr.String())
+			}
+		})
+	}
+}
+
+func TestCmdInfo_RendersSensorsSection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installListTestHarness(t, home, "sh", sensorHarnessJSON)
+
+	var stdout bytes.Buffer
+	if err := cmdInfoTo([]string{"sh"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdInfoTo: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Sensors:") {
+		t.Errorf("expected Sensors: section in info text output")
+	}
+	if !strings.Contains(out, "build") || !strings.Contains(out, "tests") {
+		t.Errorf("expected sensor names in info output: %s", out)
+	}
+}

--- a/cmd/ynh/sensors_test.go
+++ b/cmd/ynh/sensors_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -220,5 +222,171 @@ func TestCmdInfo_RendersSensorsSection(t *testing.T) {
 	}
 	if !strings.Contains(out, "build") || !strings.Contains(out, "tests") {
 		t.Errorf("expected sensor names in info output: %s", out)
+	}
+}
+
+func TestCmdSensors_Run_Command(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installListTestHarness(t, home, "sh", `{
+		"name": "sh",
+		"version": "0.1.0",
+		"sensors": {
+			"build": {
+				"source": {"command": "echo hello && exit 0"},
+				"output": {"format": "text"}
+			},
+			"fail": {
+				"source": {"command": "exit 7"},
+				"output": {"format": "text"}
+			}
+		}
+	}`)
+
+	t.Run("zero exit", func(t *testing.T) {
+		var stdout bytes.Buffer
+		if err := cmdSensorsTo([]string{"run", "sh", "build"}, &stdout, io.Discard); err != nil {
+			t.Fatalf("cmdSensorsTo: %v", err)
+		}
+		var r sensorRunResult
+		if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+			t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+		}
+		if r.ExitCode != 0 {
+			t.Errorf("ExitCode = %d, want 0", r.ExitCode)
+		}
+		if !strings.Contains(r.Output.Stdout, "hello") {
+			t.Errorf("expected hello in stdout, got %q", r.Output.Stdout)
+		}
+		if r.Kind != "command" {
+			t.Errorf("Kind = %q", r.Kind)
+		}
+	})
+
+	t.Run("non-zero exit captured, no passed bool", func(t *testing.T) {
+		var stdout bytes.Buffer
+		if err := cmdSensorsTo([]string{"run", "sh", "fail"}, &stdout, io.Discard); err != nil {
+			t.Fatalf("cmdSensorsTo: %v", err)
+		}
+		var r sensorRunResult
+		if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if r.ExitCode != 7 {
+			t.Errorf("ExitCode = %d, want 7", r.ExitCode)
+		}
+		// Verify there's no "passed" field by checking the raw JSON.
+		if strings.Contains(stdout.String(), `"passed"`) {
+			t.Errorf("expected no `passed` field in run output (loop-driver policy): %s", stdout.String())
+		}
+	})
+}
+
+func TestCmdSensors_Run_Files(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installListTestHarness(t, home, "sh", `{
+		"name": "sh",
+		"version": "0.1.0",
+		"sensors": {
+			"reports": {
+				"source": {"files": ["reports/*.txt"]},
+				"output": {"format": "text"}
+			}
+		}
+	}`)
+
+	work := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(work, "reports"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(work, "reports", "a.txt"), []byte("alpha"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(work, "reports", "b.txt"), []byte("bravo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := cmdSensorsTo([]string{"run", "sh", "reports", "--cwd", work}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdSensorsTo: %v", err)
+	}
+	var r sensorRunResult
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, stdout.String())
+	}
+	if len(r.Output.Files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(r.Output.Files))
+	}
+	if r.Output.Files[0].Content != "alpha" {
+		t.Errorf("first file content = %q", r.Output.Files[0].Content)
+	}
+
+	// --no-content suppresses content but keeps size/path
+	stdout.Reset()
+	if err := cmdSensorsTo([]string{"run", "sh", "reports", "--cwd", work, "--no-content"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("--no-content: %v", err)
+	}
+	var r2 sensorRunResult
+	if err := json.Unmarshal(stdout.Bytes(), &r2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if r2.Output.Files[0].Content != "" {
+		t.Errorf("expected no content with --no-content")
+	}
+	if r2.Output.Files[0].Size != 5 {
+		t.Errorf("expected size = 5, got %d", r2.Output.Files[0].Size)
+	}
+}
+
+func TestCmdSensors_Run_FocusReturnsResolvedPayload(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installListTestHarness(t, home, "sh", sensorHarnessJSON)
+
+	var stdout bytes.Buffer
+	if err := cmdSensorsTo([]string{"run", "sh", "sec"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdSensorsTo: %v", err)
+	}
+	var r sensorRunResult
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if r.Kind != "focus" {
+		t.Errorf("Kind = %q", r.Kind)
+	}
+	if r.Output.Focus == nil || r.Output.Focus.Prompt != "audit the diff" {
+		t.Errorf("expected resolved focus, got %+v", r.Output.Focus)
+	}
+	if r.Output.Note == "" {
+		t.Errorf("expected note explaining ynh does not invoke agent, got empty")
+	}
+}
+
+func TestRoleField_ValidatesAndSurfacesInLs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installListTestHarness(t, home, "sh", `{
+		"name": "sh",
+		"version": "0.1.0",
+		"sensors": {
+			"verify": {
+				"role": "convergence-verifier",
+				"source": {"command": "true"},
+				"output": {"format": "text"}
+			}
+		}
+	}`)
+
+	var stdout bytes.Buffer
+	if err := cmdSensorsTo([]string{"ls", "sh", "--format", "json"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdSensorsTo: %v", err)
+	}
+	var entries []sensorListEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Role != "convergence-verifier" {
+		t.Errorf("expected role=convergence-verifier in ls output: %+v", entries)
 	}
 }

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -12,6 +12,7 @@
   * [Hooks](hooks.md)
   * [MCP Servers](mcp.md)
   * [Profiles](profiles.md)
+  * [Sensors](sensors.md)
   * [Namespacing](namespacing.md)
   * [Vendor Support](vendors.md)
 
@@ -49,6 +50,7 @@
   * [15. Registry & Discovery](tutorial/07-registry-and-discovery.md)
   * [16. Docker Images](tutorial/09-docker-image.md)
   * [17. Namespacing & Migration](tutorial/18-namespacing-and-migration.md)
+  * [18. Sensors](tutorial/19-sensors.md)
 
 * **Project**
   * [Migrating to 0.2](migration.md)

--- a/docs/harness-engineering.md
+++ b/docs/harness-engineering.md
@@ -21,11 +21,12 @@ And three regulation categories:
 
 ## Where YNH Fits
 
-YNH covers the **guide layer** thoroughly:
+YNH covers the **guide layer** thoroughly and **declares** the sensor layer:
 
 | Harness Concept | YNH Implementation |
 |-----------------|-------------------|
 | Feedforward Guides | Skills, rules, instructions, agents |
+| Feedback Sensors (declared) | `sensors` block — observation surfaces a loop driver consumes |
 | Harness Templates | A harness bundles guides for a use case |
 | Vendor Abstraction | Single harness → Claude/Cursor/Codex layouts |
 | Composition | `includes` (external Git) + `delegates_to` (subagents) |
@@ -33,7 +34,7 @@ YNH covers the **guide layer** thoroughly:
 | Agent Skills Standard | Native [agentskills.io](https://agentskills.io) support |
 | Progressive Disclosure | Skills use catalog → instructions → resources loading |
 
-YNH does **not** include sensors (linters, test runners, CI/CD). These are well-served by existing tools. YNH declares what the harness needs; vendor hook systems and CI pipelines execute it.
+YNH stops at the **runtime loop layer**. It declares both guides (artifacts) and observation surfaces (sensors), and it can mechanically execute an individual sensor on demand via `ynh sensors run`. Orchestration — when to run sensors, what counts as pass, when to stop iterating — belongs to an external loop driver (CI, an orchestrator, a custom tool). See [Sensors](sensors.md) for the full contract.
 
 ### Hooks: Bridge to Feedback Sensors
 
@@ -71,7 +72,22 @@ A YNH harness template can include:
 | Commands | Slash commands / workflows | Feedforward Guide |
 | Instructions | Project-level context (AGENTS.md) | Feedforward Guide |
 | Hooks | Vendor hook declarations | Bridge to Sensors |
+| Sensors | Observation surfaces (declared, not orchestrated) | Feedback Sensor (declared) |
 | MCP Servers | Tool dependencies | Tool Registry |
+
+## Design Stance — Declarative-First, Vendor-Neutral
+
+Two architectural choices constrain everything else and explain why ynh's surface looks the way it does.
+
+**Declarative-first.** A ynh harness is configuration, not code. The manifest emits artifacts and declarations; it never executes the agent loop, mutates session state at runtime, or registers behaviour dynamically. Anything that requires a live runtime — dynamic tool registration, in-process event subscription, mid-session mutation, custom UI — belongs to the runtime that runs the agent, not to the harness.
+
+**Vendor-neutral.** The feature surface is bounded by what is portable across every supported vendor. Hook events, MCP semantics, assembly behaviour, and sensor contracts are all chosen to translate cleanly into each target. Restraint here — a small canonical hook vocabulary instead of a rich one, declared sensors instead of executable observers — is the cost of working everywhere.
+
+**Corollary: structure where prose would suffice in a single runtime.** A runtime that owns its agent loop can drive feedback through prose instructions alone — the runtime obeys its own conventions. ynh cannot. The loop is run by an external consumer (CI, an orchestrator, another tool) that has no way to discover what the harness exposes unless it is declared. Sensors formalise what would otherwise live as informal prose; that formality is the price of portability.
+
+**What this rules out.** Programmatic extensions in the manifest. Runtime hooks beyond the canonical four. Live mutation of artifacts after assembly. A ynh-owned loop driver. These are not gaps to be filled; they are deliberate refusals that protect the portability guarantee.
+
+**What this rules in.** A small, stable, machine-readable surface that any runtime — interactive vendor CLI, headless CI job, custom orchestrator — can consume in the same way. The harness encodes intent; runtimes provide capability.
 
 ## Standards Alignment
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -177,8 +177,13 @@ When writing hook scripts for use across vendors:
 4. **Keep scripts idempotent** — hooks may fire multiple times per session.
 5. **Use absolute paths** — the working directory during hook execution varies by vendor.
 
+## Pairing with Sensors
+
+Hooks fire mid-session (push) and can produce artifacts that [sensors](sensors.md) declare a contract over (pull). The most common production pattern is `after_tool` writing a results file that a `files`-sourced sensor reads — implicit coupling by shared file path. See [Sensors §"Relationship to hooks"](sensors.md#relationship-to-hooks) for the full push/pull comparison and the canonical pairing pattern.
+
 ## See Also
 
 - [Tutorial 4: Hooks](tutorial/10-hooks.md) — step-by-step walkthrough
+- [Sensors](sensors.md) — observation surfaces a loop driver consumes
 - [Harness Engineering](harness-engineering.md) — how hooks bridge guides to sensors
 - [Vendor Support](vendors.md) — vendor capabilities and differences

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -140,8 +140,11 @@ Validation runs across all profiles in one pass, reporting errors with the profi
 Error: profile "ci": hooks.before_tool[0]: missing "command" field
 ```
 
+A profile cannot override or add sensors — sensors are observation declarations, not runtime context, and live only at the top level. An [inline focus inside a sensor](sensors.md#focus) can name a profile, but the sensor itself is profile-independent.
+
 ## See Also
 
 - [Hooks](hooks.md) — hook format and vendor translation
 - [MCP Servers](mcp.md) — MCP server format and vendor translation
+- [Sensors](sensors.md) — observation surfaces declared by the harness
 - [Vendor Support](vendors.md) — vendor capabilities and differences

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -46,6 +46,9 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | `ynh include add <harness> <url>` | `--path`, `--pick`, `--ref`, `--replace` |
 | `ynh include remove <harness> <url>` | `--path` |
 | `ynh include update <harness> <url>` | `--from-path`, `--path`, `--pick`, `--ref` |
+| `ynh sensors ls <harness>` | `--format <text\|json>` |
+| `ynh sensors show <harness> <name>` | `--format <text\|json>` |
+| `ynh sensors run <harness> <name>` | `--cwd <dir>`, `--no-content` |
 | `ynh sources add <path>` | `--name`, `--description` |
 | `ynh sources list` | `--format <text\|json>` |
 | `ynh sources remove <name>` | |
@@ -82,7 +85,10 @@ Commands that take `--format json` emit machine-readable output conforming to [S
 
 | Command | Structured fields |
 |---------|-------------------|
-| `ynd compose` | Composed harness: `name`, `version`, `description`, `default_vendor`, `artifacts` (with source), `includes`, `delegates_to`, `hooks`, `mcp_servers`, `profiles`, `focuses`, `counts` |
+| `ynd compose` | Composed harness: `name`, `version`, `description`, `default_vendor`, `artifacts` (with source), `includes`, `delegates_to`, `hooks`, `mcp_servers`, `profiles`, `focuses`, `sensors`, `counts` |
+| `ynh sensors ls <harness>` | Array of sensor summaries: `name`, `category`, `role`, `source_kind`, `format`, `inline_focus` (bool) — see [Sensors](sensors.md) |
+| `ynh sensors show <harness> <name>` | Resolved sensor object with inline-focus expansion |
+| `ynh sensors run <harness> <name>` | Sensor run result: `kind`, `exit_code`, `duration_ms`, `output` (raw signal — no `passed` field; pass/fail is loop-driver policy) |
 | `ynh fork <name>` | Envelope (`capabilities`, `ynh_version`, `name`, `path`, `installed_from`) — see [ynh fork output](#ynh-fork-output) below |
 | `ynh info <name>` | Envelope (`capabilities`, `ynh_version`, `harness`) wrapping a single harness object — see [Envelope and harness fields](#envelope-and-harness-fields) below |
 | `ynh ls` | Envelope (`capabilities`, `ynh_version`, `harnesses`) wrapping an array of harness objects — same shape as `ynh info`, plus `artifacts`, minus `manifest` |

--- a/docs/schema/plugin.schema.json
+++ b/docs/schema/plugin.schema.json
@@ -80,6 +80,11 @@
           "type": "string",
           "enum": ["maintainability", "architecture", "behaviour"]
         },
+        "role": {
+          "description": "Optional role hint for loop drivers. regular = run between turns; convergence-verifier = the loop's done-check; stuck-recovery = invoked when the stuckness watchdog fires. Pure metadata — ynh does not enforce semantics.",
+          "type": "string",
+          "enum": ["regular", "convergence-verifier", "stuck-recovery"]
+        },
         "source": { "$ref": "#/$defs/sensor_source" },
         "output": { "$ref": "#/$defs/sensor_output" }
       }

--- a/docs/schema/plugin.schema.json
+++ b/docs/schema/plugin.schema.json
@@ -62,9 +62,78 @@
           "prompt": { "type": "string", "minLength": 1 }
         }
       }
+    },
+    "sensors": {
+      "description": "Named observation surfaces declared by the harness. ynh declares; loop drivers run them. Each sensor is a role declaration over existing primitives — no new artifact type.",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/sensor" }
     }
   },
   "$defs": {
+    "sensor": {
+      "type": "object",
+      "required": ["source", "output"],
+      "additionalProperties": false,
+      "properties": {
+        "category": {
+          "description": "Fowler bucket — free metadata for loop-driver triage.",
+          "type": "string",
+          "enum": ["maintainability", "architecture", "behaviour"]
+        },
+        "source": { "$ref": "#/$defs/sensor_source" },
+        "output": { "$ref": "#/$defs/sensor_output" }
+      }
+    },
+    "sensor_source": {
+      "description": "Strict one-of: files | command | focus. The set field discriminates the sensor type.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "files": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "command": { "type": "string", "minLength": 1 },
+        "focus": {
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            {
+              "type": "object",
+              "required": ["prompt"],
+              "additionalProperties": false,
+              "properties": {
+                "profile": { "type": "string" },
+                "prompt": { "type": "string", "minLength": 1 }
+              }
+            }
+          ]
+        }
+      },
+      "oneOf": [
+        { "required": ["files"] },
+        { "required": ["command"] },
+        { "required": ["focus"] }
+      ]
+    },
+    "sensor_output": {
+      "type": "object",
+      "required": ["format"],
+      "additionalProperties": false,
+      "properties": {
+        "format": {
+          "description": "Freeform format identifier — pass-through to loop driver. Conventional names: json, junit-xml, lcov-summary, sarif, markdown, text, ndjson.",
+          "type": "string",
+          "minLength": 1
+        },
+        "channel": {
+          "description": "Where the result emerges. Conventional values: stdout, stdout+exit, file, files. Defaults are inferable from source.",
+          "type": "string",
+          "minLength": 1
+        },
+        "path": { "type": "string" }
+      }
+    },
     "hooks": {
       "type": "object",
       "propertyNames": {

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -1,0 +1,378 @@
+# Sensors
+
+Sensors are named **observation surfaces** declared in a harness manifest. A loop driver — CI, an orchestrator, a custom tool — runs them between agent turns and feeds the results back into the next turn. ynh declares; the loop driver runs.
+
+A sensor is not a new artifact type. There is no `sensors/` directory and no `SENSOR.md` file. A sensor is a role declaration layered onto the primitives ynh already has (focus, hooks, files on disk). The schema addition gives loop drivers a discoverable contract — *what* observation is available, *where* its result lives, and *what shape* it's in — without ynh taking on any runtime loop responsibility.
+
+## Why declare them
+
+A coding agent that runs in a loop needs feedback between iterations: did the build pass, are the tests still green, did anything new get flagged by the linter, does an LLM judge think the change is adequate. Each of those signals already exists somewhere — as a CLI command, a file on disk, an LLM prompt. Sensors give that surface a name, a format, and a CLI handle so any orchestrator can consume it the same way.
+
+Without sensors, a loop driver has to be hand-coded against a specific harness: "for this project run `make check`, for that one run `npm test`". With sensors, the harness declares its observation contract and loop drivers consume it generically.
+
+## Schema
+
+Sensors live under the top-level `sensors` key in `.ynh-plugin/plugin.json`. Each sensor name maps to a declaration:
+
+```json
+{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "my-harness",
+  "version": "0.1.0",
+  "focus": {
+    "infer-vulns": { "prompt": "Identify high-severity vulnerabilities in the changed code" }
+  },
+  "sensors": {
+    "build": {
+      "category": "maintainability",
+      "source": { "command": "make check" },
+      "output": { "format": "text" }
+    },
+    "tests": {
+      "category": "behaviour",
+      "source": { "files": ["test-reports/**/*.xml"] },
+      "output": { "format": "junit-xml" }
+    },
+    "security-scan": {
+      "category": "behaviour",
+      "source": { "focus": "infer-vulns" },
+      "output": { "format": "markdown" }
+    },
+    "coverage-judge": {
+      "role": "convergence-verifier",
+      "source": {
+        "focus": {
+          "profile": "ci",
+          "prompt": "Assess if test coverage is adequate for the changed surface area"
+        }
+      },
+      "output": { "format": "markdown" }
+    }
+  }
+}
+```
+
+### Field reference
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `category` | enum | No | Fowler bucket: `maintainability`, `architecture`, `behaviour`. Free metadata for loop-driver triage. |
+| `role` | enum | No | Role hint: `regular` (default), `convergence-verifier`, `stuck-recovery`. Pure metadata — ynh does not enforce semantics. Loop drivers filter sensors by role to discover which one is the loop's done-check or the recovery sensor. |
+| `source` | object | **Yes** | Strict one-of: `files` \| `command` \| `focus`. Discriminates the sensor type. |
+| `output` | object | **Yes** | Where the sensor's result lives and what shape it's in. |
+
+## Source variants
+
+Exactly one of `files`, `command`, or `focus` must be set. The set field discriminates the sensor type — there is no separate `kind` field.
+
+### `files`
+
+A glob/path list of pre-existing artifacts to read (test reports, coverage files, SARIF dumps). Pure pass-through — ynh does not resolve, expand, or verify globs at validate time; it does so at `ynh sensors run` time.
+
+```json
+"coverage": {
+  "source": { "files": ["coverage/lcov.info", "coverage/*.json"] },
+  "output": { "format": "lcov-summary" }
+}
+```
+
+Use this when something else (a hook, a CI step, a human) already produces the artifact and the sensor just needs to surface it.
+
+### `command`
+
+A shell command. The loop driver runs it with the cwd of its choosing and captures stdout, stderr, and exit code.
+
+```json
+"build": {
+  "source": { "command": "make check" },
+  "output": { "format": "text", "channel": "stdout+exit" }
+}
+```
+
+Use this for build/lint/test/typecheck — anything where running a command IS the observation. Same script can be hooked at `after_tool` for in-session enforcement *and* declared as a sensor for between-turn observation; the two are not redundant.
+
+### `focus`
+
+An agent-driven sensor. The string form references an existing top-level `focus` entry by name; the object form inlines a focus.
+
+```json
+"security-scan": {
+  "source": { "focus": "infer-vulns" },
+  "output": { "format": "markdown" }
+}
+```
+
+Or inline:
+
+```json
+"coverage-judge": {
+  "source": {
+    "focus": {
+      "profile": "ci",
+      "prompt": "Assess if test coverage is adequate for the changed surface area"
+    }
+  },
+  "output": { "format": "markdown" }
+}
+```
+
+Inline focuses are scoped to the sensor that declares them — they do **not** appear in `ynh info` Focus list, and they are not selectable via `--focus` or `YNH_FOCUS`. Use a string reference when the same focus is invoked both standalone and as a sensor; use inline when the focus exists only to drive this sensor.
+
+When the loop driver runs a focus-sourced sensor via `ynh sensors run`, ynh returns the resolved focus declaration; the loop driver invokes the agent runtime itself. ynh owns no agent-invocation surface.
+
+## Output contract
+
+```json
+"output": {
+  "format": "junit-xml",
+  "channel": "files",
+  "path": "test-reports/junit.xml"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `format` | string | **Yes** | Freeform format identifier. Pass-through to the loop driver. |
+| `channel` | string | No | Where the result emerges. Defaults are inferred from `source`. |
+| `path` | string | No | Relevant when `channel=file`. |
+
+### Why `format` is freeform
+
+The space of feedback formats is moving fast — SARIF, NDJSON event streams, LLM-emitted JSON-schemas, vendor-specific report formats. ynh does not maintain a vocabulary; it stores whatever string the harness author and the loop driver agree on. Conventional names you'll see: `json`, `junit-xml`, `lcov-summary`, `sarif`, `markdown`, `text`, `ndjson`. Coining a new one is fine.
+
+### Channel inference
+
+If `channel` is omitted, `ynh sensors run` infers it from the source kind:
+
+| Source | Default channel |
+|---|---|
+| `files` | `files` |
+| `command` | `stdout+exit` |
+| `focus` | `stdout` |
+
+## Validation
+
+`ynd validate` checks:
+
+- Each sensor name is non-empty.
+- `source` has exactly one of `files`, `command`, `focus`.
+- `source.files` is a non-empty array of non-empty strings.
+- `source.command` is a non-empty string.
+- `source.focus` (string form) references a defined top-level `focus.<name>`.
+- `source.focus` (object form) has a non-empty `prompt`; if `profile` is set, it resolves to a defined profile.
+- `output.format` is non-empty.
+- `category`, if set, is one of the three Fowler enum values.
+- `role`, if set, is one of `regular`, `convergence-verifier`, `stuck-recovery`.
+- Unknown fields inside a sensor are rejected.
+
+Errors are prefixed with the sensor name:
+
+```
+sensor "coverage": source must have exactly one of files, command, focus
+sensor "security-scan": source.focus references undefined focus "infer-vulns"
+```
+
+## Composition
+
+### Includes — root-only
+
+Sensors declared in *included* harnesses are dropped during assembly, identical to the existing rule for hooks. Composed harnesses cannot silently inject observation surfaces the root harness author did not declare. If an included harness needs a sensor, copy its declaration into the root harness's `plugin.json`.
+
+### Profiles — out of scope for v1
+
+Profiles do **not** override or add sensors in v1. Sensors are observation declarations, not runtime context. If a real use case emerges, it will be revisited in a follow-up.
+
+### Focus — referenced, not modified
+
+A sensor can reference a top-level focus or inline its own. It cannot mutate a focus. Inline focuses live only as the sensor's source.
+
+## CLI
+
+### `ynh sensors ls <harness>`
+
+List declared sensors with category, role, source kind, and format. Plain text by default; `--format json` for machine consumption.
+
+```
+$ ynh sensors ls my-harness
+NAME              CATEGORY          SOURCE     FORMAT
+build             maintainability   command    text
+coverage          maintainability   files      lcov-summary
+coverage-judge    behaviour         focus*     markdown
+security-scan     behaviour         focus      markdown
+tests             behaviour         files      junit-xml
+
+* = inline focus
+```
+
+JSON form returns an array of summary objects — the canonical machine-readable form a loop driver consumes:
+
+```json
+[
+  { "name": "build", "category": "maintainability", "source_kind": "command", "format": "text" },
+  { "name": "coverage-judge", "role": "convergence-verifier", "source_kind": "focus", "format": "markdown", "inline_focus": true }
+]
+```
+
+### `ynh sensors show <harness> <name>`
+
+Print the fully-resolved sensor block as JSON. Inline focuses are kept inline; string-referenced focuses are expanded so the consumer gets a self-contained payload:
+
+```json
+{
+  "name": "security-scan",
+  "category": "behaviour",
+  "source": {
+    "focus": {
+      "name": "infer-vulns",
+      "prompt": "Identify high-severity vulnerabilities in the changed code",
+      "inline": false
+    }
+  },
+  "output": { "format": "markdown" }
+}
+```
+
+### `ynh sensors run <harness> <name>`
+
+Mechanically execute a sensor and emit a JSON result. There is no `passed` boolean — ynh returns raw exit codes, output, and file contents. Pass/fail thresholds are loop-driver policy.
+
+For a `command` sensor:
+
+```json
+{
+  "name": "build",
+  "kind": "command",
+  "exit_code": 0,
+  "duration_ms": 1247,
+  "output": {
+    "format": "text",
+    "channel": "stdout+exit",
+    "stdout": "...",
+    "stderr": ""
+  }
+}
+```
+
+For a `files` sensor, the result includes file contents (or just metadata with `--no-content`). For a `focus` sensor, ynh returns the resolved focus declaration with a note explaining the loop driver invokes the agent runtime itself.
+
+Flags:
+- `--cwd <dir>` — working directory for `command` sensors and base for relative `files` globs. Defaults to current directory.
+- `--no-content` — omit file contents for `files` sensors. Use when only metadata (path, size) is needed.
+
+## Relationship to hooks
+
+Hooks and sensors are complementary, not overlapping. Both can run shell commands; the difference is who pulls the trigger and who consumes the result.
+
+| | Hooks | Sensors |
+|---|---|---|
+| Direction | **Push** — vendor runtime fires them | **Pull** — loop driver invokes them |
+| When | Mid-session, on lifecycle events | Between iterations, on demand |
+| Purpose | Enforce / observe *during* a turn | Surface signal *for the next* turn |
+| Failure mode | Can block the action (exit 2) | Reports state; loop driver decides policy |
+
+A mature harness uses both. Hooks for in-session guardrails (block `git push --force`, run formatter on save). Sensors for between-turn judgment (coverage adequate? new high-severity vulns?).
+
+### Canonical pattern: hook emits → sensor consumes
+
+The most common integration is a hook that produces an artifact a sensor declares as its source:
+
+```json
+{
+  "hooks": {
+    "after_tool": [
+      { "matcher": "Edit|Write", "command": "./scripts/run-lint.sh > .lint-results.json" }
+    ]
+  },
+  "sensors": {
+    "lint": {
+      "category": "maintainability",
+      "source": { "files": [".lint-results.json"] },
+      "output": { "format": "json" }
+    }
+  }
+}
+```
+
+The hook is the runtime mechanism that produces the data; the sensor is the declarative contract over reading it. Coupling is **by shared file path** — implicit, no schema link needed.
+
+### Same script, different driver
+
+A sensor with `source.command: "make check"` and an `after_tool` hook running `make check` invoke the same program. The difference is who pulls the trigger. Authors should not feel forced to pick one — both can coexist when the script needs to fire both in-session (hook) and on-demand (sensor).
+
+## Consuming sensors (for loop-driver authors)
+
+The intended consumption pattern:
+
+```bash
+# Discover what's declared
+ynh sensors ls my-harness --format json
+
+# For each sensor the loop wants to run:
+result=$(ynh sensors run my-harness build)
+exit_code=$(echo "$result" | jq -r '.exit_code')
+output=$(echo "$result" | jq -r '.output.stdout')
+
+# Identify the convergence sensor by role:
+verifier=$(ynh sensors ls my-harness --format json |
+           jq -r '.[] | select(.role == "convergence-verifier") | .name')
+```
+
+ynh does **not** ship a loop driver. Orchestration policy — when to run sensors, how to weight them, when the loop is done — belongs to the layer above ynh. See `docs/harness-engineering.md` for the architectural framing.
+
+## Examples
+
+### Go project
+
+```json
+{
+  "sensors": {
+    "build": {
+      "category": "maintainability",
+      "source": { "command": "go build ./..." },
+      "output": { "format": "text" }
+    },
+    "test": {
+      "category": "behaviour",
+      "source": { "command": "go test -race -coverprofile=coverage.out ./..." },
+      "output": { "format": "text" }
+    },
+    "coverage": {
+      "source": { "files": ["coverage.out"] },
+      "output": { "format": "go-coverage" }
+    },
+    "security": {
+      "category": "behaviour",
+      "role": "convergence-verifier",
+      "source": {
+        "focus": { "prompt": "Are there any security regressions in the diff vs main?" }
+      },
+      "output": { "format": "markdown" }
+    }
+  }
+}
+```
+
+### Node project
+
+```json
+{
+  "sensors": {
+    "lint": {
+      "source": { "command": "npm run lint --silent" },
+      "output": { "format": "text" }
+    },
+    "tests": {
+      "source": { "files": ["junit.xml"] },
+      "output": { "format": "junit-xml" }
+    }
+  }
+}
+```
+
+## See also
+
+- [Hooks](hooks.md)
+- [Profiles](profiles.md)
+- [Focus](tutorial/14-focus.md)
+- [Harness engineering](harness-engineering.md)
+- [CLI structured output](cli-structured.md)

--- a/docs/tutorial/01-first-harness.md
+++ b/docs/tutorial/01-first-harness.md
@@ -181,6 +181,9 @@ Profiles:
 
 Focus:
   (none)
+
+Sensors:
+  (none)
 ```
 
 Check the launcher script:

--- a/docs/tutorial/10-hooks.md
+++ b/docs/tutorial/10-hooks.md
@@ -235,6 +235,8 @@ rm -rf /tmp/ynh-tutorial
 - Hook scripts should exit with code 2 to block actions and include remediation instructions
 - `ynd diff` compares the assembled output across vendors side by side
 
+Hooks often pair with sensors — a hook produces an artifact mid-session that a sensor declares a contract over. See [Tutorial 19: Sensors](19-sensors.md).
+
 ## Next
 
 [Tutorial 5: MCP Servers](tutorial/11-mcp-servers.md) — declare tool dependencies that vendors load automatically.

--- a/docs/tutorial/14-focus.md
+++ b/docs/tutorial/14-focus.md
@@ -1,6 +1,6 @@
 # Tutorial 14: Focus
 
-Define named focus entries that combine a profile with a prompt for repeatable, non-interactive AI execution. Focus entries are the bridge between harness configuration and CI automation.
+Define named focus entries that combine a profile with a prompt for repeatable, non-interactive AI execution. Focus entries are the bridge between harness configuration and CI automation. They can also serve as the source of an agent-driven [sensor](../sensors.md#focus) — referenced by name or inlined inside the sensor.
 
 ## Prerequisites
 

--- a/docs/tutorial/15-project-local-config.md
+++ b/docs/tutorial/15-project-local-config.md
@@ -98,6 +98,7 @@ The project-local config pattern works well with focus entries (Tutorial 14) for
 
 ```json
 {
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
   "default_vendor": "claude",
   "focus": {
     "review": { "prompt": "Review staged changes" },

--- a/docs/tutorial/19-sensors.md
+++ b/docs/tutorial/19-sensors.md
@@ -1,0 +1,279 @@
+# Tutorial 19: Sensors
+
+Declare observation surfaces that a loop driver — CI, an orchestrator, a custom tool — runs between agent turns. ynh declares; the loop driver runs.
+
+This tutorial walks through every sensor source variant, the validation rules, and the discovery surface a loop driver consumes. It does **not** demonstrate a working loop driver — that is out of scope for ynh. See [Sensors reference](../sensors.md) for the full schema and consumer guide.
+
+## Prerequisites
+
+```bash
+rm -rf /tmp/ynh-tutorial
+ynh uninstall sensor-demo 2>/dev/null
+
+mkdir -p /tmp/ynh-tutorial/sensor-harness/.ynh-plugin
+```
+
+## T19.1: A `files` sensor
+
+The simplest sensor reads pre-existing artifacts. Create a harness that declares a coverage sensor:
+
+```bash
+cat > /tmp/ynh-tutorial/sensor-harness/.ynh-plugin/plugin.json << 'EOF'
+{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-demo",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "sensors": {
+    "coverage": {
+      "category": "maintainability",
+      "source": { "files": ["coverage/lcov.info"] },
+      "output": { "format": "lcov-summary" }
+    }
+  }
+}
+EOF
+
+ynd validate /tmp/ynh-tutorial/sensor-harness
+```
+
+Expected output: `valid`.
+
+## T19.2: A `command` sensor
+
+Add a sensor that runs a shell command. Edit the manifest:
+
+```bash
+cat > /tmp/ynh-tutorial/sensor-harness/.ynh-plugin/plugin.json << 'EOF'
+{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-demo",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "sensors": {
+    "build": {
+      "category": "maintainability",
+      "source": { "command": "make check" },
+      "output": { "format": "text" }
+    },
+    "coverage": {
+      "category": "maintainability",
+      "source": { "files": ["coverage/lcov.info"] },
+      "output": { "format": "lcov-summary" }
+    }
+  }
+}
+EOF
+
+ynd validate /tmp/ynh-tutorial/sensor-harness
+```
+
+## T19.3: A `focus`-referencing sensor
+
+Sensors can reuse a top-level focus. Add a focus and reference it:
+
+```bash
+cat > /tmp/ynh-tutorial/sensor-harness/.ynh-plugin/plugin.json << 'EOF'
+{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-demo",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "focus": {
+    "audit-vulns": {
+      "prompt": "Identify any high-severity vulnerabilities in the diff vs main."
+    }
+  },
+  "sensors": {
+    "build": {
+      "source": { "command": "make check" },
+      "output": { "format": "text" }
+    },
+    "security": {
+      "category": "behaviour",
+      "source": { "focus": "audit-vulns" },
+      "output": { "format": "markdown" }
+    }
+  }
+}
+EOF
+
+ynd validate /tmp/ynh-tutorial/sensor-harness
+```
+
+## T19.4: An inline-focus sensor
+
+Sometimes a focus exists only to drive one sensor. Inline it directly:
+
+```bash
+cat > /tmp/ynh-tutorial/sensor-harness/.ynh-plugin/plugin.json << 'EOF'
+{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-demo",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "focus": {
+    "audit-vulns": {
+      "prompt": "Identify any high-severity vulnerabilities in the diff vs main."
+    }
+  },
+  "sensors": {
+    "build": {
+      "source": { "command": "make check" },
+      "output": { "format": "text" }
+    },
+    "security": {
+      "source": { "focus": "audit-vulns" },
+      "output": { "format": "markdown" }
+    },
+    "coverage-judge": {
+      "role": "convergence-verifier",
+      "source": {
+        "focus": {
+          "prompt": "Assess if test coverage is adequate for the changed surface area."
+        }
+      },
+      "output": { "format": "markdown" }
+    }
+  }
+}
+EOF
+
+ynd validate /tmp/ynh-tutorial/sensor-harness
+```
+
+Inline focuses are scoped to the sensor that declares them. Install the harness and confirm the inline focus does **not** appear in the top-level Focus list:
+
+```bash
+ynh install /tmp/ynh-tutorial/sensor-harness
+ynh info sensor-demo | grep -A 3 'Focus:'
+```
+
+You should see only `audit-vulns` listed under Focus — `coverage-judge` is a sensor, and its inline focus is hidden inside the sensor declaration.
+
+## T19.5: Discovery — `ynh sensors ls/show`
+
+Loop drivers discover what's declared via the CLI:
+
+```bash
+ynh sensors ls sensor-demo
+```
+
+Expected (trimmed):
+
+```
+NAME              CATEGORY          SOURCE     FORMAT
+build             -                 command    text
+coverage-judge    -                 focus*     markdown
+security          -                 focus      markdown
+
+* = inline focus
+```
+
+The JSON form is what a loop driver actually consumes:
+
+```bash
+ynh sensors ls sensor-demo --format json
+```
+
+To resolve a single sensor with its focus expanded into a self-contained payload:
+
+```bash
+ynh sensors show sensor-demo security
+```
+
+The string focus reference (`"focus": "audit-vulns"`) is expanded inline so the consumer doesn't have to look up the focus declaration separately.
+
+## T19.6: Validation — every rule produces a clear error
+
+Demonstrate one validation rule. Set two source fields:
+
+```bash
+cat > /tmp/ynh-tutorial/sensor-harness/.ynh-plugin/plugin.json << 'EOF'
+{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-demo",
+  "version": "0.1.0",
+  "sensors": {
+    "broken": {
+      "source": { "command": "x", "files": ["a"] },
+      "output": { "format": "text" }
+    }
+  }
+}
+EOF
+
+ynd validate /tmp/ynh-tutorial/sensor-harness
+```
+
+Expected error:
+
+```
+sensor "broken": source must have exactly one of files, command, focus
+```
+
+## T19.7: Hook–sensor pairing
+
+The most common production pattern: a hook produces an artifact, a sensor declares its contract over that artifact. Re-link the harness to the previous sensors plus a hook:
+
+```bash
+cat > /tmp/ynh-tutorial/sensor-harness/.ynh-plugin/plugin.json << 'EOF'
+{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-demo",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "hooks": {
+    "after_tool": [
+      { "matcher": "Edit|Write", "command": "./scripts/run-lint.sh > .lint-results.json" }
+    ]
+  },
+  "sensors": {
+    "lint": {
+      "category": "maintainability",
+      "source": { "files": [".lint-results.json"] },
+      "output": { "format": "json" }
+    }
+  }
+}
+EOF
+
+ynd validate /tmp/ynh-tutorial/sensor-harness
+```
+
+The hook produces the file mid-session; the sensor consumes it between iterations. Coupling is by shared file path — implicit, no schema link needed.
+
+## T19.8: Round-trip via `ynd export`
+
+Sensors round-trip through `ynd export`. Re-install with the latest manifest:
+
+```bash
+ynh install /tmp/ynh-tutorial/sensor-harness
+ynd export --harness sensor-demo --to /tmp/ynh-tutorial/exported
+grep -A 5 '"sensors"' /tmp/ynh-tutorial/exported/.ynh-plugin/plugin.json
+```
+
+The exported manifest preserves the sensors block faithfully.
+
+## T19.9: Cleanup
+
+```bash
+ynh uninstall sensor-demo
+rm -rf /tmp/ynh-tutorial
+```
+
+## What a loop driver does with this
+
+A loop driver wraps an agent runtime (Claude Code, Codex, etc.) and runs sensors between turns. Discovery is `ynh sensors ls --format json`; resolution is `ynh sensors show --format json`; execution is `ynh sensors run`. ynh emits raw signal — exit codes, output, file contents — and the loop driver turns that into pass/fail policy and feedback for the next turn.
+
+ynh ships no loop driver. See [Sensors reference §"Consuming sensors"](../sensors.md#consuming-sensors-for-loop-driver-authors) for the consumer pattern, and [harness engineering](../harness-engineering.md) for the architectural framing.
+
+## What you learned
+
+- A sensor is a role declaration over existing primitives — no new artifact type.
+- Three source variants: `files`, `command`, `focus` (string ref or inline).
+- Inline focuses are scoped to the sensor that declares them.
+- The discovery surface (`ls`, `show`) is the contract loop drivers consume.
+- Hooks and sensors are complementary — push vs pull, in-session vs between-turn.
+
+Hooks often pair with sensors — see [Tutorial 4 (Hooks)](10-hooks.md).

--- a/docs/tutorial/19-sensors.md
+++ b/docs/tutorial/19-sensors.md
@@ -206,9 +206,10 @@ EOF
 ynd validate /tmp/ynh-tutorial/sensor-harness
 ```
 
-Expected error:
+Expected error (the schema-level violation and the cross-field violation each emit one line):
 
 ```
+sensors/broken/source: 'oneOf' failed, subschemas 0, 1 matched
 sensor "broken": source must have exactly one of files, command, focus
 ```
 
@@ -243,17 +244,18 @@ ynd validate /tmp/ynh-tutorial/sensor-harness
 
 The hook produces the file mid-session; the sensor consumes it between iterations. Coupling is by shared file path — implicit, no schema link needed.
 
-## T19.8: Round-trip via `ynd export`
+## T19.8: Install round-trip preserves sensors
 
-Sensors round-trip through `ynd export`. Re-install with the latest manifest:
+Re-install the harness and confirm sensors still appear in the discovery surface:
 
 ```bash
 ynh install /tmp/ynh-tutorial/sensor-harness
-ynd export --harness sensor-demo --to /tmp/ynh-tutorial/exported
-grep -A 5 '"sensors"' /tmp/ynh-tutorial/exported/.ynh-plugin/plugin.json
+ynh sensors ls sensor-demo --format json | jq '.[] | .name'
 ```
 
-The exported manifest preserves the sensors block faithfully.
+Expected: each sensor name appears, one per line. Sensors flow from the source `plugin.json` through the install path into the on-disk harness directory and surface back through the discovery CLI unchanged.
+
+Note: `ynd export` produces vendor-native plugin formats (Claude/Cursor/Codex), and vendors have no concept of sensors today. Sensors live only in the ynh manifest and are consumed by loop drivers via `ynh sensors`. They are not part of vendor export.
 
 ## T19.9: Cleanup
 

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -38,6 +38,7 @@ Progressive tutorials from first steps to advanced configurations. Each tutorial
 | 12 | [Marketplace](tutorial/06-marketplace.md) | Generate marketplace indexes for team distribution |
 | 13 | [Registry & Discovery](tutorial/07-registry-and-discovery.md) | Search and install harnesses from curated registries |
 | 14 | [Docker Images](tutorial/09-docker-image.md) | Build harness appliance images for CI/CD |
+| 15 | [Sensors](tutorial/19-sensors.md) | Declare observation surfaces a loop driver consumes |
 
 ## Manual Test Plan
 

--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -442,6 +442,47 @@ rm -rf /tmp/ynh-bad-focus
 
 ---
 
+## Sensors
+
+### S1: Declare a command sensor and run it
+
+```bash
+mkdir -p /tmp/ynh-sensors/.ynh-plugin
+cat > /tmp/ynh-sensors/.ynh-plugin/plugin.json << 'EOF'
+{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-test",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "sensors": {
+    "build": {
+      "category": "maintainability",
+      "source": { "command": "echo built && exit 0" },
+      "output": { "format": "text" }
+    }
+  }
+}
+EOF
+ynd validate /tmp/ynh-sensors
+ynh install /tmp/ynh-sensors
+ynh sensors ls sensor-test
+ynh sensors run sensor-test build | jq '.exit_code, .output.stdout'
+ynh uninstall sensor-test
+rm -rf /tmp/ynh-sensors
+```
+
+Expected: `valid`, sensor listed in ls output, run result with `exit_code: 0` and stdout `"built\n"`. No `passed` field in run output.
+
+### S2: focus-source sensor returns resolved payload
+
+Re-run S1 with a focus-source sensor and verify `ynh sensors run` returns the resolved focus declaration plus a note that ynh does not invoke the agent runtime.
+
+### S3: Validation rejects two-source declaration
+
+`source` with both `command` and `files` set must error: `sensor "X": source must have exactly one of files, command, focus`.
+
+---
+
 ## Summary
 
 | Section | Tests |
@@ -462,5 +503,6 @@ rm -rf /tmp/ynh-bad-focus
 | Tutorial 14: Focus | 7 |
 | Tutorial 15: Project-Local Config | 4 |
 | Tutorial 16: Structured Output | 11 |
+| Sensors | 3 |
 | Edge Cases | 22 |
 | **Total** | **150** |

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -121,6 +121,7 @@ type Harness struct {
 	MCPServers    map[string]plugin.MCPServer
 	Profiles      map[string]plugin.Profile
 	Focuses       map[string]plugin.Focus
+	Sensors       map[string]plugin.Sensor
 	InstalledFrom *Provenance
 }
 
@@ -423,6 +424,9 @@ func LoadDir(dir string) (*Harness, error) {
 	if len(hj.Focuses) > 0 {
 		p.Focuses = hj.Focuses
 	}
+	if len(hj.Sensors) > 0 {
+		p.Sensors = hj.Sensors
+	}
 
 	// Provenance: prefer installed.json (new format), fall back to InstalledFrom in manifest (legacy).
 	if ins, err := plugin.LoadInstalledJSON(dir); err == nil {
@@ -604,6 +608,9 @@ func LoadFile(path string) (*Harness, error) {
 	}
 	if len(hj.Focuses) > 0 {
 		p.Focuses = hj.Focuses
+	}
+	if len(hj.Sensors) > 0 {
+		p.Sensors = hj.Sensors
 	}
 
 	return p, nil

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -23,7 +23,181 @@ type HarnessJSON struct {
 	MCPServers    map[string]MCPServer   `json:"mcp_servers,omitempty"`
 	Profiles      map[string]Profile     `json:"profiles,omitempty"`
 	Focuses       map[string]Focus       `json:"focus,omitempty"`
+	Sensors       map[string]Sensor      `json:"sensors,omitempty"`
 	InstalledFrom *ProvenanceMeta        `json:"installed_from,omitempty"`
+}
+
+// Sensor declares an observation surface — a feedforward signal a loop
+// driver consumes between agent turns. ynh declares; the loop driver runs.
+type Sensor struct {
+	Category string       `json:"category,omitempty"`
+	Source   SensorSource `json:"source"`
+	Output   SensorOutput `json:"output"`
+}
+
+// SensorSource is a strict one-of: files, command, or focus. Exactly one
+// must be set. Discriminated by structure, not labels.
+type SensorSource struct {
+	Files   []string  `json:"files,omitempty"`
+	Command string    `json:"command,omitempty"`
+	Focus   *FocusRef `json:"focus,omitempty"`
+}
+
+// Kind reports which source variant is set. Returns "" if none or
+// (impossibly, for a validated sensor) more than one.
+func (s SensorSource) Kind() string {
+	count := 0
+	kind := ""
+	if s.Files != nil {
+		count++
+		kind = "files"
+	}
+	if s.Command != "" {
+		count++
+		kind = "command"
+	}
+	if s.Focus != nil {
+		count++
+		kind = "focus"
+	}
+	if count != 1 {
+		return ""
+	}
+	return kind
+}
+
+// UnmarshalJSON enforces that exactly one of files, command, focus is set.
+func (s *SensorSource) UnmarshalJSON(data []byte) error {
+	type alias SensorSource
+	var raw alias
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&raw); err != nil {
+		return err
+	}
+	*s = SensorSource(raw)
+	if s.Kind() == "" {
+		return fmt.Errorf("source must have exactly one of files, command, focus")
+	}
+	return nil
+}
+
+// FocusRef is either a string (referring to a named top-level focus) or
+// an inline focus object.
+type FocusRef struct {
+	Name   string       // set when source.focus is a string reference
+	Inline *InlineFocus // set when source.focus is an inline object
+}
+
+// InlineFocus is a focus declared inline inside a sensor's source.
+// Inline focuses are not exposed via --focus or YNH_FOCUS — they live
+// only as the sensor's source.
+type InlineFocus struct {
+	Profile string `json:"profile,omitempty"`
+	Prompt  string `json:"prompt"`
+}
+
+// UnmarshalJSON accepts either a string ref or an inline focus object.
+func (f *FocusRef) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		if s == "" {
+			return fmt.Errorf("focus reference must not be empty")
+		}
+		f.Name = s
+		return nil
+	}
+	var inline InlineFocus
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&inline); err != nil {
+		return err
+	}
+	if inline.Prompt == "" {
+		return fmt.Errorf("inline focus must have a non-empty prompt")
+	}
+	f.Inline = &inline
+	return nil
+}
+
+// MarshalJSON emits the variant that is set.
+func (f FocusRef) MarshalJSON() ([]byte, error) {
+	if f.Inline != nil {
+		return json.Marshal(f.Inline)
+	}
+	return json.Marshal(f.Name)
+}
+
+// SensorOutput declares where a sensor's result lives and what shape it
+// has. format is a freeform pass-through identifier; ynh maintains no
+// vocabulary.
+type SensorOutput struct {
+	Format  string `json:"format"`
+	Channel string `json:"channel,omitempty"`
+	Path    string `json:"path,omitempty"`
+}
+
+// ValidSensorCategories lists the Fowler buckets a sensor's category may use.
+var ValidSensorCategories = map[string]bool{
+	"maintainability": true,
+	"architecture":    true,
+	"behaviour":       true,
+}
+
+// ValidateSensors checks each sensor's source/output/category and resolves
+// focus references against the supplied profile and focus name sets.
+// profileNames and focusNames may be nil if no cross-reference data is
+// available (callers should pass both to enable full validation).
+func ValidateSensors(sensors map[string]Sensor, profileNames, focusNames map[string]bool) []string {
+	var issues []string
+	for name, s := range sensors {
+		if name == "" {
+			issues = append(issues, "sensor name must not be empty")
+			continue
+		}
+		prefix := fmt.Sprintf("sensor %q:", name)
+		if s.Category != "" && !ValidSensorCategories[s.Category] {
+			issues = append(issues, fmt.Sprintf("%s category %q must be one of maintainability, architecture, behaviour", prefix, s.Category))
+		}
+		if s.Source.Kind() == "" {
+			issues = append(issues, fmt.Sprintf("%s source must have exactly one of files, command, focus", prefix))
+		} else {
+			switch s.Source.Kind() {
+			case "files":
+				if len(s.Source.Files) == 0 {
+					issues = append(issues, fmt.Sprintf("%s source.files must be a non-empty array", prefix))
+				}
+				for i, p := range s.Source.Files {
+					if p == "" {
+						issues = append(issues, fmt.Sprintf("%s source.files[%d] must be non-empty", prefix, i))
+					}
+				}
+			case "command":
+				if s.Source.Command == "" {
+					issues = append(issues, fmt.Sprintf("%s source.command must be a non-empty string", prefix))
+				}
+			case "focus":
+				if s.Source.Focus.Inline != nil {
+					if s.Source.Focus.Inline.Prompt == "" {
+						issues = append(issues, fmt.Sprintf("%s source.focus.prompt must not be empty", prefix))
+					}
+					if p := s.Source.Focus.Inline.Profile; p != "" && profileNames != nil && !profileNames[p] {
+						issues = append(issues, fmt.Sprintf("%s source.focus references unknown profile %q", prefix, p))
+					}
+				} else if s.Source.Focus.Name != "" && focusNames != nil && !focusNames[s.Source.Focus.Name] {
+					issues = append(issues, fmt.Sprintf("%s source.focus references undefined focus %q", prefix, s.Source.Focus.Name))
+				}
+			}
+		}
+		if s.Output.Format == "" {
+			issues = append(issues, fmt.Sprintf("%s output.format must not be empty", prefix))
+		}
+	}
+	return issues
 }
 
 // Focus is a named combination of profile + prompt for repeatable AI execution.

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -31,8 +31,18 @@ type HarnessJSON struct {
 // driver consumes between agent turns. ynh declares; the loop driver runs.
 type Sensor struct {
 	Category string       `json:"category,omitempty"`
+	Role     string       `json:"role,omitempty"`
 	Source   SensorSource `json:"source"`
 	Output   SensorOutput `json:"output"`
+}
+
+// ValidSensorRoles lists the role hints loop drivers can use to discover
+// which sensor plays which role. Loop-driver policy, not ynh policy —
+// ynh just stores the hint.
+var ValidSensorRoles = map[string]bool{
+	"regular":              true,
+	"convergence-verifier": true,
+	"stuck-recovery":       true,
 }
 
 // SensorSource is a strict one-of: files, command, or focus. Exactly one
@@ -162,6 +172,9 @@ func ValidateSensors(sensors map[string]Sensor, profileNames, focusNames map[str
 		prefix := fmt.Sprintf("sensor %q:", name)
 		if s.Category != "" && !ValidSensorCategories[s.Category] {
 			issues = append(issues, fmt.Sprintf("%s category %q must be one of maintainability, architecture, behaviour", prefix, s.Category))
+		}
+		if s.Role != "" && !ValidSensorRoles[s.Role] {
+			issues = append(issues, fmt.Sprintf("%s role %q must be one of regular, convergence-verifier, stuck-recovery", prefix, s.Role))
 		}
 		if s.Source.Kind() == "" {
 			issues = append(issues, fmt.Sprintf("%s source must have exactly one of files, command, focus", prefix))

--- a/internal/plugin/sensors_test.go
+++ b/internal/plugin/sensors_test.go
@@ -1,0 +1,243 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writePluginJSON(dir, content string) error {
+	if err := os.MkdirAll(filepath.Join(dir, PluginDir), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, PluginDir, PluginFile), []byte(content), 0o644)
+}
+
+func TestSensorSource_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+		wantKnd string
+	}{
+		{"files only", `{"files":["a","b"]}`, "", "files"},
+		{"command only", `{"command":"make check"}`, "", "command"},
+		{"focus string", `{"focus":"infer-vulns"}`, "", "focus"},
+		{"focus inline", `{"focus":{"prompt":"x"}}`, "", "focus"},
+		{"empty", `{}`, "exactly one", ""},
+		{"two set", `{"files":["a"],"command":"x"}`, "exactly one", ""},
+		{"three set", `{"files":["a"],"command":"x","focus":"y"}`, "exactly one", ""},
+		{"unknown field", `{"command":"x","junk":1}`, "unknown field", ""},
+		{"empty focus string", `{"focus":""}`, "must not be empty", ""},
+		{"inline focus no prompt", `{"focus":{"profile":"ci"}}`, "non-empty prompt", ""},
+		{"inline focus unknown field", `{"focus":{"prompt":"x","junk":1}}`, "unknown field", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var s SensorSource
+			err := json.Unmarshal([]byte(tt.input), &s)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if s.Kind() != tt.wantKnd {
+					t.Errorf("Kind = %q, want %q", s.Kind(), tt.wantKnd)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFocusRef_UnmarshalRoundTrip(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		var f FocusRef
+		if err := json.Unmarshal([]byte(`"my-focus"`), &f); err != nil {
+			t.Fatal(err)
+		}
+		if f.Name != "my-focus" || f.Inline != nil {
+			t.Errorf("got %+v", f)
+		}
+		out, _ := json.Marshal(f)
+		if string(out) != `"my-focus"` {
+			t.Errorf("round-trip = %s", out)
+		}
+	})
+	t.Run("inline", func(t *testing.T) {
+		var f FocusRef
+		if err := json.Unmarshal([]byte(`{"profile":"ci","prompt":"do x"}`), &f); err != nil {
+			t.Fatal(err)
+		}
+		if f.Inline == nil || f.Inline.Prompt != "do x" || f.Inline.Profile != "ci" {
+			t.Errorf("got %+v", f.Inline)
+		}
+		out, _ := json.Marshal(f)
+		if !strings.Contains(string(out), `"prompt":"do x"`) {
+			t.Errorf("round-trip = %s", out)
+		}
+	})
+}
+
+func TestValidateSensors(t *testing.T) {
+	profiles := map[string]bool{"ci": true}
+	focuses := map[string]bool{"known": true}
+
+	tests := []struct {
+		name      string
+		sensors   map[string]Sensor
+		wantIssue string // empty = expect no issues
+	}{
+		{
+			name: "valid files sensor",
+			sensors: map[string]Sensor{
+				"coverage": {
+					Category: "maintainability",
+					Source:   SensorSource{Files: []string{"coverage/*.json"}},
+					Output:   SensorOutput{Format: "lcov-summary"},
+				},
+			},
+		},
+		{
+			name: "valid command sensor",
+			sensors: map[string]Sensor{
+				"build": {
+					Source: SensorSource{Command: "make check"},
+					Output: SensorOutput{Format: "text"},
+				},
+			},
+		},
+		{
+			name: "valid string focus ref",
+			sensors: map[string]Sensor{
+				"sec": {
+					Source: SensorSource{Focus: &FocusRef{Name: "known"}},
+					Output: SensorOutput{Format: "markdown"},
+				},
+			},
+		},
+		{
+			name: "valid inline focus",
+			sensors: map[string]Sensor{
+				"sec": {
+					Source: SensorSource{Focus: &FocusRef{Inline: &InlineFocus{Profile: "ci", Prompt: "audit"}}},
+					Output: SensorOutput{Format: "markdown"},
+				},
+			},
+		},
+		{
+			name: "bad category",
+			sensors: map[string]Sensor{
+				"x": {
+					Category: "wrong",
+					Source:   SensorSource{Command: "true"},
+					Output:   SensorOutput{Format: "text"},
+				},
+			},
+			wantIssue: `category "wrong"`,
+		},
+		{
+			name: "missing format",
+			sensors: map[string]Sensor{
+				"x": {
+					Source: SensorSource{Command: "true"},
+					Output: SensorOutput{},
+				},
+			},
+			wantIssue: "output.format must not be empty",
+		},
+		{
+			name: "unknown focus reference",
+			sensors: map[string]Sensor{
+				"x": {
+					Source: SensorSource{Focus: &FocusRef{Name: "nope"}},
+					Output: SensorOutput{Format: "markdown"},
+				},
+			},
+			wantIssue: `references undefined focus "nope"`,
+		},
+		{
+			name: "inline focus references unknown profile",
+			sensors: map[string]Sensor{
+				"x": {
+					Source: SensorSource{Focus: &FocusRef{Inline: &InlineFocus{Profile: "missing", Prompt: "x"}}},
+					Output: SensorOutput{Format: "markdown"},
+				},
+			},
+			wantIssue: `unknown profile "missing"`,
+		},
+		{
+			name: "no source set",
+			sensors: map[string]Sensor{
+				"x": {
+					Output: SensorOutput{Format: "text"},
+				},
+			},
+			wantIssue: "source must have exactly one",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := ValidateSensors(tt.sensors, profiles, focuses)
+			if tt.wantIssue == "" {
+				if len(issues) > 0 {
+					t.Errorf("expected no issues, got: %v", issues)
+				}
+				return
+			}
+			found := false
+			for _, i := range issues {
+				if strings.Contains(i, tt.wantIssue) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected issue containing %q, got: %v", tt.wantIssue, issues)
+			}
+		})
+	}
+}
+
+func TestLoadPluginJSON_WithSensors(t *testing.T) {
+	dir := t.TempDir()
+	if err := writePluginJSON(dir, `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "h",
+  "version": "0.1.0",
+  "sensors": {
+    "build": {
+      "source": {"command": "make check"},
+      "output": {"format": "text"}
+    },
+    "tests": {
+      "category": "behaviour",
+      "source": {"files": ["test-reports/**/*.xml"]},
+      "output": {"format": "junit-xml"}
+    }
+  }
+}`); err != nil {
+		t.Fatal(err)
+	}
+	hj, err := LoadPluginJSON(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hj.Sensors) != 2 {
+		t.Fatalf("expected 2 sensors, got %d", len(hj.Sensors))
+	}
+	if hj.Sensors["build"].Source.Kind() != "command" {
+		t.Errorf("build kind = %q", hj.Sensors["build"].Source.Kind())
+	}
+	if hj.Sensors["tests"].Source.Kind() != "files" {
+		t.Errorf("tests kind = %q", hj.Sensors["tests"].Source.Kind())
+	}
+}

--- a/test/e2e/sensors_test.go
+++ b/test/e2e/sensors_test.go
@@ -1,0 +1,419 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sensorListShape mirrors cmd/ynh.sensorListEntry for assertions.
+type sensorListShape struct {
+	Name        string `json:"name"`
+	Category    string `json:"category,omitempty"`
+	Role        string `json:"role,omitempty"`
+	SourceKind  string `json:"source_kind"`
+	Format      string `json:"format"`
+	InlineFocus bool   `json:"inline_focus,omitempty"`
+}
+
+// sensorShowShape mirrors cmd/ynh.sensorShowEntry — only the fields the
+// suite asserts on, kept local so tests don't import internal/*.
+type sensorShowShape struct {
+	Name     string `json:"name"`
+	Category string `json:"category,omitempty"`
+	Role     string `json:"role,omitempty"`
+	Source   struct {
+		Files   []string `json:"files,omitempty"`
+		Command string   `json:"command,omitempty"`
+		Focus   *struct {
+			Name   string `json:"name,omitempty"`
+			Prompt string `json:"prompt"`
+			Inline bool   `json:"inline"`
+		} `json:"focus,omitempty"`
+	} `json:"source"`
+	Output struct {
+		Format string `json:"format"`
+	} `json:"output"`
+}
+
+// sensorRunShape mirrors cmd/ynh.sensorRunResult.
+type sensorRunShape struct {
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+	Role     string `json:"role,omitempty"`
+	Category string `json:"category,omitempty"`
+	ExitCode int    `json:"exit_code"`
+	Output   struct {
+		Format string `json:"format"`
+		Stdout string `json:"stdout,omitempty"`
+		Stderr string `json:"stderr,omitempty"`
+		Files  []struct {
+			Path    string `json:"path"`
+			Size    int64  `json:"size"`
+			Content string `json:"content,omitempty"`
+		} `json:"files,omitempty"`
+		Focus *struct {
+			Name   string `json:"name,omitempty"`
+			Prompt string `json:"prompt"`
+			Inline bool   `json:"inline"`
+		} `json:"focus,omitempty"`
+	} `json:"output"`
+}
+
+// writeSensorHarness writes a plugin.json into a fresh tmpdir and returns
+// the harness directory. Used by every sensors E2E test that needs an
+// installable fixture.
+func writeSensorHarness(t *testing.T, manifest string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "sensor-harness")
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, ".ynh-plugin", "plugin.json"),
+		[]byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestSensors_Install_PreservesAllSourceVariants installs a manifest with
+// every sensor source variant — files, command, focus-ref, inline-focus —
+// and asserts all four survive the install path unchanged.
+//
+// Behavioural backstop for the sensors flow through plugin → harness →
+// install → discovery CLI.
+func TestSensors_Install_PreservesAllSourceVariants(t *testing.T) {
+	s := newSandbox(t)
+
+	manifest := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-demo",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "focus": {
+    "audit-vulns": { "prompt": "Audit the diff for vulnerabilities." }
+  },
+  "sensors": {
+    "coverage": {
+      "category": "maintainability",
+      "source": { "files": ["coverage/lcov.info"] },
+      "output": { "format": "lcov-summary" }
+    },
+    "build": {
+      "source": { "command": "make check" },
+      "output": { "format": "text" }
+    },
+    "security": {
+      "source": { "focus": "audit-vulns" },
+      "output": { "format": "markdown" }
+    },
+    "coverage-judge": {
+      "role": "convergence-verifier",
+      "source": {
+        "focus": { "prompt": "Is coverage adequate for the changed surface?" }
+      },
+      "output": { "format": "markdown" }
+    }
+  }
+}`
+
+	src := writeSensorHarness(t, manifest)
+	s.mustRunYnh(t, "install", src)
+
+	out, _ := s.mustRunYnh(t, "sensors", "ls", "sensor-demo", "--format", "json")
+	var got []sensorListShape
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing sensors ls JSON: %v\n%s", err, out)
+	}
+
+	want := map[string]sensorListShape{
+		"coverage":       {Name: "coverage", Category: "maintainability", SourceKind: "files", Format: "lcov-summary"},
+		"build":          {Name: "build", SourceKind: "command", Format: "text"},
+		"security":       {Name: "security", SourceKind: "focus", Format: "markdown"},
+		"coverage-judge": {Name: "coverage-judge", Role: "convergence-verifier", SourceKind: "focus", Format: "markdown", InlineFocus: true},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d sensors, got %d: %+v", len(want), len(got), got)
+	}
+	for _, g := range got {
+		w, ok := want[g.Name]
+		if !ok {
+			t.Errorf("unexpected sensor %q in ls output", g.Name)
+			continue
+		}
+		assertEqual(t, g.Name+".category", g.Category, w.Category)
+		assertEqual(t, g.Name+".role", g.Role, w.Role)
+		assertEqual(t, g.Name+".source_kind", g.SourceKind, w.SourceKind)
+		assertEqual(t, g.Name+".format", g.Format, w.Format)
+		assertEqual(t, g.Name+".inline_focus", g.InlineFocus, w.InlineFocus)
+	}
+}
+
+// TestSensors_Show_ResolvesFocusReference verifies that `ynh sensors show`
+// expands a string focus reference inline so the consumer gets a
+// self-contained payload — the entire point of show vs ls.
+func TestSensors_Show_ResolvesFocusReference(t *testing.T) {
+	s := newSandbox(t)
+
+	manifest := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-show",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "focus": {
+    "audit-vulns": { "prompt": "Audit the diff for vulnerabilities." }
+  },
+  "sensors": {
+    "security": {
+      "source": { "focus": "audit-vulns" },
+      "output": { "format": "markdown" }
+    }
+  }
+}`
+
+	src := writeSensorHarness(t, manifest)
+	s.mustRunYnh(t, "install", src)
+
+	out, _ := s.mustRunYnh(t, "sensors", "show", "sensor-show", "security", "--format", "json")
+	var got sensorShowShape
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing sensors show JSON: %v\n%s", err, out)
+	}
+
+	if got.Source.Focus == nil {
+		t.Fatalf("expected source.focus to be populated, got: %+v", got)
+	}
+	assertEqual(t, "focus.name", got.Source.Focus.Name, "audit-vulns")
+	assertEqual(t, "focus.prompt", got.Source.Focus.Prompt, "Audit the diff for vulnerabilities.")
+	assertEqual(t, "focus.inline", got.Source.Focus.Inline, false)
+}
+
+// TestSensors_Run_CommandCapturesExitAndStreams runs a command sensor that
+// exits non-zero with output on both streams. Asserts ynh emits raw signal
+// (exit_code, stdout, stderr) and — critically — does not invent a
+// `passed` boolean. Pass/fail is loop-driver policy.
+func TestSensors_Run_CommandCapturesExitAndStreams(t *testing.T) {
+	s := newSandbox(t)
+
+	manifest := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-run-cmd",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "sensors": {
+    "noisy": {
+      "source": { "command": "echo OUT; echo ERR 1>&2; exit 7" },
+      "output": { "format": "text" }
+    }
+  }
+}`
+
+	src := writeSensorHarness(t, manifest)
+	s.mustRunYnh(t, "install", src)
+
+	// runYnh, not mustRunYnh — sensor command exits non-zero. ynh itself
+	// must still exit 0; the non-zero is reported via JSON.
+	out, _, err := s.runYnh(t, "sensors", "run", "sensor-run-cmd", "noisy")
+	if err != nil {
+		t.Fatalf("ynh sensors run unexpectedly failed: %v\n%s", err, out)
+	}
+
+	var got sensorRunShape
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing sensors run JSON: %v\n%s", err, out)
+	}
+
+	assertEqual(t, "kind", got.Kind, "command")
+	assertEqual(t, "exit_code", got.ExitCode, 7)
+	if !strings.Contains(got.Output.Stdout, "OUT") {
+		t.Errorf("expected stdout to contain OUT, got %q", got.Output.Stdout)
+	}
+	if !strings.Contains(got.Output.Stderr, "ERR") {
+		t.Errorf("expected stderr to contain ERR, got %q", got.Output.Stderr)
+	}
+
+	// Contract check: the JSON must NOT contain a "passed" key. Loop
+	// drivers turn raw signal into pass/fail, not ynh.
+	if strings.Contains(out, `"passed"`) {
+		t.Errorf("ynh sensors run JSON must not include a 'passed' field:\n%s", out)
+	}
+}
+
+// TestSensors_Run_FilesGlobAndNoContent exercises the files-source path:
+// glob expands to multiple matches, default invocation includes content,
+// --no-content omits it but keeps path/size.
+func TestSensors_Run_FilesGlobAndNoContent(t *testing.T) {
+	s := newSandbox(t)
+
+	manifest := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-run-files",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "sensors": {
+    "results": {
+      "source": { "files": ["results/*.txt"] },
+      "output": { "format": "text" }
+    }
+  }
+}`
+
+	src := writeSensorHarness(t, manifest)
+	s.mustRunYnh(t, "install", src)
+
+	// Lay down two matching files in a per-test cwd that sensor run will
+	// glob against via --cwd.
+	cwd := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cwd, "results"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"a.txt", "b.txt"} {
+		if err := os.WriteFile(filepath.Join(cwd, "results", name),
+			[]byte("payload-"+name), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// First run: include content.
+	out, _ := s.mustRunYnh(t, "sensors", "run", "sensor-run-files", "results", "--cwd", cwd)
+	var withContent sensorRunShape
+	if err := json.Unmarshal([]byte(out), &withContent); err != nil {
+		t.Fatalf("parsing run JSON: %v\n%s", err, out)
+	}
+	assertEqual(t, "kind", withContent.Kind, "files")
+	if len(withContent.Output.Files) != 2 {
+		t.Fatalf("expected 2 glob matches, got %d: %+v", len(withContent.Output.Files), withContent.Output.Files)
+	}
+	for _, f := range withContent.Output.Files {
+		if f.Content == "" {
+			t.Errorf("expected content for %s in default mode, got empty", f.Path)
+		}
+		if f.Size <= 0 {
+			t.Errorf("expected nonzero size for %s, got %d", f.Path, f.Size)
+		}
+	}
+
+	// Second run: --no-content.
+	out2, _ := s.mustRunYnh(t, "sensors", "run", "sensor-run-files", "results", "--cwd", cwd, "--no-content")
+	var withoutContent sensorRunShape
+	if err := json.Unmarshal([]byte(out2), &withoutContent); err != nil {
+		t.Fatalf("parsing run JSON: %v\n%s", err, out2)
+	}
+	if len(withoutContent.Output.Files) != 2 {
+		t.Fatalf("expected 2 glob matches with --no-content, got %d", len(withoutContent.Output.Files))
+	}
+	for _, f := range withoutContent.Output.Files {
+		if f.Content != "" {
+			t.Errorf("expected empty content with --no-content for %s, got %q", f.Path, f.Content)
+		}
+		if f.Size <= 0 {
+			t.Errorf("expected size preserved with --no-content for %s, got %d", f.Path, f.Size)
+		}
+	}
+}
+
+// TestSensors_InlineFocus_NotInTopLevelFocus locks the scoping rule:
+// inline focuses declared inside a sensor must NOT leak into the
+// top-level focus map. Top-level focus is the public surface; inline
+// focuses belong to their sensor.
+func TestSensors_InlineFocus_NotInTopLevelFocus(t *testing.T) {
+	s := newSandbox(t)
+
+	manifest := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-inline",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "focus": {
+    "audit-vulns": { "prompt": "Audit the diff." }
+  },
+  "sensors": {
+    "judge": {
+      "source": {
+        "focus": { "prompt": "Inline-only — must not leak to top-level focus." }
+      },
+      "output": { "format": "markdown" }
+    }
+  }
+}`
+
+	src := writeSensorHarness(t, manifest)
+	s.mustRunYnh(t, "install", src)
+
+	// Inspect top-level focus via info text — info JSON does not break
+	// out focus as a discrete field, but the text rendering does.
+	out, _ := s.mustRunYnh(t, "info", "sensor-inline")
+	if !strings.Contains(out, "audit-vulns") {
+		t.Errorf("expected top-level focus 'audit-vulns' in info output:\n%s", out)
+	}
+	// The inline focus has no name — it should appear under Sensors,
+	// never under Focus. Assert by checking that nothing under Focus
+	// references the inline prompt.
+	if focusBlock := extractInfoBlock(out, "Focus:"); strings.Contains(focusBlock, "Inline-only") {
+		t.Errorf("inline-focus prompt leaked into top-level Focus block:\n%s", focusBlock)
+	}
+	// And the Sensors block should mention judge with its inline marker.
+	if sensorsBlock := extractInfoBlock(out, "Sensors:"); !strings.Contains(sensorsBlock, "judge") {
+		t.Errorf("expected 'judge' under Sensors block, got:\n%s", sensorsBlock)
+	}
+}
+
+// extractInfoBlock returns the lines under a `ynh info` section header
+// (e.g. "Focus:") up to the next blank line or top-level header. Used by
+// inline-focus scoping assertions.
+func extractInfoBlock(info, header string) string {
+	lines := strings.Split(info, "\n")
+	var out []string
+	in := false
+	for _, line := range lines {
+		if !in {
+			if strings.TrimSpace(line) == header {
+				in = true
+			}
+			continue
+		}
+		// Section ends at blank line or new top-level header (no leading space).
+		if line == "" || (len(line) > 0 && line[0] != ' ' && line[0] != '\t' && strings.HasSuffix(strings.TrimSpace(line), ":")) {
+			break
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+// TestSensors_Validate_OneOfSourceViolation locks the dual-error contract
+// for an invalid sensor source: schema-level oneOf rejection AND the
+// cross-field validator each emit one line. Loop-driver authors and
+// harness writers both rely on this dual signal.
+func TestSensors_Validate_OneOfSourceViolation(t *testing.T) {
+	manifest := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "sensor-bad",
+  "version": "0.1.0",
+  "sensors": {
+    "broken": {
+      "source": { "command": "x", "files": ["a"] },
+      "output": { "format": "text" }
+    }
+  }
+}`
+
+	dir := writeSensorHarness(t, manifest)
+
+	stdout, errOut, err := runYnd(t, "validate", dir)
+	if err == nil {
+		t.Fatalf("expected validate to fail on multi-field source, got success\nstdout:\n%s\nstderr:\n%s", stdout, errOut)
+	}
+	combined := stdout + errOut
+	if !strings.Contains(combined, "oneOf") {
+		t.Errorf("expected schema-level 'oneOf' line in stderr, got:\n%s", combined)
+	}
+	if !strings.Contains(combined, "exactly one of files, command, focus") {
+		t.Errorf("expected cross-field source rule line in stderr, got:\n%s", combined)
+	}
+}

--- a/test/e2e/sensors_test.go
+++ b/test/e2e/sensors_test.go
@@ -3,7 +3,9 @@
 package e2e
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,9 +32,10 @@ type sensorShowShape struct {
 		Files   []string `json:"files,omitempty"`
 		Command string   `json:"command,omitempty"`
 		Focus   *struct {
-			Name   string `json:"name,omitempty"`
-			Prompt string `json:"prompt"`
-			Inline bool   `json:"inline"`
+			Name    string `json:"name,omitempty"`
+			Profile string `json:"profile,omitempty"`
+			Prompt  string `json:"prompt"`
+			Inline  bool   `json:"inline"`
 		} `json:"focus,omitempty"`
 	} `json:"source"`
 	Output struct {
@@ -57,9 +60,10 @@ type sensorRunShape struct {
 			Content string `json:"content,omitempty"`
 		} `json:"files,omitempty"`
 		Focus *struct {
-			Name   string `json:"name,omitempty"`
-			Prompt string `json:"prompt"`
-			Inline bool   `json:"inline"`
+			Name    string `json:"name,omitempty"`
+			Profile string `json:"profile,omitempty"`
+			Prompt  string `json:"prompt"`
+			Inline  bool   `json:"inline"`
 		} `json:"focus,omitempty"`
 	} `json:"output"`
 }
@@ -415,5 +419,112 @@ func TestSensors_Validate_OneOfSourceViolation(t *testing.T) {
 	}
 	if !strings.Contains(combined, "exactly one of files, command, focus") {
 		t.Errorf("expected cross-field source rule line in stderr, got:\n%s", combined)
+	}
+}
+
+// sensorsProfileFocusHarnessTmpl is a single harness wiring all three
+// concepts together: a top-level focus declares a profile, a sensor's
+// source references that focus, and the named profile defines a hook
+// that REPLACES the base hook on --profile / --focus invocation.
+const sensorsProfileFocusHarnessTmpl = `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": %q,
+  "version": "0.1.0",
+  "hooks": {
+    "before_tool": [{"command": "echo BASE"}]
+  },
+  "profiles": {
+    "review": {
+      "hooks": {
+        "before_tool": [{"command": "echo REVIEW"}]
+      }
+    }
+  },
+  "focus": {
+    "audit": {"profile": "review", "prompt": "audit the diff"}
+  },
+  "sensors": {
+    "audit-gate": {
+      "source": { "focus": "audit" },
+      "output": { "format": "markdown" }
+    }
+  }
+}
+`
+
+// TestSensors_ProfileFocusRoundTrip is the integration backstop for the
+// sensor → focus → profile chain. One harness, one fixture, three
+// assertions that together prove a loop driver can:
+//
+//  1. Discover a focus-sourced sensor and read the profile it points at
+//     (`ynh sensors show` exposes source.focus.profile).
+//  2. Run the sensor and receive the same focus payload, including the
+//     profile name (`ynh sensors run` returns output.focus.profile).
+//  3. Hand that profile name back to `ynh run --focus <name>` and have
+//     the named profile's hook override land in the assembled output.
+//
+// If any link breaks, sensors and run go out of sync and the loop driver
+// can no longer chain them. Don't split this test — the value is the
+// shared harness that proves all three commands agree on the wiring.
+func TestSensors_ProfileFocusRoundTrip(t *testing.T) {
+	const harnessName = "sensor-profile-focus"
+
+	src := filepath.Join(t.TempDir(), harnessName)
+	if err := os.MkdirAll(filepath.Join(src, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := fmt.Sprintf(sensorsProfileFocusHarnessTmpl, harnessName)
+	if err := os.WriteFile(filepath.Join(src, ".ynh-plugin", "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newSandbox(t)
+	s.mustRunYnh(t, "install", src)
+
+	// 1. show — focus reference resolved, profile field surfaced.
+	showOut, _ := s.mustRunYnh(t, "sensors", "show", harnessName, "audit-gate", "--format", "json")
+	var shown sensorShowShape
+	if err := json.Unmarshal([]byte(showOut), &shown); err != nil {
+		t.Fatalf("parsing sensors show JSON: %v\n%s", err, showOut)
+	}
+	if shown.Source.Focus == nil {
+		t.Fatalf("sensors show: source.focus missing — got %+v", shown)
+	}
+	assertEqual(t, "show.focus.name", shown.Source.Focus.Name, "audit")
+	assertEqual(t, "show.focus.profile", shown.Source.Focus.Profile, "review")
+	assertEqual(t, "show.focus.prompt", shown.Source.Focus.Prompt, "audit the diff")
+	assertEqual(t, "show.focus.inline", shown.Source.Focus.Inline, false)
+
+	// 2. run — same focus payload returned to the loop driver.
+	runOut, _ := s.mustRunYnh(t, "sensors", "run", harnessName, "audit-gate")
+	var ran sensorRunShape
+	if err := json.Unmarshal([]byte(runOut), &ran); err != nil {
+		t.Fatalf("parsing sensors run JSON: %v\n%s", err, runOut)
+	}
+	assertEqual(t, "run.kind", ran.Kind, "focus")
+	if ran.Output.Focus == nil {
+		t.Fatalf("sensors run: output.focus missing — got %+v", ran)
+	}
+	assertEqual(t, "run.focus.name", ran.Output.Focus.Name, "audit")
+	assertEqual(t, "run.focus.profile", ran.Output.Focus.Profile, "review")
+
+	// 3. run --focus — same focus name resolves to the same profile and
+	//    the profile's hook REPLACES the base hook in assembled output.
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunYnhInDir(t, s, project, "run", harnessName, "-v", "cursor", "--focus", "audit", "--install")
+
+	hookFile := filepath.Join(s.home, "run", harnessName, ".cursor", "hooks.json")
+	body, err := os.ReadFile(hookFile)
+	if err != nil {
+		t.Fatalf("reading hook file: %v", err)
+	}
+	if !bytes.Contains(body, []byte("REVIEW")) {
+		t.Errorf("focus did not apply profile — hook file missing REVIEW:\n%s", body)
+	}
+	if bytes.Contains(body, []byte("BASE")) {
+		t.Errorf("hook file should not contain base hook BASE after profile override:\n%s", body)
 	}
 }


### PR DESCRIPTION
## Summary

Adds **sensors** to ynh — named observation surfaces declared in the harness manifest. ynh declares; an external loop driver runs them between agent turns. This is the feedforward half of harness engineering — the layer YNH explicitly disclaimed in earlier versions.

The PR also includes the two TermQ-driven extensions agreed for v0.3.0: `ynh sensors run` for mechanical sensor execution and an optional `role` field for loop-driver discovery.

### Schema and model
- New top-level `sensors` field in `.ynh-plugin/plugin.json` with strict one-of source (`files` | `command` | `focus`).
- `category` (Fowler bucket: maintainability / architecture / behaviour) and `role` (regular / convergence-verifier / stuck-recovery) — both optional.
- `output.format` is freeform — ynh maintains no vocabulary.
- Focus sources support both string-ref and inline forms.

### CLI
- `ynh sensors ls <harness> [--format json]` — discovery summary.
- `ynh sensors show <harness> <name> [--format json|text]` — resolved view, with inline focuses preserved and string-referenced focuses expanded into a self-contained payload.
- `ynh sensors run <harness> <name>` — mechanical execution. Returns raw `exit_code`, output, files, or resolved focus payload. **No `passed` boolean** — pass/fail policy stays in the loop driver.
- `ynh info` and `ynd compose` JSON gain a sensors block.

### Validation
- `ynd validate` enforces all 11 sensor rules with sensor-name-prefixed errors.

### Composition
- Sensors flow root-only — included harnesses' sensors are dropped, mirroring the existing rule for hooks.
- Profiles do not override or add sensors in v1.

### Docs
- New: `docs/sensors.md` (full reference) and `docs/tutorial/19-sensors.md` (nine-step walkthrough).
- Rewritten: `docs/harness-engineering.md` — boundary moves from "ynh does not include sensors" to "ynh declares both guides and observation surfaces; orchestration belongs to an external loop driver." Adds a Design Stance subsection.
- New: `.github/CONTRIBUTING.md` Design Stance for contributors.
- Light cross-link touch-ups: hooks.md, profiles.md, focus tutorial, tutorial 10, sidebar, reference.md, README.md.
- Manual test plan gains a Sensors section (S1–S3).

### Eval gate
EVALS: PASS (19 tutorials, 0 failures). Pre-existing tutorial breakage in T13/T14/T15 (missing `$schema` in inline examples) was fixed alongside the new content.

### Out of scope
- A ynh-owned loop runtime (stays out per the design stance).
- Profile-scoped sensor overrides (deferred until a real use case).
- A `passed` boolean on `ynh sensors run` (loop-driver policy).
- An enumerated `output.format` vocabulary (freeform).

Target version: **v0.3.0** — additive, non-breaking.

## Test plan

- [x] `make check` passes (lint, format, build, tests at 80%+ coverage)
- [x] `/evals` PASS — 19 tutorials, 0 failures
- [x] Manual test plan S1–S3 (new sensors scenarios) verified
- [x] Tutorial 19 verified end-to-end against fresh binaries
- [ ] CI green on PR