### PR TITLE
fix(harness): record resolved SHA per include/delegate

### DIFF
--- a/cmd/ynh/check_updates.go
+++ b/cmd/ynh/check_updates.go
@@ -181,9 +181,14 @@ func probeHarness(entry *listEntry, probe updateProbe, mu *sync.Mutex) {
 
 func probeInclude(entry *listEntry, idx int, probe updateProbe, mu *sync.Mutex) {
 	inc := entry.Includes[idx]
-	ref := inc.RefInstalled
-	if harness.IsPinnedRef(ref) {
-		ref = ""
+	// IsPinned reflects the manifest pin (a SHA-shaped ref). For pinned
+	// entries we probe HEAD instead — there's no point re-resolving the
+	// pinned SHA. For floating-ref entries we probe the manifest ref
+	// (branch/tag), not RefInstalled (which is now the resolved SHA at
+	// install time, not a fetchable ref).
+	ref := ""
+	if !inc.IsPinned {
+		ref = inc.Ref
 	}
 	sha, ok := probe.git(inc.Git, ref)
 	if !ok {

--- a/cmd/ynh/check_updates_test.go
+++ b/cmd/ynh/check_updates_test.go
@@ -51,10 +51,12 @@ func (f *fakeProbe) probe() updateProbe {
 }
 
 func TestFillUpdates_GitIncludeFloatingRef(t *testing.T) {
+	// Floating-ref include: manifest declares Ref="main", install resolves
+	// it to a SHA recorded as RefInstalled. Probe should target "main" upstream.
 	entries := []listEntry{{
 		Name: "demo",
 		Includes: []listInclude{
-			{Git: "github.com/example/repo", RefInstalled: "main"},
+			{Git: "github.com/example/repo", Ref: "main", RefInstalled: "oldsha", IsPinned: false},
 		},
 	}}
 
@@ -79,7 +81,12 @@ func TestFillUpdates_GitIncludePinnedProbesHEAD(t *testing.T) {
 	entries := []listEntry{{
 		Name: "demo",
 		Includes: []listInclude{
-			{Git: "github.com/example/repo", RefInstalled: "abc1234567890abcdef1234567890abcdef12345"},
+			{
+				Git:          "github.com/example/repo",
+				Ref:          "abc1234567890abcdef1234567890abcdef12345",
+				RefInstalled: "abc1234567890abcdef1234567890abcdef12345",
+				IsPinned:     true,
+			},
 		},
 	}}
 
@@ -104,7 +111,7 @@ func TestFillUpdates_ProbeFailureStaysOmitted(t *testing.T) {
 	entries := []listEntry{{
 		Name: "demo",
 		Includes: []listInclude{
-			{Git: "github.com/example/repo", RefInstalled: "main"},
+			{Git: "github.com/example/repo", Ref: "main", RefInstalled: "oldsha", IsPinned: false},
 		},
 	}}
 

--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -70,7 +70,11 @@ type listArtifacts struct {
 }
 
 type listInclude struct {
-	Git          string   `json:"git"`
+	Git string `json:"git"`
+	// Ref is the manifest pin (branch, tag, or SHA) declared in plugin.json.
+	// Internal field — not emitted in JSON output. Used by --check-updates
+	// to know which upstream ref to probe for floating-ref includes.
+	Ref          string   `json:"-"`
 	RefInstalled string   `json:"ref_installed,omitempty"`
 	RefAvailable string   `json:"ref_available,omitempty"`
 	IsPinned     bool     `json:"is_pinned"`
@@ -260,9 +264,16 @@ func scanArtifactCounts(dir string) listArtifacts {
 func buildIncludes(includes []harness.Include) []listInclude {
 	result := make([]listInclude, 0, len(includes))
 	for _, inc := range includes {
+		// Prefer the resolved SHA recorded at install/update time. Fall back
+		// to the manifest ref so pre-migration installs still report something.
+		refInstalled := inc.SHA
+		if refInstalled == "" {
+			refInstalled = inc.Ref
+		}
 		li := listInclude{
 			Git:          inc.Git,
-			RefInstalled: inc.Ref,
+			Ref:          inc.Ref,
+			RefInstalled: refInstalled,
 			IsPinned:     harness.IsPinnedRef(inc.Ref),
 			Path:         inc.Path,
 		}
@@ -277,9 +288,13 @@ func buildIncludes(includes []harness.Include) []listInclude {
 func buildDelegates(delegates []harness.Delegate) []listDelegate {
 	result := make([]listDelegate, 0, len(delegates))
 	for _, del := range delegates {
+		refInstalled := del.SHA
+		if refInstalled == "" {
+			refInstalled = del.Ref
+		}
 		result = append(result, listDelegate{
 			Git:          del.Git,
-			RefInstalled: del.Ref,
+			RefInstalled: refInstalled,
 			IsPinned:     harness.IsPinnedRef(del.Ref),
 			Path:         del.Path,
 		})

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -331,11 +331,10 @@ func cmdInstall(args []string) error {
 		InstalledAt:  time.Now().UTC().Format(time.RFC3339),
 		ForkedFrom:   forkedFrom,
 	}
-	if err := plugin.SaveInstalledJSON(installDir, ins); err != nil {
-		return fmt.Errorf("saving provenance: %w", err)
-	}
 
-	// Pre-fetch includes and delegates so ynh run works offline
+	// Pre-fetch includes and delegates so ynh run works offline.
+	// Capture each resolved SHA into ins.Resolved so floating-ref entries
+	// have a recorded commit for later update detection.
 	if len(p.Includes) > 0 || len(p.DelegatesTo) > 0 {
 		fmt.Printf("Fetching %d include(s) and %d delegate(s)...\n", len(p.Includes), len(p.DelegatesTo))
 	}
@@ -352,9 +351,16 @@ func cmdInstall(args []string) error {
 				return fmt.Errorf("include %q: %w", inc.Git, err)
 			}
 		}
-		if _, err := resolver.EnsureRepo(inc.Git, inc.Ref); err != nil {
+		res, err := resolver.EnsureRepo(inc.Git, inc.Ref)
+		if err != nil {
 			return fmt.Errorf("fetching include %s: %w", inc.Git, err)
 		}
+		ins.Resolved = append(ins.Resolved, plugin.ResolvedSourceJSON{
+			Git:  inc.Git,
+			Ref:  inc.Ref,
+			Path: inc.Path,
+			SHA:  res.SHA,
+		})
 		fmt.Printf("  Fetched %s\n", resolver.ShortGitURL(inc.Git))
 	}
 	for _, del := range p.DelegatesTo {
@@ -363,10 +369,21 @@ func cmdInstall(args []string) error {
 				return fmt.Errorf("delegate %q: %w", del.Git, err)
 			}
 		}
-		if _, err := resolver.EnsureRepo(del.Git, del.Ref); err != nil {
+		res, err := resolver.EnsureRepo(del.Git, del.Ref)
+		if err != nil {
 			return fmt.Errorf("fetching delegate %s: %w", del.Git, err)
 		}
+		ins.Resolved = append(ins.Resolved, plugin.ResolvedSourceJSON{
+			Git:  del.Git,
+			Ref:  del.Ref,
+			Path: del.Path,
+			SHA:  res.SHA,
+		})
 		fmt.Printf("  Fetched %s\n", resolver.ShortGitURL(del.Git))
+	}
+
+	if err := plugin.SaveInstalledJSON(installDir, ins); err != nil {
+		return fmt.Errorf("saving provenance: %w", err)
 	}
 
 	// Generate launcher script (skip for reserved names that conflict with the binary)
@@ -469,6 +486,7 @@ func cmdUpdate(args []string) error {
 
 	checked := 0
 	updated := 0
+	resolvedSources := make([]plugin.ResolvedSourceJSON, 0, len(p.Includes)+len(p.DelegatesTo))
 	for _, inc := range p.Includes {
 		// Local-path includes have no cache entry to refresh.
 		if inc.IsLocal() {
@@ -484,6 +502,12 @@ func cmdUpdate(args []string) error {
 			continue
 		}
 		checked++
+		resolvedSources = append(resolvedSources, plugin.ResolvedSourceJSON{
+			Git:  inc.Git,
+			Ref:  inc.Ref,
+			Path: inc.Path,
+			SHA:  result.SHA,
+		})
 		if result.Changed {
 			updated++
 			fmt.Printf("  Updated.\n")
@@ -502,11 +526,26 @@ func cmdUpdate(args []string) error {
 			continue
 		}
 		checked++
+		resolvedSources = append(resolvedSources, plugin.ResolvedSourceJSON{
+			Git:  del.Git,
+			Ref:  del.Ref,
+			Path: del.Path,
+			SHA:  result.SHA,
+		})
 		if result.Changed {
 			updated++
 			fmt.Printf("  Updated.\n")
 		} else {
 			fmt.Printf("  Already up to date.\n")
+		}
+	}
+
+	// Persist resolved SHAs back to installed.json so subsequent --check-updates
+	// queries can compare against the recorded SHA without re-fetching.
+	if ins, loadErr := plugin.LoadInstalledJSON(p.Dir); loadErr == nil && ins != nil {
+		ins.Resolved = resolvedSources
+		if err := plugin.SaveInstalledJSON(p.Dir, ins); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not update installed.json: %v\n", err)
 		}
 	}
 

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -37,10 +37,17 @@ func (g GitSource) IsLocal() bool { return g.Local != "" && g.Git == "" }
 type Include struct {
 	GitSource
 	Pick []string
+	// SHA is the resolved commit at install/update time, populated from
+	// installed.json's resolved slice. Empty for local-path includes and for
+	// pre-migration installs that predate SHA recording.
+	SHA string
 }
 
 type Delegate struct {
 	GitSource
+	// SHA is the resolved commit at install/update time, populated from
+	// installed.json's resolved slice. Empty for pre-migration installs.
+	SHA string
 }
 
 // Provenance records where a harness was installed from.
@@ -310,6 +317,29 @@ func LoadDir(dir string) (*Harness, error) {
 		p.DelegatesTo = append(p.DelegatesTo, Delegate{
 			GitSource: GitSource{Git: del.Git, Ref: del.Ref, Path: del.Path},
 		})
+	}
+
+	// Backfill resolved SHAs from installed.json onto includes/delegates so
+	// downstream consumers (list, info, --check-updates) have a recorded
+	// commit even for floating refs.
+	if ins, err := plugin.LoadInstalledJSON(dir); err == nil && ins != nil && len(ins.Resolved) > 0 {
+		shaFor := func(git, ref, path string) string {
+			for _, r := range ins.Resolved {
+				if r.Git == git && r.Ref == ref && r.Path == path {
+					return r.SHA
+				}
+			}
+			return ""
+		}
+		for i := range p.Includes {
+			if p.Includes[i].Git == "" {
+				continue
+			}
+			p.Includes[i].SHA = shaFor(p.Includes[i].Git, p.Includes[i].Ref, p.Includes[i].Path)
+		}
+		for i := range p.DelegatesTo {
+			p.DelegatesTo[i].SHA = shaFor(p.DelegatesTo[i].Git, p.DelegatesTo[i].Ref, p.DelegatesTo[i].Path)
+		}
 	}
 	if len(hj.Hooks) > 0 {
 		p.Hooks = hj.Hooks

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -334,6 +334,91 @@ func TestLoadDir_WithoutProvenance(t *testing.T) {
 	}
 }
 
+func TestLoadDir_BackfillsResolvedSHAs(t *testing.T) {
+	dir := t.TempDir()
+	hj := `{
+		"name": "withincludes",
+		"version": "0.1.0",
+		"default_vendor": "claude",
+		"includes": [
+			{"git": "github.com/org/floating", "path": "skills"},
+			{"git": "github.com/org/pinned", "ref": "v1.0.0", "path": "rules"},
+			{"git": "github.com/org/missing", "path": "agents"},
+			{"local": "./local-include"}
+		],
+		"delegates_to": [
+			{"git": "github.com/org/del-floating", "path": "x"}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(dir, ".harness.json"), []byte(hj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, plugin.PluginDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	installed := `{
+		"source_type": "git",
+		"source": "github.com/example/withincludes",
+		"installed_at": "2026-04-30T12:00:00Z",
+		"resolved": [
+			{"git": "github.com/org/floating", "path": "skills", "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			{"git": "github.com/org/pinned", "ref": "v1.0.0", "path": "rules", "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+			{"git": "github.com/org/del-floating", "path": "x", "sha": "cccccccccccccccccccccccccccccccccccccccc"}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(dir, plugin.PluginDir, plugin.InstalledFile), []byte(installed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir failed: %v", err)
+	}
+
+	if len(p.Includes) != 4 {
+		t.Fatalf("expected 4 includes, got %d", len(p.Includes))
+	}
+	wantSHAs := []string{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // floating, matched
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", // pinned, matched
+		"", // missing from resolved, fallback to empty
+		"", // local-only, no Git URL → skipped
+	}
+	for i, want := range wantSHAs {
+		if p.Includes[i].SHA != want {
+			t.Errorf("include[%d].SHA = %q, want %q", i, p.Includes[i].SHA, want)
+		}
+	}
+
+	if len(p.DelegatesTo) != 1 {
+		t.Fatalf("expected 1 delegate, got %d", len(p.DelegatesTo))
+	}
+	if got, want := p.DelegatesTo[0].SHA, "cccccccccccccccccccccccccccccccccccccccc"; got != want {
+		t.Errorf("delegate[0].SHA = %q, want %q", got, want)
+	}
+}
+
+func TestLoadDir_NoInstalledJSON_LeavesSHAsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	hj := `{
+		"name": "noinst",
+		"version": "0.1.0",
+		"default_vendor": "claude",
+		"includes": [{"git": "github.com/org/foo", "path": "x"}]
+	}`
+	if err := os.WriteFile(filepath.Join(dir, ".harness.json"), []byte(hj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir failed: %v", err)
+	}
+	if p.Includes[0].SHA != "" {
+		t.Errorf("include SHA = %q, want empty (no installed.json present)", p.Includes[0].SHA)
+	}
+}
+
 func TestLoadDir_RegistryProvenance(t *testing.T) {
 	dir := t.TempDir()
 	hj := `{

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -187,15 +187,28 @@ const InstalledFile = "installed.json"
 // InstalledJSON records where a harness was installed from.
 // It lives at .ynh-plugin/installed.json, separate from the author-controlled plugin.json.
 type InstalledJSON struct {
-	SourceType   string          `json:"source_type"`
-	Source       string          `json:"source"`
-	Ref          string          `json:"ref,omitempty"`
-	SHA          string          `json:"sha,omitempty"`
-	Path         string          `json:"path,omitempty"`
-	Namespace    string          `json:"namespace,omitempty"`
-	RegistryName string          `json:"registry_name,omitempty"`
-	InstalledAt  string          `json:"installed_at"`
-	ForkedFrom   *ForkedFromJSON `json:"forked_from,omitempty"`
+	SourceType   string               `json:"source_type"`
+	Source       string               `json:"source"`
+	Ref          string               `json:"ref,omitempty"`
+	SHA          string               `json:"sha,omitempty"`
+	Path         string               `json:"path,omitempty"`
+	Namespace    string               `json:"namespace,omitempty"`
+	RegistryName string               `json:"registry_name,omitempty"`
+	InstalledAt  string               `json:"installed_at"`
+	ForkedFrom   *ForkedFromJSON      `json:"forked_from,omitempty"`
+	Resolved     []ResolvedSourceJSON `json:"resolved,omitempty"`
+}
+
+// ResolvedSourceJSON records the resolved commit SHA for an include or
+// delegate at install/update time. Identity is the (Git, Ref, Path) triple
+// matching the manifest entry. Floating-ref entries (Ref == "" or branch
+// name) get their SHA filled here so consumers can compare against
+// ls-remote without re-resolving.
+type ResolvedSourceJSON struct {
+	Git  string `json:"git"`
+	Ref  string `json:"ref,omitempty"`
+	Path string `json:"path,omitempty"`
+	SHA  string `json:"sha"`
 }
 
 // ForkedFromJSON records the upstream a local harness was forked from.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -166,6 +166,7 @@ func ShortGitURL(url string) string {
 // RepoResult describes the outcome of EnsureRepo.
 type RepoResult struct {
 	Path    string // path to the cached repo on disk
+	SHA     string // resolved commit SHA at HEAD after fetch/checkout
 	Cloned  bool   // true if freshly cloned (not previously cached)
 	Changed bool   // true if HEAD moved during update
 }
@@ -194,7 +195,7 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 		if err := gitCmd(args...); err != nil {
 			return RepoResult{}, fmt.Errorf("git clone %s: %w", fullURL, err)
 		}
-		return RepoResult{Path: repoDir, Cloned: true, Changed: true}, nil
+		return RepoResult{Path: repoDir, SHA: gitHead(repoDir), Cloned: true, Changed: true}, nil
 	}
 
 	// Update existing clone — capture HEAD before and after
@@ -237,7 +238,7 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 		if err := gitCmd(args...); err != nil {
 			return RepoResult{}, fmt.Errorf("git clone %s: %w", fullURL, err)
 		}
-		return RepoResult{Path: repoDir, Cloned: true, Changed: true}, nil
+		return RepoResult{Path: repoDir, SHA: gitHead(repoDir), Cloned: true, Changed: true}, nil
 	}
 
 	if ref != "" {
@@ -251,7 +252,7 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 	}
 
 	after := gitHead(repoDir)
-	return RepoResult{Path: repoDir, Changed: before != after}, nil
+	return RepoResult{Path: repoDir, SHA: after, Changed: before != after}, nil
 }
 
 // CacheOnlyRepo returns a cached repo without hitting the network.
@@ -262,7 +263,7 @@ func CacheOnlyRepo(gitURL string, ref string) (RepoResult, error) {
 	repoDir := filepath.Join(cacheDir, repoDirName(gitURL, ref))
 
 	if _, err := os.Stat(filepath.Join(repoDir, ".git")); err == nil {
-		return RepoResult{Path: repoDir}, nil
+		return RepoResult{Path: repoDir, SHA: gitHead(repoDir)}, nil
 	}
 
 	// Cache miss — fall back to network fetch.


### PR DESCRIPTION
Closes #113.

Floating-ref includes had no place to record their resolved commit SHA, so `ref_installed` came back empty in `--check-updates` JSON output and downstream consumers (TermQ) couldn't detect drift.

## Changes

- `resolver.RepoResult` now exposes the resolved `SHA` after fetch/checkout
- `installed.json` gains a `resolved[]` slice recording per-source `(git, ref, path, sha)` triples at install/update time
- `harness.Include` / `harness.Delegate` gain an `SHA` field, backfilled on `Load` from `installed.json`
- `cmd/ynh/list.go` emits `ref_installed` from `inc.SHA` (falls back to `inc.Ref` for pre-migration installs)
- `probeInclude` uses the manifest `IsPinned` signal directly instead of re-classifying `RefInstalled` (which is now a SHA, not a fetchable ref)

## Migration

Zero-cost. Pre-migration `installed.json` lacks `resolved`, JSON unmarshal leaves the slice nil, fallback emits the manifest ref. First `ynh update <name>` after upgrade backfills.

## Verification

- `make check` green: lint 0, race-clean tests, both binaries build, `internal/harness` coverage 78.7% → 79.2%
- `/evals` PASS: 18 tutorials, 0 failures