### PR TITLE
fix(fork): resolve namespaced installs via loaded harness Dir

### DIFF
--- a/cmd/ynh/fork.go
+++ b/cmd/ynh/fork.go
@@ -75,8 +75,10 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 			fmt.Sprintf("invalid --format value %q (want text or json)", format))
 	}
 
-	// Load source harness
-	p, err := harness.Load(name)
+	// Load source harness. LoadQualified accepts both bare names ("researcher")
+	// and namespace-qualified refs ("researcher@org/repo") so callers can
+	// disambiguate when two registries publish the same name.
+	p, err := harness.LoadQualified(name)
 	if err != nil {
 		code := errCodeNotFound
 		if !strings.Contains(err.Error(), "not found") {
@@ -93,7 +95,7 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 			return cliError(stderr, structured, errCodeIOError,
 				fmt.Sprintf("getting working directory: %v", cwdErr))
 		}
-		destDir = filepath.Join(cwd, name)
+		destDir = filepath.Join(cwd, p.Name)
 	}
 	absDestDir, absErr := filepath.Abs(destDir)
 	if absErr != nil {
@@ -107,7 +109,9 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 			fmt.Sprintf("destination already exists: %s", absDestDir))
 	}
 
-	installDir := harness.InstalledDir(name)
+	// p.Dir is the resolved install directory — works for both flat and
+	// namespaced layouts (.ynh/harnesses/<ns--repo>/<name>/).
+	installDir := p.Dir
 
 	// Copy harness files to destination
 	if mkErr := os.MkdirAll(absDestDir, 0o755); mkErr != nil {
@@ -173,7 +177,7 @@ func buildForkedFrom(p *harness.Harness) *plugin.ForkedFromJSON {
 	if p.InstalledFrom == nil {
 		return &plugin.ForkedFromJSON{
 			SourceType: "local",
-			Source:     harness.InstalledDir(p.Name),
+			Source:     p.Dir,
 			Version:    p.Version,
 		}
 	}

--- a/cmd/ynh/fork_test.go
+++ b/cmd/ynh/fork_test.go
@@ -101,6 +101,56 @@ func TestCmdFork_DestAlreadyExists(t *testing.T) {
 	}
 }
 
+// installNamespacedForkTestHarness writes a harness under
+// YNH_HOME/harnesses/<ns--repo>/<name>/, mirroring how registry installs land.
+func installNamespacedForkTestHarness(t *testing.T, home, fsNS, name string, ins *plugin.InstalledJSON) string {
+	t.Helper()
+	dir := filepath.Join(home, "harnesses", fsNS, name)
+	if err := os.MkdirAll(filepath.Join(dir, plugin.PluginDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hj := `{"name":"` + name + `","version":"0.1.0","default_vendor":"claude"}`
+	if err := os.WriteFile(filepath.Join(dir, plugin.PluginDir, plugin.PluginFile), []byte(hj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if ins != nil {
+		if err := plugin.SaveInstalledJSON(dir, ins); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestCmdFork_NamespacedInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installNamespacedForkTestHarness(t, home, "eyelock--assistants", "researcher", &plugin.InstalledJSON{
+		SourceType:   "registry",
+		Source:       "github.com/eyelock/assistants",
+		Ref:          "main",
+		SHA:          "abc123",
+		RegistryName: "eyelock-assistants",
+		InstalledAt:  "2026-01-01T00:00:00Z",
+	})
+
+	dest := filepath.Join(t.TempDir(), "forked-researcher")
+	if err := cmdForkTo([]string{"researcher", "--to", dest}, io.Discard, io.Discard); err != nil {
+		t.Fatalf("cmdForkTo: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dest, plugin.PluginDir, plugin.PluginFile)); err != nil {
+		t.Errorf("plugin.json not found in dest: %v", err)
+	}
+
+	ins, err := plugin.LoadInstalledJSON(dest)
+	if err != nil {
+		t.Fatalf("LoadInstalledJSON: %v", err)
+	}
+	if ins.ForkedFrom == nil || ins.ForkedFrom.RegistryName != "eyelock-assistants" {
+		t.Errorf("forked_from registry not preserved: %+v", ins.ForkedFrom)
+	}
+}
+
 func TestCmdFork_NotFound(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("YNH_HOME", home)


### PR DESCRIPTION
## Summary

- `ynh fork <name>` recomputed a flat install path (`harnesses/<name>`) instead of using the directory the lookup actually resolved, so registry installs under namespaced paths (`harnesses/<ns--repo>/<name>/`) failed with `lstat .../harnesses/<name>: no such file or directory`.
- Use the resolved `p.Dir` from the loaded harness for both the copy source and the local-fallback `forked_from.source`.
- Switch to `harness.LoadQualified` so callers can disambiguate with `name@org/repo` when two registries publish the same harness name.

Same class of bug fixed for `ResolveEditTarget` in #106 and for `ls`/`info`/`uninstall` in #104.

## Repro (before)

\`\`\`
ynh install eyelock-assistants:researcher
ynh fork researcher --to /tmp/forked-researcher --format json
# {"error":{"code":"io_error","message":"copying harness: lstat /Users/.../.ynh/harnesses/researcher: no such file or directory"}}
\`\`\`

## Test plan

- [x] New unit test \`TestCmdFork_NamespacedInstall\` exercises the registry-namespaced layout
- [x] \`make check\` green
- [x] \`/evals\` PASS (18 tutorials + 22 edge cases, 0 failures)
- [x] Manual repro: install + fork against \`eyelock-assistants:researcher\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)