### PR TITLE
hotfix: honor entry-level ref and sha pins on install

### DIFF
--- a/cmd/ynh/image.go
+++ b/cmd/ynh/image.go
@@ -170,9 +170,12 @@ func cmdImageTo(args []string, stdout, stderr io.Writer) error {
 			if err := cfg.CheckRemoteSource(source); err != nil {
 				return err
 			}
-			result, err := resolver.EnsureRepo(source, "")
+			result, err := resolver.EnsureRepo(source, resolved.ref)
 			if err != nil {
 				return fmt.Errorf("resolving %s: %w", source, err)
+			}
+			if err := verifyResolvedSHA(result.Path, resolved.sha); err != nil {
+				return err
 			}
 			harnessSrcDir = result.Path
 		}

--- a/cmd/ynh/install_helpers.go
+++ b/cmd/ynh/install_helpers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -51,4 +52,23 @@ func loadOrSynthesizeHarness(dir string) (*harness.Harness, error) {
 	}
 
 	return harness.LoadDir(dir)
+}
+
+// verifyResolvedSHA checks that the working tree at repoDir is at the declared
+// commit SHA. The marketplace schema says: when both ref and sha are present,
+// ref controls what is fetched; sha is verified against the fetched commit.
+// An empty wantSHA is a no-op. Short SHAs are matched as a prefix of HEAD.
+func verifyResolvedSHA(repoDir, wantSHA string) error {
+	if wantSHA == "" {
+		return nil
+	}
+	out, err := exec.Command("git", "-C", repoDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return fmt.Errorf("verifying sha: reading HEAD of %s: %w", repoDir, err)
+	}
+	got := strings.TrimSpace(string(out))
+	if !strings.HasPrefix(got, wantSHA) {
+		return fmt.Errorf("sha mismatch: registry entry declared %s but fetched commit is %s", wantSHA, got)
+	}
+	return nil
 }

--- a/cmd/ynh/install_resolve.go
+++ b/cmd/ynh/install_resolve.go
@@ -15,6 +15,8 @@ import (
 type resolvedSource struct {
 	gitURL       string // non-empty if resolved to a Git URL (from registry)
 	path         string // monorepo subdir (from registry entry)
+	ref          string // optional Git ref pin from a registry entry
+	sha          string // optional commit SHA, verified against the fetched HEAD
 	localPath    string // absolute path when resolved from a configured source
 	sourceType   string // "local", "git", "registry", "source"
 	registryName string // non-empty for registry lookups (user-declared label)
@@ -82,6 +84,8 @@ func lookupFromRegistry(qualified string, cfg *config.Config) (resolvedSource, e
 	return resolvedSource{
 		gitURL:       entry.Repo,
 		path:         entry.Path,
+		ref:          entry.Ref,
+		sha:          entry.SHA,
 		sourceType:   "registry",
 		registryName: results[0].RegistryName,
 		namespace:    entry.Namespace,
@@ -107,6 +111,8 @@ func searchFromRegistry(name string, cfg *config.Config) (resolvedSource, error)
 		return resolvedSource{
 			gitURL:       entry.Repo,
 			path:         entry.Path,
+			ref:          entry.Ref,
+			sha:          entry.SHA,
 			sourceType:   "registry",
 			registryName: results[0].RegistryName,
 			namespace:    entry.Namespace,

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -234,10 +234,16 @@ func cmdInstall(args []string) error {
 			return err
 		}
 
-		// Resolve from Git via cache
-		result, err := resolver.EnsureRepo(source, "")
+		// Resolve from Git via cache. When the source came from a registry
+		// entry that pinned a ref, honor it so the on-disk checkout matches
+		// what the marketplace declared. If a sha is also declared, verify
+		// it against the fetched HEAD.
+		result, err := resolver.EnsureRepo(source, resolved.ref)
 		if err != nil {
 			return fmt.Errorf("resolving %s: %w", source, err)
+		}
+		if err := verifyResolvedSHA(result.Path, resolved.sha); err != nil {
+			return err
 		}
 		srcDir = result.Path
 	}

--- a/docs/tutorial/07-registry-and-discovery.md
+++ b/docs/tutorial/07-registry-and-discovery.md
@@ -169,6 +169,61 @@ ynh install planner@tutorial-registry
 
 The `name@registry` format bypasses ambiguity.
 
+## T7.6b: Pin a registry entry to a ref or SHA
+
+The legacy `registry.json` format used in T7.1 has no per-entry pinning. Modern marketplaces use `.ynh-plugin/marketplace.json` with a `source` object that supports `ref` (branch, tag, or SHA) and `sha` (commit verification):
+
+```bash
+mkdir -p /tmp/ynh-tutorial/pinned-registry/.ynh-plugin
+cd /tmp/ynh-tutorial/pinned-registry
+
+cat > .ynh-plugin/marketplace.json << 'EOF'
+{
+  "$schema": "https://eyelock.github.io/ynh/schema/marketplace.schema.json",
+  "name": "pinned-registry",
+  "owner": {"name": "tutorial"},
+  "harnesses": [
+    {
+      "name": "david-stable",
+      "description": "david pinned to the main branch",
+      "source": {
+        "type": "github",
+        "repo": "github.com/eyelock/assistants",
+        "path": "ynh/david",
+        "ref": "main"
+      }
+    }
+  ]
+}
+EOF
+
+git init && git add . && git commit -m "init pinned registry"
+
+ynh registry add /tmp/ynh-tutorial/pinned-registry
+ynh install david-stable
+```
+
+The entry's `ref` controls which branch, tag, or commit gets cloned for the install — independent of the registry's own ref. If `sha` is also set, ynh verifies the fetched commit matches and aborts the install on mismatch:
+
+```json
+{
+  "name": "david-locked",
+  "source": {
+    "type": "github",
+    "repo": "github.com/eyelock/assistants",
+    "path": "ynh/david",
+    "ref": "main",
+    "sha": "0000000000000000000000000000000000000000"
+  }
+}
+```
+
+```
+Error: sha mismatch: registry entry declared 0000... but fetched commit is <actual>
+```
+
+Use `ref` for human-friendly pins (a release tag, a stable branch); add `sha` when you want belt-and-braces protection against branch tip movement or repo tampering.
+
 ## T7.7: Install — direct URL still works
 
 ```bash

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -29,6 +29,8 @@ type Entry struct {
 	// Source fields (from marketplace.json or mapped from legacy)
 	Repo    string // owner/repo or full URL
 	Path    string // subdirectory within repo
+	Ref     string // optional Git ref pin (branch, tag, or SHA) for the entry's source
+	SHA     string // optional commit SHA verified against the fetched HEAD
 	Version string
 	Vendors []string
 }
@@ -130,6 +132,8 @@ func LoadFromDir(dir string) (Registry, error) {
 				e.Repo = src.URL
 			}
 			e.Path = src.Path
+			e.Ref = src.Ref
+			e.SHA = src.SHA
 		}
 
 		reg.Entries = append(reg.Entries, e)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -66,6 +66,66 @@ func TestLoadFromDir(t *testing.T) {
 	}
 }
 
+// TestLoadFromDirCarriesEntryRef ensures a per-entry ref pinned in
+// marketplace.json's RemoteSource is preserved on the parsed Entry so the
+// install path can pass it to the cloner. Regression test: the ref was
+// previously dropped, causing pinned entries to silently install from the
+// default branch.
+func TestLoadFromDirCarriesEntryRef(t *testing.T) {
+	dir := t.TempDir()
+	mj := `{
+  "name": "test-reg",
+  "owner": {"name": "test"},
+  "harnesses": [
+    {
+      "name": "pinned",
+      "source": {"type": "github", "repo": "eyelock/assistants", "path": "ynh/david", "ref": "develop", "sha": "0123456789abcdef0123456789abcdef01234567"}
+    },
+    {
+      "name": "unpinned",
+      "source": {"type": "github", "repo": "eyelock/assistants", "path": "ynh/david"}
+    }
+  ]
+}`
+	pluginDir := filepath.Join(dir, ".ynh-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "marketplace.json"), []byte(mj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, err := LoadFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadFromDir: %v", err)
+	}
+	if len(reg.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(reg.Entries))
+	}
+
+	pinned := reg.Entries[0]
+	if pinned.Name != "pinned" {
+		t.Fatalf("entries[0].Name = %q", pinned.Name)
+	}
+	if pinned.Ref != "develop" {
+		t.Errorf("entries[0].Ref = %q, want %q", pinned.Ref, "develop")
+	}
+	if pinned.SHA != "0123456789abcdef0123456789abcdef01234567" {
+		t.Errorf("entries[0].SHA = %q", pinned.SHA)
+	}
+	if pinned.Repo != "eyelock/assistants" {
+		t.Errorf("entries[0].Repo = %q", pinned.Repo)
+	}
+
+	unpinned := reg.Entries[1]
+	if unpinned.Ref != "" {
+		t.Errorf("entries[1].Ref = %q, want empty", unpinned.Ref)
+	}
+	if unpinned.SHA != "" {
+		t.Errorf("entries[1].SHA = %q, want empty", unpinned.SHA)
+	}
+}
+
 func TestLoadFromDirMissing(t *testing.T) {
 	_, err := LoadFromDir(t.TempDir())
 	if err == nil {


### PR DESCRIPTION
## Summary

Hotfix for v0.2.2: marketplace registry entries that pinned a Git ref via `source.ref` were silently installed from the source repo's default branch. The schema (`docs/schema/marketplace.schema.json`) and docs (`docs/marketplace.md`) advertised `ref`/`sha` as supported pinning fields, but `registry.Entry` had no `Ref`/`SHA` fields, `LoadFromDir` dropped them, and both `cmdInstall` and `cmdImage` called `EnsureRepo` with an empty ref. A marketplace author following the docs would publish an entry pinned to `v2.0.0` and users would silently get whatever was on `main`.

Cherry-picked from #109 (merged to develop) onto `v0.2.2`. Drift was minimal — only `cmd/ynh/main.go` needed a 22-line auto-merge. The T13 docs change from #109 was a no-op here because main already had the `$schema` lines (a previous hotfix that was never forward-ported to develop).

## Changes

- `internal/registry/registry.go` — `Ref` and `SHA` on `Entry`; populated from `RemoteSource`.
- `cmd/ynh/install_resolve.go` — carry `ref`/`sha` through `resolvedSource`.
- `cmd/ynh/main.go` and `cmd/ynh/image.go` — pass `resolved.ref` to `EnsureRepo`; verify `resolved.sha` against fetched HEAD.
- `cmd/ynh/install_helpers.go` — `verifyResolvedSHA` helper.
- `internal/registry/registry_test.go` — `TestLoadFromDirCarriesEntryRef` regression test.
- `docs/tutorial/07-registry-and-discovery.md` — new T7.6b documenting entry-level pinning.

## Test plan

- [x] `make check` (lint, race tests, build) — green
- [x] On-disk verification with hotfix binary against `eyelock/assistants`:
  - `ref:develop` correct `sha` → installs OK
  - wrong `sha` → `Error: sha mismatch: registry entry declared 0000... but fetched commit is 339725ed`
  - `ref:main` with develop-only path → `Error: path "plugins/vendor-harness" not found in source`

## Forward-port

Already on develop via #109 — no forward-port needed.

## Release

Tag `v0.2.3` after merge.