### PR TITLE
fix(harness): correct drift signals for harness-level updates

### DIFF
--- a/cmd/ynh/check_updates.go
+++ b/cmd/ynh/check_updates.go
@@ -148,25 +148,43 @@ func probeHarness(entry *listEntry, probe updateProbe, mu *sync.Mutex) {
 	prov := entry.InstalledFrom
 	switch prov.SourceType {
 	case "registry":
-		version, sha, ok := probe.registry(entry.Name, prov.Source, prov.Path)
-		if !ok {
-			return
+		// Registry harnesses get two signals (Option C):
+		//   version_available / ref_available — from the registry entry's
+		//     marketplace.json (maintainer-controlled, may be stale)
+		//   sha_available — live ls-remote against the underlying git source
+		// They answer different questions ("has the registry entry moved?"
+		// vs "has the source moved since I installed?"). Consumers may want
+		// both — TermQ's badge logic can pick the stricter signal.
+		if version, sha, ok := probe.registry(entry.Name, prov.Source, prov.Path); ok {
+			mu.Lock()
+			if version != "" {
+				entry.VersionAvailable = version
+			}
+			if sha != "" {
+				entry.RefAvailable = sha
+			}
+			mu.Unlock()
 		}
-		mu.Lock()
-		if version != "" {
-			entry.VersionAvailable = version
+		if prov.Source != "" {
+			if sha, ok := probe.git(prov.Source, prov.Ref); ok {
+				mu.Lock()
+				entry.SHAAvailable = sha
+				mu.Unlock()
+			}
 		}
-		if sha != "" {
-			entry.RefAvailable = sha
-		}
-		mu.Unlock()
 	case "git":
 		// A git-installed harness was tracked at a specific ref; "available"
-		// is the current SHA of the same ref upstream.
-		ref := entry.RefInstalled
+		// is the current SHA of the same ref upstream. Prefer the recorded
+		// install ref so probe targets the same branch ynh update tracks.
+		// Pre-migration installs lack prov.Ref — fall back to RefInstalled
+		// (the legacy field that may hold the manifest ref). SHAAvailable
+		// mirrors RefAvailable for git source — they differ only for registry.
+		ref := prov.Ref
+		if ref == "" {
+			ref = entry.RefInstalled
+		}
 		if harness.IsPinnedRef(ref) {
-			// Pinned to a SHA — probe HEAD to surface "is there anything
-			// newer on the default branch" rather than re-resolving the SHA.
+			// Pinned to a SHA — probe HEAD instead of re-resolving the SHA.
 			ref = ""
 		}
 		sha, ok := probe.git(prov.Source, ref)
@@ -175,6 +193,7 @@ func probeHarness(entry *listEntry, probe updateProbe, mu *sync.Mutex) {
 		}
 		mu.Lock()
 		entry.RefAvailable = sha
+		entry.SHAAvailable = sha
 		mu.Unlock()
 	}
 }

--- a/cmd/ynh/check_updates_test.go
+++ b/cmd/ynh/check_updates_test.go
@@ -170,6 +170,86 @@ func TestFillUpdates_LocalHarnessNotProbed(t *testing.T) {
 	}
 }
 
+func TestFillUpdates_RegistryHarness_LiveSHAProbe(t *testing.T) {
+	// Registry harnesses get both signals: marketplace.json's recorded SHA
+	// (RefAvailable) AND a live ls-remote against the underlying git source
+	// using the recorded install ref (SHAAvailable). The two differ when
+	// marketplace.json is stale — the canonical motivating case for this
+	// dual-signal contract.
+	entries := []listEntry{{
+		Name: "demo",
+		InstalledFrom: &listInstalledFrom{
+			SourceType:   "registry",
+			Source:       "github.com/example/registry-harness",
+			Ref:          "main",
+			Path:         "harnesses/demo",
+			RegistryName: "demo-registry",
+		},
+	}}
+
+	fp := &fakeProbe{
+		gitResults: map[string]struct {
+			sha string
+			ok  bool
+		}{
+			"github.com/example/registry-harness|main": {sha: "live-sha", ok: true},
+		},
+		registryResults: map[string]struct {
+			version string
+			sha     string
+			ok      bool
+		}{
+			"demo|github.com/example/registry-harness|harnesses/demo": {
+				version: "0.2.0", sha: "stale-marketplace-sha", ok: true,
+			},
+		},
+	}
+	fillUpdates(entries, fp.probe())
+
+	if entries[0].VersionAvailable != "0.2.0" {
+		t.Errorf("version_available = %q, want 0.2.0", entries[0].VersionAvailable)
+	}
+	if entries[0].RefAvailable != "stale-marketplace-sha" {
+		t.Errorf("ref_available = %q, want stale-marketplace-sha", entries[0].RefAvailable)
+	}
+	if entries[0].SHAAvailable != "live-sha" {
+		t.Errorf("sha_available = %q, want live-sha", entries[0].SHAAvailable)
+	}
+}
+
+func TestFillUpdates_GitHarness_PrefersRecordedRef(t *testing.T) {
+	// Git harness with a recorded install ref — probe targets THAT ref, not
+	// the upstream HEAD. Catches the regression that motivated this fix:
+	// installs from a non-default branch that drift away from the new default.
+	entries := []listEntry{{
+		Name: "demo",
+		InstalledFrom: &listInstalledFrom{
+			SourceType: "git",
+			Source:     "github.com/example/harness-repo",
+			Ref:        "main",
+		},
+		RefInstalled: "old-main-sha",
+	}}
+
+	fp := &fakeProbe{
+		gitResults: map[string]struct {
+			sha string
+			ok  bool
+		}{
+			"github.com/example/harness-repo|main": {sha: "main-tip", ok: true},
+			"github.com/example/harness-repo|":     {sha: "head-of-default", ok: true},
+		},
+	}
+	fillUpdates(entries, fp.probe())
+
+	if entries[0].SHAAvailable != "main-tip" {
+		t.Errorf("sha_available = %q, want main-tip (probed via recorded ref)", entries[0].SHAAvailable)
+	}
+	if entries[0].RefAvailable != "main-tip" {
+		t.Errorf("ref_available = %q, want main-tip (mirrors sha for git source)", entries[0].RefAvailable)
+	}
+}
+
 func TestFillUpdates_GitHarnessProbesSource(t *testing.T) {
 	entries := []listEntry{{
 		Name:         "demo",

--- a/cmd/ynh/info.go
+++ b/cmd/ynh/info.go
@@ -34,6 +34,7 @@ type infoEntry struct {
 	Path             string             `json:"path"`
 	RefInstalled     string             `json:"ref_installed,omitempty"`
 	RefAvailable     string             `json:"ref_available,omitempty"`
+	SHAAvailable     string             `json:"sha_available,omitempty"`
 	IsPinned         bool               `json:"is_pinned"`
 	InstalledFrom    *listInstalledFrom `json:"installed_from,omitempty"`
 	Includes         []listInclude      `json:"includes"`
@@ -304,6 +305,7 @@ func printInfoJSON(stdout, stderr io.Writer, name string, checkUpdates bool) err
 		Path:             base.Path,
 		RefInstalled:     base.RefInstalled,
 		RefAvailable:     base.RefAvailable,
+		SHAAvailable:     base.SHAAvailable,
 		IsPinned:         base.IsPinned,
 		InstalledFrom:    base.InstalledFrom,
 		Includes:         base.Includes,

--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -25,24 +25,35 @@ type listEnvelope struct {
 // listEntry is the JSON shape for a single harness in the `ynh ls` output.
 // Field order drives JSON key order via MarshalIndent.
 type listEntry struct {
-	Name             string             `json:"name"`
-	VersionInstalled string             `json:"version_installed"`
-	VersionAvailable string             `json:"version_available,omitempty"`
-	Description      string             `json:"description,omitempty"`
-	DefaultVendor    string             `json:"default_vendor"`
-	Path             string             `json:"path"`
-	RefInstalled     string             `json:"ref_installed,omitempty"`
-	RefAvailable     string             `json:"ref_available,omitempty"`
-	IsPinned         bool               `json:"is_pinned"`
-	InstalledFrom    *listInstalledFrom `json:"installed_from,omitempty"`
-	Artifacts        listArtifacts      `json:"artifacts"`
-	Includes         []listInclude      `json:"includes"`
-	DelegatesTo      []listDelegate     `json:"delegates_to"`
+	Name             string `json:"name"`
+	VersionInstalled string `json:"version_installed"`
+	VersionAvailable string `json:"version_available,omitempty"`
+	Description      string `json:"description,omitempty"`
+	DefaultVendor    string `json:"default_vendor"`
+	Path             string `json:"path"`
+	RefInstalled     string `json:"ref_installed,omitempty"`
+	RefAvailable     string `json:"ref_available,omitempty"`
+	// SHAAvailable is the live upstream SHA for the harness source itself
+	// (probed via ls-remote against the recorded install ref). Distinct from
+	// RefAvailable, which for registry harnesses comes from the registry
+	// entry's recorded SHA. Both can be present — answers different
+	// questions: "has the source moved?" vs "has the registry entry moved?".
+	SHAAvailable  string             `json:"sha_available,omitempty"`
+	IsPinned      bool               `json:"is_pinned"`
+	InstalledFrom *listInstalledFrom `json:"installed_from,omitempty"`
+	Artifacts     listArtifacts      `json:"artifacts"`
+	Includes      []listInclude      `json:"includes"`
+	DelegatesTo   []listDelegate     `json:"delegates_to"`
 }
 
 type listInstalledFrom struct {
-	SourceType   string          `json:"source_type"`
-	Source       string          `json:"source"`
+	SourceType string `json:"source_type"`
+	Source     string `json:"source"`
+	// Ref is the branch/tag/SHA recorded at install time — the ref this
+	// harness actually tracks. Used by --check-updates to probe the same ref
+	// ynh update tracks. Empty for pre-migration installs.
+	Ref          string          `json:"ref,omitempty"`
+	SHA          string          `json:"sha,omitempty"`
 	Path         string          `json:"path,omitempty"`
 	RegistryName string          `json:"registry_name,omitempty"`
 	InstalledAt  string          `json:"installed_at"`
@@ -237,6 +248,8 @@ func buildListEntry(p *harness.Harness) listEntry {
 		entry.InstalledFrom = &listInstalledFrom{
 			SourceType:   p.InstalledFrom.SourceType,
 			Source:       p.InstalledFrom.Source,
+			Ref:          p.InstalledFrom.Ref,
+			SHA:          p.InstalledFrom.SHA,
 			Path:         p.InstalledFrom.Path,
 			RegistryName: p.InstalledFrom.RegistryName,
 			InstalledAt:  p.InstalledFrom.InstalledAt,

--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/resolver"
 )
 
 // listEnvelope wraps the array of harnesses with the wire-contract version
@@ -224,10 +225,48 @@ func printListJSON(w io.Writer, checkUpdates bool) error {
 	return err
 }
 
+// backfillProvenanceFromCache populates harness-level SHA/Ref from the local
+// git cache when installed.json predates SHA/ref recording. The cache's
+// origin/HEAD symref pins to the branch resolved at clone time and survives
+// upstream default-branch changes, so it's a reliable source for what the
+// install actually tracks. No network call.
+func backfillProvenanceFromCache(prov *harness.Provenance) {
+	if prov == nil {
+		return
+	}
+	if prov.SHA != "" && prov.Ref != "" {
+		return
+	}
+	switch prov.SourceType {
+	case "git", "registry":
+		// continue
+	default:
+		return
+	}
+	if prov.Source == "" {
+		return
+	}
+	res, ok := resolver.LookupCache(prov.Source, prov.Ref)
+	if !ok {
+		return
+	}
+	if prov.SHA == "" {
+		prov.SHA = res.SHA
+	}
+	if prov.Ref == "" {
+		prov.Ref = res.ResolvedRef
+	}
+}
+
 // buildListEntry assembles the structured-output entry for a loaded harness.
 // Shared by cmdListTo and cmdInfoTo so the per-harness shape stays uniform
 // between the two commands.
 func buildListEntry(p *harness.Harness) listEntry {
+	// Best-effort backfill of pre-migration provenance from the cache so
+	// downstream consumers see a populated installed_from.{sha,ref} without
+	// requiring a manual `ynh update`.
+	backfillProvenanceFromCache(p.InstalledFrom)
+
 	entry := listEntry{
 		Name:             p.Name,
 		VersionInstalled: p.Version,

--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -71,9 +71,13 @@ type listArtifacts struct {
 
 type listInclude struct {
 	Git string `json:"git"`
-	// Ref is the manifest pin (branch, tag, or SHA) declared in plugin.json.
-	// Internal field — not emitted in JSON output. Used by --check-updates
-	// to know which upstream ref to probe for floating-ref includes.
+	// Ref is the ref this include actually tracks — equal to the manifest
+	// pin if non-empty, otherwise the resolved branch name recorded in
+	// installed.json (e.g. "main" for an empty manifest ref where the
+	// cache resolved to main at clone time). Internal field, not emitted
+	// in JSON output. Used by --check-updates to probe the same ref that
+	// ynh update tracks, so the two stay consistent across upstream
+	// default-branch changes.
 	Ref          string   `json:"-"`
 	RefInstalled string   `json:"ref_installed,omitempty"`
 	RefAvailable string   `json:"ref_available,omitempty"`
@@ -83,8 +87,11 @@ type listInclude struct {
 }
 
 type listDelegate struct {
-	Git          string `json:"git"`
+	Git string `json:"git"`
+	// Ref — see listInclude.Ref.
+	Ref          string `json:"-"`
 	RefInstalled string `json:"ref_installed,omitempty"`
+	RefAvailable string `json:"ref_available,omitempty"`
 	IsPinned     bool   `json:"is_pinned"`
 	Path         string `json:"path,omitempty"`
 }
@@ -270,9 +277,16 @@ func buildIncludes(includes []harness.Include) []listInclude {
 		if refInstalled == "" {
 			refInstalled = inc.Ref
 		}
+		// Probe target: prefer the ref recorded in installed.json (the actual
+		// tracked branch) over the manifest ref, so default-branch changes
+		// upstream don't produce phantom drift against ynh update.
+		probeRef := inc.ResolvedRef
+		if probeRef == "" {
+			probeRef = inc.Ref
+		}
 		li := listInclude{
 			Git:          inc.Git,
-			Ref:          inc.Ref,
+			Ref:          probeRef,
 			RefInstalled: refInstalled,
 			IsPinned:     harness.IsPinnedRef(inc.Ref),
 			Path:         inc.Path,
@@ -292,8 +306,13 @@ func buildDelegates(delegates []harness.Delegate) []listDelegate {
 		if refInstalled == "" {
 			refInstalled = del.Ref
 		}
+		probeRef := del.ResolvedRef
+		if probeRef == "" {
+			probeRef = del.Ref
+		}
 		result = append(result, listDelegate{
 			Git:          del.Git,
+			Ref:          probeRef,
 			RefInstalled: refInstalled,
 			IsPinned:     harness.IsPinnedRef(del.Ref),
 			Path:         del.Path,

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -212,6 +212,12 @@ func cmdInstall(args []string) error {
 	// 6. Plain word → registry search
 	var srcDir string
 
+	// Captured from EnsureRepo when the install resolves to a git/registry
+	// source. Used to record harness-level provenance into installed.json so
+	// --check-updates can detect drift between the installed harness and
+	// upstream (symmetric to per-include resolved tracking).
+	var harnessSHA, harnessResolvedRef string
+
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
@@ -254,6 +260,10 @@ func cmdInstall(args []string) error {
 			return err
 		}
 		srcDir = result.Path
+		// Capture the resolved harness-source SHA and ref so installed.json
+		// can record them. Empty for local installs (set in the local branch).
+		harnessSHA = result.SHA
+		harnessResolvedRef = result.ResolvedRef
 	}
 
 	// Scope to subdirectory if --path was specified
@@ -325,6 +335,8 @@ func cmdInstall(args []string) error {
 	ins := &plugin.InstalledJSON{
 		SourceType:   resolved.sourceType,
 		Source:       provSource,
+		Ref:          harnessResolvedRef,
+		SHA:          harnessSHA,
 		Path:         pathFlag,
 		Namespace:    resolved.namespace,
 		RegistryName: resolved.registryName,
@@ -455,6 +467,23 @@ func cmdUninstall(args []string) error {
 	return nil
 }
 
+// harnessHasRemoteSource reports whether the harness was installed from a
+// git or registry source we can re-pull. Local installs and forks are
+// excluded — those have no upstream to track.
+func harnessHasRemoteSource(p *harness.Harness) bool {
+	if p.InstalledFrom == nil {
+		return false
+	}
+	if p.InstalledFrom.ForkedFrom != nil {
+		return false
+	}
+	switch p.InstalledFrom.SourceType {
+	case "git", "registry":
+		return p.InstalledFrom.Source != ""
+	}
+	return false
+}
+
 func cmdUpdate(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("usage: ynh update <harness-name>")
@@ -473,7 +502,10 @@ func cmdUpdate(args []string) error {
 			"  To incorporate upstream changes, fork again from the re-installed original", name)
 	}
 
-	if len(p.Includes) == 0 && len(p.DelegatesTo) == 0 {
+	// A harness is updateable if it has a remote source (git/registry) OR
+	// any includes/delegates. Pure local installs have nothing to pull.
+	hasHarnessSource := harnessHasRemoteSource(p)
+	if len(p.Includes) == 0 && len(p.DelegatesTo) == 0 && !hasHarnessSource {
 		fmt.Printf("Harness %q has no Git sources to update.\n", name)
 		return nil
 	}
@@ -486,6 +518,48 @@ func cmdUpdate(args []string) error {
 
 	checked := 0
 	updated := 0
+	// Re-pull the harness source itself first so any newly-added includes
+	// or delegates upstream are visible to the include walk below.
+	var harnessSHA, harnessResolvedRef string
+	if hasHarnessSource {
+		gitURL := p.InstalledFrom.Source
+		if err := cfg.CheckRemoteSource(gitURL); err != nil {
+			return fmt.Errorf("harness source %q: %w", gitURL, err)
+		}
+		fmt.Printf("Checking harness source %s...\n", gitURL)
+		ref := p.InstalledFrom.Ref
+		result, err := resolver.EnsureRepo(gitURL, ref)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  Warning: %v\n", err)
+		} else {
+			checked++
+			harnessSHA = result.SHA
+			harnessResolvedRef = result.ResolvedRef
+			if result.Changed {
+				updated++
+				fmt.Printf("  Updated.\n")
+				// Sync the installed harness directory with the new content.
+				// Skip when source path is empty (whole-repo install) or path
+				// doesn't exist in the new tree.
+				newSrcDir := result.Path
+				if p.InstalledFrom.Path != "" {
+					newSrcDir = filepath.Join(result.Path, p.InstalledFrom.Path)
+				}
+				if _, statErr := os.Stat(newSrcDir); statErr == nil {
+					if err := assembler.CopyDir(newSrcDir, p.Dir); err != nil {
+						fmt.Fprintf(os.Stderr, "  Warning: copying refreshed harness: %v\n", err)
+					}
+					// Reload after content refresh so include/delegate slices
+					// reflect any newly-added entries from upstream.
+					if reloaded, reloadErr := harness.LoadDir(p.Dir); reloadErr == nil {
+						p = reloaded
+					}
+				}
+			} else {
+				fmt.Printf("  Already up to date.\n")
+			}
+		}
+	}
 	resolvedSources := make([]plugin.ResolvedSourceJSON, 0, len(p.Includes)+len(p.DelegatesTo))
 	for _, inc := range p.Includes {
 		// Local-path includes have no cache entry to refresh.
@@ -541,9 +615,17 @@ func cmdUpdate(args []string) error {
 	}
 
 	// Persist resolved SHAs back to installed.json so subsequent --check-updates
-	// queries can compare against the recorded SHA without re-fetching.
+	// queries can compare against the recorded SHA without re-fetching. Also
+	// refresh the harness-level SHA/Ref when re-pulled so the harness's own
+	// drift signal stays accurate.
 	if ins, loadErr := plugin.LoadInstalledJSON(p.Dir); loadErr == nil && ins != nil {
 		ins.Resolved = resolvedSources
+		if hasHarnessSource && harnessSHA != "" {
+			ins.SHA = harnessSHA
+			if harnessResolvedRef != "" {
+				ins.Ref = harnessResolvedRef
+			}
+		}
 		if err := plugin.SaveInstalledJSON(p.Dir, ins); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not update installed.json: %v\n", err)
 		}

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -357,7 +357,7 @@ func cmdInstall(args []string) error {
 		}
 		ins.Resolved = append(ins.Resolved, plugin.ResolvedSourceJSON{
 			Git:  inc.Git,
-			Ref:  inc.Ref,
+			Ref:  res.ResolvedRef,
 			Path: inc.Path,
 			SHA:  res.SHA,
 		})
@@ -375,7 +375,7 @@ func cmdInstall(args []string) error {
 		}
 		ins.Resolved = append(ins.Resolved, plugin.ResolvedSourceJSON{
 			Git:  del.Git,
-			Ref:  del.Ref,
+			Ref:  res.ResolvedRef,
 			Path: del.Path,
 			SHA:  res.SHA,
 		})
@@ -504,7 +504,7 @@ func cmdUpdate(args []string) error {
 		checked++
 		resolvedSources = append(resolvedSources, plugin.ResolvedSourceJSON{
 			Git:  inc.Git,
-			Ref:  inc.Ref,
+			Ref:  result.ResolvedRef,
 			Path: inc.Path,
 			SHA:  result.SHA,
 		})
@@ -528,7 +528,7 @@ func cmdUpdate(args []string) error {
 		checked++
 		resolvedSources = append(resolvedSources, plugin.ResolvedSourceJSON{
 			Git:  del.Git,
-			Ref:  del.Ref,
+			Ref:  result.ResolvedRef,
 			Path: del.Path,
 			SHA:  result.SHA,
 		})

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -119,24 +119,27 @@ Per-harness fields:
 | `default_vendor` | Vendor for `ynh run` without `-v` |
 | `path` | Absolute path to the installed harness directory |
 | `ref_installed` | Currently installed Git ref or SHA — omitted when there is no Git provenance |
-| `ref_available` | Latest Git SHA known upstream — same omission rules as `version_available` |
+| `ref_available` | Latest Git SHA known upstream — same omission rules as `version_available`. For registry harnesses this is the registry entry's recorded SHA (may lag the actual source); for git harnesses it equals `sha_available` |
+| `sha_available` | Live upstream SHA from a fresh `git ls-remote` against `installed_from.source` at the recorded `installed_from.ref` — answers "has the source moved since I installed?" independently of registry freshness. Omitted with the same rules as `ref_available` |
 | `is_pinned` | `true` iff `ref_installed` matches `^[0-9a-f]{7,40}$` (resolved SHA). Tags and branches are floating |
-| `installed_from` | Provenance object — `source_type`, `source`, `installed_at`, optional `path`, `registry_name`, `forked_from` |
+| `installed_from` | Provenance object — `source_type`, `source`, optional `ref`, `sha`, `path`, `registry_name`, `installed_at`, `forked_from` |
+| `installed_from.ref` | Branch/tag/SHA recorded at install time — the ref this harness actually tracks. Empty for pre-migration installs (re-run `ynh update <name>` to backfill) |
+| `installed_from.sha` | Resolved commit SHA at install time. Empty for pre-migration installs |
 | `installed_from.forked_from` | Upstream a forked harness was copied from — `source_type`, `source`, `version`, `sha`, optional `ref`, `path`, `registry_name`. Absent on non-fork installs |
 | `artifacts` | (`ynh ls` only) Counts: `skills`, `agents`, `rules`, `commands` |
 | `includes` | Array of include objects: `git`, `ref_installed`, `ref_available`, `is_pinned`, optional `path`, `pick` |
-| `delegates_to` | Array of delegate objects: `git`, `ref_installed`, `is_pinned`, optional `path` |
+| `delegates_to` | Array of delegate objects: `git`, `ref_installed`, `ref_available`, `is_pinned`, optional `path` |
 | `manifest` | (`ynh info` only) Raw `.ynh-plugin/plugin.json` body, JSON-compacted |
 
 #### `--check-updates` flag
 
-`ynh info` and `ynh ls` accept `--check-updates` together with `--format json`. The flag opts in to upstream lookups for `version_available` and `ref_available`. Without it, those fields are always omitted (the "unknown" three-state).
+`ynh info` and `ynh ls` accept `--check-updates` together with `--format json`. The flag opts in to upstream lookups for `version_available`, `ref_available`, and `sha_available`. Without it, those fields are always omitted (the "unknown" three-state).
 
 What gets probed:
 
-- **Includes** (per `git`, with a remote URL): `git ls-remote` against the upstream URL, returning the current SHA on `ref_installed`. **Pinned includes** (`is_pinned: true`) probe `HEAD` instead of re-resolving the pinned SHA — otherwise a pinned include could never appear behind upstream.
-- **Registry-installed harnesses**: configured registries are walked and the matching entry's version becomes `version_available`.
-- **Git-installed harnesses**: same as include probing, against the harness's own `installed_from.source`.
+- **Includes and delegates** (per `git`, with a remote URL): `git ls-remote` against the upstream URL, targeting the recorded install ref (`installed.json.resolved[].ref`) — the branch the cache actually tracks. Falls back to the manifest ref for pre-migration installs. **Pinned entries** (`is_pinned: true`) probe `HEAD` instead of re-resolving the pinned SHA — otherwise a pinned entry could never appear behind upstream.
+- **Registry-installed harnesses**: configured registries are walked. The matching entry's version → `version_available`; the entry's recorded SHA → `ref_available` (maintainer-controlled, may be stale). A live `ls-remote` against `installed_from.source` at `installed_from.ref` → `sha_available`.
+- **Git-installed harnesses**: live `ls-remote` against `installed_from.source` at the recorded ref → `ref_available` and `sha_available` (identical for this source type).
 - **Local-only harnesses** (no `installed_from`, or `source_type: "local"` without a remote): no probe possible — fields stay omitted.
 
 > Note: `--check-updates` performs network calls. Failures degrade silently — fields are simply omitted, the command does not error. Default `info` and `ls` calls (without the flag) remain offline, fast, and deterministic. Probes run concurrently (bounded fan-out) so a multi-include harness does not serialize the network.

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -41,6 +41,12 @@ type Include struct {
 	// installed.json's resolved slice. Empty for local-path includes and for
 	// pre-migration installs that predate SHA recording.
 	SHA string
+	// ResolvedRef is the branch name actually tracked at install/update time.
+	// For non-empty manifest refs it equals the manifest ref. For empty
+	// manifest refs it is the cache's resolved default branch (e.g. "main")
+	// captured at clone time. Used by --check-updates so probe targets the
+	// same ref that ynh update tracks. Empty for pre-migration installs.
+	ResolvedRef string
 }
 
 type Delegate struct {
@@ -48,6 +54,8 @@ type Delegate struct {
 	// SHA is the resolved commit at install/update time, populated from
 	// installed.json's resolved slice. Empty for pre-migration installs.
 	SHA string
+	// ResolvedRef — see Include.ResolvedRef.
+	ResolvedRef string
 }
 
 // Provenance records where a harness was installed from.
@@ -319,26 +327,38 @@ func LoadDir(dir string) (*Harness, error) {
 		})
 	}
 
-	// Backfill resolved SHAs from installed.json onto includes/delegates so
-	// downstream consumers (list, info, --check-updates) have a recorded
-	// commit even for floating refs.
+	// Backfill resolved SHAs and resolved refs from installed.json onto
+	// includes/delegates so downstream consumers (list, info,
+	// --check-updates) have both a recorded commit and the ref that was
+	// actually tracked, even for floating manifest refs.
+	//
+	// Matching: prefer an exact (git, ref, path) match against the manifest
+	// ref. If none, fall back to (git, path). The fallback covers the
+	// floating-ref case where the manifest ref is empty but the resolved
+	// entry's ref records the cache's default branch — e.g. "main" — that
+	// the install actually tracked.
 	if ins, err := plugin.LoadInstalledJSON(dir); err == nil && ins != nil && len(ins.Resolved) > 0 {
-		shaFor := func(git, ref, path string) string {
+		find := func(git, ref, path string) (sha, resolvedRef string) {
 			for _, r := range ins.Resolved {
 				if r.Git == git && r.Ref == ref && r.Path == path {
-					return r.SHA
+					return r.SHA, r.Ref
 				}
 			}
-			return ""
+			for _, r := range ins.Resolved {
+				if r.Git == git && r.Path == path {
+					return r.SHA, r.Ref
+				}
+			}
+			return "", ""
 		}
 		for i := range p.Includes {
 			if p.Includes[i].Git == "" {
 				continue
 			}
-			p.Includes[i].SHA = shaFor(p.Includes[i].Git, p.Includes[i].Ref, p.Includes[i].Path)
+			p.Includes[i].SHA, p.Includes[i].ResolvedRef = find(p.Includes[i].Git, p.Includes[i].Ref, p.Includes[i].Path)
 		}
 		for i := range p.DelegatesTo {
-			p.DelegatesTo[i].SHA = shaFor(p.DelegatesTo[i].Git, p.DelegatesTo[i].Ref, p.DelegatesTo[i].Path)
+			p.DelegatesTo[i].SHA, p.DelegatesTo[i].ResolvedRef = find(p.DelegatesTo[i].Git, p.DelegatesTo[i].Ref, p.DelegatesTo[i].Path)
 		}
 	}
 	if len(hj.Hooks) > 0 {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -165,10 +165,17 @@ func ShortGitURL(url string) string {
 
 // RepoResult describes the outcome of EnsureRepo.
 type RepoResult struct {
-	Path    string // path to the cached repo on disk
-	SHA     string // resolved commit SHA at HEAD after fetch/checkout
-	Cloned  bool   // true if freshly cloned (not previously cached)
-	Changed bool   // true if HEAD moved during update
+	Path string // path to the cached repo on disk
+	SHA  string // resolved commit SHA at HEAD after fetch/checkout
+	// ResolvedRef is the branch name actually tracked by this clone.
+	// For non-empty input refs it equals the input ref. For empty input
+	// refs it is read from the cache's origin/HEAD symref (the default
+	// branch as of clone time, which never auto-updates with upstream
+	// default-branch changes). Used by --check-updates to probe the same
+	// ref that ynh update tracks, so the two stay consistent.
+	ResolvedRef string
+	Cloned      bool // true if freshly cloned (not previously cached)
+	Changed     bool // true if HEAD moved during update
 }
 
 // EnsureRepo clones or updates a Git repo in the cache directory.
@@ -195,7 +202,7 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 		if err := gitCmd(args...); err != nil {
 			return RepoResult{}, fmt.Errorf("git clone %s: %w", fullURL, err)
 		}
-		return RepoResult{Path: repoDir, SHA: gitHead(repoDir), Cloned: true, Changed: true}, nil
+		return RepoResult{Path: repoDir, SHA: gitHead(repoDir), ResolvedRef: effectiveRef(repoDir, ref), Cloned: true, Changed: true}, nil
 	}
 
 	// Update existing clone — capture HEAD before and after
@@ -238,7 +245,7 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 		if err := gitCmd(args...); err != nil {
 			return RepoResult{}, fmt.Errorf("git clone %s: %w", fullURL, err)
 		}
-		return RepoResult{Path: repoDir, SHA: gitHead(repoDir), Cloned: true, Changed: true}, nil
+		return RepoResult{Path: repoDir, SHA: gitHead(repoDir), ResolvedRef: effectiveRef(repoDir, ref), Cloned: true, Changed: true}, nil
 	}
 
 	if ref != "" {
@@ -252,7 +259,7 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 	}
 
 	after := gitHead(repoDir)
-	return RepoResult{Path: repoDir, SHA: after, Changed: before != after}, nil
+	return RepoResult{Path: repoDir, SHA: after, ResolvedRef: effectiveRef(repoDir, ref), Changed: before != after}, nil
 }
 
 // CacheOnlyRepo returns a cached repo without hitting the network.
@@ -263,7 +270,7 @@ func CacheOnlyRepo(gitURL string, ref string) (RepoResult, error) {
 	repoDir := filepath.Join(cacheDir, repoDirName(gitURL, ref))
 
 	if _, err := os.Stat(filepath.Join(repoDir, ".git")); err == nil {
-		return RepoResult{Path: repoDir, SHA: gitHead(repoDir)}, nil
+		return RepoResult{Path: repoDir, SHA: gitHead(repoDir), ResolvedRef: effectiveRef(repoDir, ref)}, nil
 	}
 
 	// Cache miss — fall back to network fetch.
@@ -304,6 +311,38 @@ func resolveGitBin() string {
 		}
 	}
 	return "git" // last resort — let exec fail with a clear error
+}
+
+// resolvedBranchName returns the bare branch name that origin/HEAD points to
+// in the local cache (e.g. "main" or "develop"). Empty if the symref is not
+// set or doesn't point at a remote-tracking branch under origin/.
+//
+// We capture this so --check-updates probes the same ref that ynh update
+// tracks. Git pins this symref at clone time and does not auto-update it
+// when upstream changes its default branch — which is exactly the divergence
+// that makes phantom drift possible.
+func resolvedBranchName(repoDir string) string {
+	cmd := exec.Command(gitBin, "-C", repoDir, "symbolic-ref", "refs/remotes/origin/HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	ref := strings.TrimSpace(string(out))
+	const prefix = "refs/remotes/origin/"
+	if !strings.HasPrefix(ref, prefix) {
+		return ""
+	}
+	return strings.TrimPrefix(ref, prefix)
+}
+
+// effectiveRef returns the ref to record alongside this clone. If the caller
+// supplied an explicit ref it is echoed; otherwise the cache's resolved
+// branch name is returned (empty string if it cannot be determined).
+func effectiveRef(repoDir, inputRef string) string {
+	if inputRef != "" {
+		return inputRef
+	}
+	return resolvedBranchName(repoDir)
 }
 
 func gitHead(repoDir string) string {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -266,16 +266,26 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 // If the cache entry exists, it is returned as-is. If not, it falls back to
 // EnsureRepo (which clones from the network) and prints a warning to stderr.
 func CacheOnlyRepo(gitURL string, ref string) (RepoResult, error) {
-	cacheDir := config.CacheDir()
-	repoDir := filepath.Join(cacheDir, repoDirName(gitURL, ref))
-
-	if _, err := os.Stat(filepath.Join(repoDir, ".git")); err == nil {
-		return RepoResult{Path: repoDir, SHA: gitHead(repoDir), ResolvedRef: effectiveRef(repoDir, ref)}, nil
+	if res, ok := LookupCache(gitURL, ref); ok {
+		return res, nil
 	}
-
 	// Cache miss — fall back to network fetch.
 	// Caller can detect this via RepoResult.Cloned.
 	return EnsureRepo(gitURL, ref)
+}
+
+// LookupCache returns the cached repo state for (gitURL, ref) without hitting
+// the network. ok=false if no cache entry exists. Used to backfill harness
+// provenance for pre-migration installs whose installed.json predates SHA/ref
+// recording — we can still recover the install ref from the cache's pinned
+// origin/HEAD symref.
+func LookupCache(gitURL string, ref string) (RepoResult, bool) {
+	cacheDir := config.CacheDir()
+	repoDir := filepath.Join(cacheDir, repoDirName(gitURL, ref))
+	if _, err := os.Stat(filepath.Join(repoDir, ".git")); err != nil {
+		return RepoResult{}, false
+	}
+	return RepoResult{Path: repoDir, SHA: gitHead(repoDir), ResolvedRef: effectiveRef(repoDir, ref)}, true
 }
 
 // ResolveGitSourceFromCache is like ResolveGitSource but uses CacheOnlyRepo


### PR DESCRIPTION
## Summary

Three fixes uncovered by TermQ integration testing of the per-include SHA work in #115:

- **Probe the recorded ref, not upstream HEAD.** `--check-updates` was running `ls-remote` without a ref, so floating-ref installs always reported drift against the remote default branch. Now probes `prov.Ref` (with `RefInstalled` fallback for pre-migration installs).
- **Detect harness-level drift.** Self-contained harnesses (no includes) had no drift signal at all. `cmdInstall` now records harness SHA/ref into `installed.json`; `cmdUpdate` refreshes the harness directory itself when drifted; `ynh ls/info` emit `installed_from.sha` and `sha_available`.
- **Backfill provenance from cache.** Pre-migration installs with no recorded SHA/ref now resolve from the local clone via `resolver.LookupCache`, so the new fields populate without forcing a `ynh update`. Also fixes `infoEntry` missing the `SHAAvailable` field copy.

For registry harnesses, `ref_available` (marketplace SHA) and `sha_available` (live ls-remote of the underlying source) are now distinct signals — consumers like TermQ can pick the stricter one.

## Test plan

- [x] `make check` — green
- [x] `/evals` — PASS (8 tutorials, 19 steps, 0 failures)
- [x] Live verification against `gitflow` install: `installed_from.sha`, `installed_from.ref`, and `sha_available` all populate correctly; equal SHAs report no drift