### PR TITLE
feat(fork): self-register forks via pointer file, add --name flag

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -373,6 +373,11 @@ A harness has two locations in its life:
 1. **Source** — git-tracked in the harness's repo. Author-managed. The author writes `.ynh-plugin/plugin.json` containing `name`, `version`, `includes`, `delegates_to`, `default_vendor`, hooks, MCP servers, profiles, focuses.
 2. **Installed copy** — at `~/.ynh/harnesses/<name>/`. Created by `ynh install`. Local-only, not git-tracked. Contains the copied source plus a separate `.ynh-plugin/installed.json` file written by ynh.
 
+There are two install layouts on disk, chosen by command:
+
+- **Tree-shaped** (`~/.ynh/harnesses/<name>/`) — created by `ynh install` for git and registry sources. The harness lives as a copy under `harnesses/`, with `.ynh-plugin/installed.json` recording provenance in-tree.
+- **Pointer-shaped** (`~/.ynh/installed/<name>.json`) — created by `ynh fork`. The harness lives at a user-chosen path; the pointer file in `installed/` registers it under the YNH layer. No copy under `harnesses/` is made. Edits to the source tree are live to `ynh run`. The pointer file holds only registration metadata (name → source path → timestamp); provenance still lives in the source tree's `.ynh-plugin/installed.json`. `harness.Load(name)` checks pointers before tree directories.
+
 During install:
 - `ynh install` copies the entire harness directory (including the `.ynh-plugin/` directory) to `~/.ynh/harnesses/<name>/`.
 - If the source uses the legacy `.harness.json` single-file format, the migration chain converts it to `.ynh-plugin/plugin.json` in place during install.
@@ -430,7 +435,7 @@ Possible `source_type` values: `"local"`, `"git"`, `"registry"`. Registry instal
 ~/.ynh/
 ├── config.json               # Global configuration
 ├── symlinks.json             # Symlink transaction log (install/clean tracking)
-├── harnesses/                  # Installed harnesses
+├── harnesses/                  # Installed harnesses (tree-shaped: git, registry)
 │   └── david/
 │       ├── .ynh-plugin/
 │       │   ├── plugin.json   # Author manifest (copied from source)
@@ -439,6 +444,9 @@ Possible `source_type` values: `"local"`, `"git"`, `"registry"`. Registry instal
 │       ├── agents/
 │       ├── rules/
 │       └── commands/
+├── installed/                  # Pointer files for forks (pointer-shaped: ynh fork)
+│   └── researcher.json       # Registers a user-owned tree under <name>
+
 ├── cache/                     # Cloned Git repos
 │   └── eyelock--assistants--a1b2c3d4/
 ├── run/                       # Assembled vendor config (per harness, overwritten each run)

--- a/cmd/ynh/fork.go
+++ b/cmd/ynh/fork.go
@@ -34,6 +34,7 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 	format := "text"
 	var toPath string
 	var name string
+	var newName string
 	i := 0
 	for i < len(args) {
 		switch args[i] {
@@ -49,6 +50,12 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 			}
 			i++
 			toPath = args[i]
+		case "--name":
+			if i+1 >= len(args) {
+				return cliError(stderr, structured, errCodeInvalidInput, "--name requires a value")
+			}
+			i++
+			newName = args[i]
 		default:
 			if strings.HasPrefix(args[i], "-") {
 				return cliError(stderr, structured, errCodeInvalidInput,
@@ -64,7 +71,11 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 	}
 
 	if name == "" {
-		return cliError(stderr, structured, errCodeInvalidInput, "usage: ynh fork <harness-name> [--to <path>]")
+		return cliError(stderr, structured, errCodeInvalidInput, "usage: ynh fork <harness-name> [--to <path>] [--name <new>]")
+	}
+	if newName != "" && !harness.IsValidName(newName) {
+		return cliError(stderr, structured, errCodeInvalidInput,
+			fmt.Sprintf("invalid --name value %q: must match %s", newName, harness.ValidNamePattern()))
 	}
 
 	switch format {
@@ -87,6 +98,15 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 		return cliError(stderr, structured, code, err.Error())
 	}
 
+	// installName is the name the fork registers under and writes into its
+	// own plugin.json. Defaults to the source name; --name lets the user
+	// fork while keeping the upstream installed (otherwise the clash check
+	// would force them to uninstall first).
+	installName := p.Name
+	if newName != "" {
+		installName = newName
+	}
+
 	// Resolve destination directory
 	destDir := toPath
 	if destDir == "" {
@@ -95,7 +115,7 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 			return cliError(stderr, structured, errCodeIOError,
 				fmt.Sprintf("getting working directory: %v", cwdErr))
 		}
-		destDir = filepath.Join(cwd, p.Name)
+		destDir = filepath.Join(cwd, installName)
 	}
 	absDestDir, absErr := filepath.Abs(destDir)
 	if absErr != nil {
@@ -107,6 +127,21 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 	if _, statErr := os.Stat(absDestDir); statErr == nil {
 		return cliError(stderr, structured, errCodeInvalidInput,
 			fmt.Sprintf("destination already exists: %s", absDestDir))
+	}
+
+	// Clash check: refuse to register if a flat install already claims the
+	// install name — either a pointer file or a flat tree at
+	// ~/.ynh/harnesses/<installName>/. Namespaced installs of the same name
+	// are fine; they remain accessible via "name@org/repo" while the fork
+	// takes over the bare name. Same rule ynh install uses, applied at
+	// registration time.
+	if existing, err := harness.LoadPointer(installName); err == nil && existing != nil {
+		return cliError(stderr, structured, errCodeInvalidInput,
+			fmt.Sprintf("harness %q is already installed (registered at %s)", installName, existing.Source))
+	}
+	if _, err := os.Stat(harness.InstalledDir(installName)); err == nil {
+		return cliError(stderr, structured, errCodeInvalidInput,
+			fmt.Sprintf("harness %q is already installed (uninstall it first, or pass --name to fork under a different name)", installName))
 	}
 
 	// p.Dir is the resolved install directory — works for both flat and
@@ -122,6 +157,26 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 		_ = os.RemoveAll(absDestDir)
 		return cliError(stderr, structured, errCodeIOError,
 			fmt.Sprintf("copying harness: %v", copyErr))
+	}
+
+	// Rewrite plugin.json's name field when --name was given. Required
+	// for identity coherence: Load(installName) returns a Harness whose
+	// p.Name must equal installName, otherwise downstream code (run dirs,
+	// launcher exec, profile lookup) gets confused. Provenance survives —
+	// the upstream identity is preserved in installed_from.forked_from.
+	if newName != "" {
+		hj, loadErr := plugin.LoadPluginJSON(absDestDir)
+		if loadErr != nil {
+			_ = os.RemoveAll(absDestDir)
+			return cliError(stderr, structured, errCodeIOError,
+				fmt.Sprintf("reading fork manifest: %v", loadErr))
+		}
+		hj.Name = installName
+		if saveErr := plugin.SavePluginJSON(absDestDir, hj); saveErr != nil {
+			_ = os.RemoveAll(absDestDir)
+			return cliError(stderr, structured, errCodeIOError,
+				fmt.Sprintf("renaming fork manifest: %v", saveErr))
+		}
 	}
 
 	// Build forked_from from source provenance
@@ -140,11 +195,38 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 			fmt.Sprintf("saving provenance: %v", saveErr))
 	}
 
+	// Register the fork in the YNH layer via a pointer file. Pointer wins
+	// over tree-shaped installs in Load() so subsequent ynh run / ls / info
+	// resolve to absDestDir directly — no copy under ~/.ynh/harnesses.
+	ptr := &harness.Pointer{
+		Name:        installName,
+		SourceType:  "local",
+		Source:      absDestDir,
+		InstalledAt: ins.InstalledAt,
+	}
+	if err := harness.SavePointer(ptr); err != nil {
+		_ = os.RemoveAll(absDestDir)
+		return cliError(stderr, structured, errCodeIOError,
+			fmt.Sprintf("registering fork: %v", err))
+	}
+
+	// Generate launcher so the fork is fully runnable as `<installName>`,
+	// matching ynh install. Skip for the reserved "ynh" name to avoid
+	// shadowing the binary.
+	if installName != "ynh" {
+		if err := generateLauncher(installName); err != nil {
+			_ = harness.RemovePointer(installName)
+			_ = os.RemoveAll(absDestDir)
+			return cliError(stderr, structured, errCodeIOError,
+				fmt.Sprintf("generating launcher: %v", err))
+		}
+	}
+
 	if format == "json" {
 		result := forkResult{
 			Capabilities: config.CapabilitiesVersion,
 			YnhVersion:   config.Version,
-			Name:         p.Name,
+			Name:         installName,
 			Path:         absDestDir,
 			InstalledFrom: &listInstalledFrom{
 				SourceType:  "local",
@@ -162,7 +244,11 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 	}
 
 	// Text output
-	_, _ = fmt.Fprintf(stdout, "Forked harness %q to %s\n", p.Name, absDestDir)
+	if installName != p.Name {
+		_, _ = fmt.Fprintf(stdout, "Forked harness %q as %q to %s\n", p.Name, installName, absDestDir)
+	} else {
+		_, _ = fmt.Fprintf(stdout, "Forked harness %q to %s\n", p.Name, absDestDir)
+	}
 	if p.InstalledFrom != nil {
 		_, _ = fmt.Fprintf(stdout, "  Source:  %s (%s)\n", p.InstalledFrom.Source, p.InstalledFrom.SourceType)
 	}

--- a/cmd/ynh/fork_test.go
+++ b/cmd/ynh/fork_test.go
@@ -9,14 +9,18 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/eyelock/ynh/internal/config"
+	"github.com/eyelock/ynh/internal/harness"
 	"github.com/eyelock/ynh/internal/plugin"
 )
 
-// installForkTestHarness writes a minimal harness into YNH_HOME/harnesses/<name>.
+// installForkTestHarness writes a minimal harness into YNH_HOME/harnesses/<ns>/<name>.
+// Sources are installed namespaced so the flat name remains free for the fork's
+// pointer registration (matching how registry installs land in practice).
 // Returns the installed directory path.
 func installForkTestHarness(t *testing.T, home, name string, ins *plugin.InstalledJSON) string {
 	t.Helper()
-	dir := filepath.Join(home, "harnesses", name)
+	dir := filepath.Join(home, "harnesses", "test--src", name)
 	if err := os.MkdirAll(filepath.Join(dir, plugin.PluginDir), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -307,6 +311,229 @@ func TestCmdUpdate_ForkBlocked(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "fork") {
 		t.Errorf("expected 'fork' in error message, got: %v", err)
+	}
+}
+
+func TestCmdFork_WritesPointerAndLauncher(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installForkTestHarness(t, home, "demo", &plugin.InstalledJSON{
+		SourceType:   "registry",
+		Source:       "github.com/org/demo",
+		Ref:          "v0.1.0",
+		SHA:          "deadbeef",
+		RegistryName: "org-registry",
+		InstalledAt:  "2026-01-01T00:00:00Z",
+	})
+
+	dest := filepath.Join(t.TempDir(), "my-demo")
+	if err := cmdForkTo([]string{"demo", "--to", dest}, io.Discard, io.Discard); err != nil {
+		t.Fatalf("cmdForkTo: %v", err)
+	}
+
+	// Pointer file written under ~/.ynh/installed/demo.json
+	ptr, err := harness.LoadPointer("demo")
+	if err != nil {
+		t.Fatalf("LoadPointer: %v", err)
+	}
+	if ptr == nil {
+		t.Fatal("pointer not written")
+	}
+	absDest, _ := filepath.Abs(dest)
+	if ptr.Source != absDest {
+		t.Errorf("pointer.source = %q, want %q", ptr.Source, absDest)
+	}
+	if ptr.SourceType != "local" {
+		t.Errorf("pointer.source_type = %q, want local", ptr.SourceType)
+	}
+
+	// Launcher generated under ~/.ynh/bin/demo
+	launcher := filepath.Join(config.BinDir(), "demo")
+	if _, err := os.Stat(launcher); err != nil {
+		t.Errorf("launcher not generated: %v", err)
+	}
+}
+
+func TestCmdFork_ClashWithExistingFlatTree(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Pre-existing flat tree at ~/.ynh/harnesses/demo
+	flatDir := filepath.Join(home, "harnesses", "demo")
+	if err := os.MkdirAll(filepath.Join(flatDir, plugin.PluginDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hj := `{"name":"demo","version":"0.1.0","default_vendor":"claude"}`
+	if err := os.WriteFile(filepath.Join(flatDir, plugin.PluginDir, plugin.PluginFile), []byte(hj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "my-demo")
+	err := cmdForkTo([]string{"demo", "--to", dest}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected clash error, got nil")
+	}
+	if !strings.Contains(err.Error(), "already installed") {
+		t.Errorf("expected 'already installed' in error, got: %v", err)
+	}
+}
+
+func TestCmdFork_ClashWithExistingPointer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installForkTestHarness(t, home, "demo", nil)
+
+	// First fork registers the pointer
+	dest1 := filepath.Join(t.TempDir(), "demo-one")
+	if err := cmdForkTo([]string{"demo", "--to", dest1}, io.Discard, io.Discard); err != nil {
+		t.Fatalf("first fork: %v", err)
+	}
+
+	// Second fork must clash on the pointer
+	dest2 := filepath.Join(t.TempDir(), "demo-two")
+	err := cmdForkTo([]string{"demo", "--to", dest2}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected clash error on second fork, got nil")
+	}
+	if !strings.Contains(err.Error(), "already installed") {
+		t.Errorf("expected 'already installed' in error, got: %v", err)
+	}
+}
+
+func TestCmdUninstall_PointerRemovesPointerNotSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installForkTestHarness(t, home, "demo", nil)
+
+	dest := filepath.Join(t.TempDir(), "my-demo")
+	if err := cmdForkTo([]string{"demo", "--to", dest}, io.Discard, io.Discard); err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+
+	if err := cmdUninstall([]string{"demo"}); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	// Pointer gone
+	if ptr, _ := harness.LoadPointer("demo"); ptr != nil {
+		t.Errorf("pointer still present after uninstall: %+v", ptr)
+	}
+	// Source tree preserved
+	if _, err := os.Stat(filepath.Join(dest, plugin.PluginDir, plugin.PluginFile)); err != nil {
+		t.Errorf("source tree was deleted on uninstall: %v", err)
+	}
+	// Launcher cleaned up
+	if _, err := os.Stat(filepath.Join(config.BinDir(), "demo")); err == nil {
+		t.Errorf("launcher still present after uninstall")
+	}
+}
+
+func TestCmdFork_WithName(t *testing.T) {
+	// --name lets a user fork a harness while keeping upstream installed.
+	// Source "demo" is flat-installed; fork registers as "my-demo" with
+	// the manifest rewritten so identity is coherent.
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Source as a flat-installed harness (the case --name solves)
+	srcDir := filepath.Join(home, "harnesses", "demo")
+	if err := os.MkdirAll(filepath.Join(srcDir, plugin.PluginDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hj := `{"name":"demo","version":"0.1.0","default_vendor":"claude"}`
+	if err := os.WriteFile(filepath.Join(srcDir, plugin.PluginDir, plugin.PluginFile), []byte(hj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "fork-tree")
+	if err := cmdForkTo([]string{"demo", "--to", dest, "--name", "my-demo"}, io.Discard, io.Discard); err != nil {
+		t.Fatalf("cmdForkTo: %v", err)
+	}
+
+	// Pointer registered under the new name, source unchanged
+	ptr, err := harness.LoadPointer("my-demo")
+	if err != nil || ptr == nil {
+		t.Fatalf("pointer for new name not written: %v", err)
+	}
+	if old, _ := harness.LoadPointer("demo"); old != nil {
+		t.Errorf("pointer under source name should not exist: %+v", old)
+	}
+
+	// Manifest in the fork tree was rewritten — identity coherence
+	got, err := plugin.LoadPluginJSON(dest)
+	if err != nil {
+		t.Fatalf("LoadPluginJSON: %v", err)
+	}
+	if got.Name != "my-demo" {
+		t.Errorf("fork manifest name = %q, want my-demo", got.Name)
+	}
+
+	// Source manifest untouched
+	srcManifest, _ := plugin.LoadPluginJSON(srcDir)
+	if srcManifest.Name != "demo" {
+		t.Errorf("source manifest name was mutated: %q", srcManifest.Name)
+	}
+
+	// Launcher under the new name
+	if _, err := os.Stat(filepath.Join(config.BinDir(), "my-demo")); err != nil {
+		t.Errorf("launcher for new name not generated: %v", err)
+	}
+
+	// forked_from preserved (provenance of the upstream identity)
+	ins, err := plugin.LoadInstalledJSON(dest)
+	if err != nil {
+		t.Fatalf("LoadInstalledJSON: %v", err)
+	}
+	if ins.ForkedFrom == nil {
+		t.Error("forked_from should be populated")
+	}
+}
+
+func TestCmdFork_NameInvalid(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installForkTestHarness(t, home, "demo", nil)
+
+	dest := filepath.Join(t.TempDir(), "fork-tree")
+	err := cmdForkTo([]string{"demo", "--to", dest, "--name", "bad/name"}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected validation error for invalid --name")
+	}
+	if !strings.Contains(err.Error(), "--name") {
+		t.Errorf("expected '--name' in error, got: %v", err)
+	}
+}
+
+func TestCmdFork_NameClashesOnNewName(t *testing.T) {
+	// Clash check uses the new name, not the source name.
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	installForkTestHarness(t, home, "demo", nil)
+
+	// Pre-register a pointer named "my-demo"
+	if err := harness.SavePointer(&harness.Pointer{
+		Name: "my-demo", SourceType: "local",
+		Source: t.TempDir(), InstalledAt: "2026-05-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "fork-tree")
+	err := cmdForkTo([]string{"demo", "--to", dest, "--name", "my-demo"}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected clash error on --name target")
+	}
+	if !strings.Contains(err.Error(), "my-demo") {
+		t.Errorf("expected 'my-demo' in error, got: %v", err)
+	}
+}
+
+func TestCmdFork_MissingNameValue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	err := cmdForkTo([]string{"demo", "--name"}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected error for missing --name value")
 	}
 }
 

--- a/cmd/ynh/info.go
+++ b/cmd/ynh/info.go
@@ -26,7 +26,9 @@ type infoEnvelope struct {
 // infoEntry is the JSON shape for `ynh info` structured output.
 // Carries the same per-harness fields as listEntry, plus the raw manifest.
 type infoEntry struct {
-	Name             string             `json:"name"`
+	Name string `json:"name"`
+	// Kind classifies the install — see listEntry.Kind.
+	Kind             string             `json:"kind"`
 	VersionInstalled string             `json:"version_installed"`
 	VersionAvailable string             `json:"version_available,omitempty"`
 	Description      string             `json:"description,omitempty"`
@@ -298,6 +300,7 @@ func printInfoJSON(stdout, stderr io.Writer, name string, checkUpdates bool) err
 	}
 	entry := infoEntry{
 		Name:             base.Name,
+		Kind:             base.Kind,
 		VersionInstalled: base.VersionInstalled,
 		VersionAvailable: base.VersionAvailable,
 		Description:      base.Description,

--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -26,7 +26,11 @@ type listEnvelope struct {
 // listEntry is the JSON shape for a single harness in the `ynh ls` output.
 // Field order drives JSON key order via MarshalIndent.
 type listEntry struct {
-	Name             string `json:"name"`
+	Name string `json:"name"`
+	// Kind classifies the install: "local-fork" (pointer-shaped, forked
+	// from an upstream), "local" (local path, no upstream), "registry",
+	// "git", or "-" for pre-migration entries with no recorded source.
+	Kind             string `json:"kind"`
 	VersionInstalled string `json:"version_installed"`
 	VersionAvailable string `json:"version_available,omitempty"`
 	Description      string `json:"description,omitempty"`
@@ -167,12 +171,12 @@ func printListText(w io.Writer) error {
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "NAME\tVENDOR\tSOURCE\tARTIFACTS\tINCLUDES\tDELEGATES TO")
+	_, _ = fmt.Fprintln(tw, "NAME\tKIND\tVENDOR\tSOURCE\tARTIFACTS\tINCLUDES\tDELEGATES TO")
 
 	for _, e := range entries {
 		p, err := harness.LoadDir(e.Dir)
 		if err != nil {
-			_, _ = fmt.Fprintf(tw, "%s\t(error: %v)\t\t\t\t\n", e.Name, err)
+			_, _ = fmt.Fprintf(tw, "%s\t(error: %v)\t\t\t\t\t\n", e.Name, err)
 			continue
 		}
 
@@ -181,12 +185,13 @@ func printListText(w io.Writer) error {
 			vendorName = "-"
 		}
 
+		kind := classifyKind(p.InstalledFrom)
 		source := formatProvenance(p.InstalledFrom)
 		artifacts := formatArtifactSummaryDir(e.Dir)
 		includes := formatIncludes(p.Includes)
 		delegates := formatDelegates(p.DelegatesTo)
 
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", p.Name, vendorName, source, artifacts, includes, delegates)
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", p.Name, kind, vendorName, source, artifacts, includes, delegates)
 	}
 
 	return tw.Flush()
@@ -202,6 +207,22 @@ func printListJSON(w io.Writer, checkUpdates bool) error {
 	for _, e := range all {
 		p, loadErr := harness.LoadDir(e.Dir)
 		if loadErr != nil {
+			// Surface broken pointer entries as minimal placeholders so the
+			// JSON consumer sees the registration even when the source path
+			// is missing. Text mode already shows these as "(error: ...)"
+			// rows; the JSON contract should be no less informative.
+			if ptr, _ := harness.LoadPointer(e.Name); ptr != nil {
+				entries = append(entries, listEntry{
+					Name: ptr.Name,
+					Kind: "local-fork",
+					Path: ptr.Source,
+					InstalledFrom: &listInstalledFrom{
+						SourceType:  ptr.SourceType,
+						Source:      ptr.Source,
+						InstalledAt: ptr.InstalledAt,
+					},
+				})
+			}
 			continue
 		}
 		entries = append(entries, buildListEntry(p))
@@ -269,6 +290,7 @@ func buildListEntry(p *harness.Harness) listEntry {
 
 	entry := listEntry{
 		Name:             p.Name,
+		Kind:             classifyKind(p.InstalledFrom),
 		VersionInstalled: p.Version,
 		Description:      p.Description,
 		DefaultVendor:    p.DefaultVendor,
@@ -399,6 +421,25 @@ func formatArtifactSummaryDir(dir string) string {
 		parts = append(parts, fmt.Sprintf("%dc", len(arts.Commands)))
 	}
 	return strings.Join(parts, " ")
+}
+
+// classifyKind returns the KIND label for ynh ls.
+//   - local-fork: a fork registered via pointer (forked_from is set)
+//   - local: installed from a local path, no upstream
+//   - registry: installed via a registry reference
+//   - git: installed from a remote git URL
+//   - "-": unknown / pre-migration
+func classifyKind(prov *harness.Provenance) string {
+	if prov == nil {
+		return "-"
+	}
+	if prov.ForkedFrom != nil {
+		return "local-fork"
+	}
+	if prov.SourceType == "" {
+		return "-"
+	}
+	return prov.SourceType
 }
 
 // formatProvenance formats the SOURCE column for ynh ls.

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -427,18 +427,28 @@ func cmdUninstall(args []string) error {
 
 	ref := args[0]
 
-	// Load to resolve the actual on-disk directory (may be namespaced).
-	// Accepts plain "name" or qualified "name@org/repo".
+	// Load to resolve the actual on-disk directory (may be namespaced or
+	// pointer-shaped). Accepts plain "name" or qualified "name@org/repo".
 	p, err := harness.LoadQualified(ref)
 	if err != nil {
 		return fmt.Errorf("harness %q is not installed", ref)
 	}
-	installDir := p.Dir
 	bareName := p.Name // bare name for launcher/run/sources cleanup
 
-	// Remove harness directory
-	if err := os.RemoveAll(installDir); err != nil {
-		return fmt.Errorf("removing harness: %w", err)
+	// Pointer-shaped install: remove only the pointer file. The user owns
+	// the source tree — uninstall is a registration removal, not a
+	// destructive delete. Tree-shaped installs (the original code path) get
+	// the directory removed.
+	var pointerSource string
+	if ptr, err := harness.LoadPointer(bareName); err == nil && ptr != nil {
+		pointerSource = ptr.Source
+		if err := harness.RemovePointer(bareName); err != nil {
+			return fmt.Errorf("removing pointer: %w", err)
+		}
+	} else {
+		if err := os.RemoveAll(p.Dir); err != nil {
+			return fmt.Errorf("removing harness: %w", err)
+		}
 	}
 
 	// Remove launcher script
@@ -464,6 +474,9 @@ func cmdUninstall(args []string) error {
 	}
 
 	fmt.Printf("Uninstalled harness %q\n", bareName)
+	if pointerSource != "" {
+		fmt.Printf("  Source tree left in place: %s\n", pointerSource)
+	}
 	return nil
 }
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -35,7 +35,7 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | `ynh run [harness]` | `-v`, `--profile`, `--install`, `--clean` |
 | `ynh uninstall <harness>` | |
 | `ynh update [harness]` | |
-| `ynh fork <name>` | `--to <path>`, `--format <text\|json>` |
+| `ynh fork <name>` | `--to <path>`, `--name <new>`, `--format <text\|json>` |
 | `ynh ls` | `--format <text\|json>` |
 | `ynh info <harness>` | `--format <text\|json>` |
 | `ynh vendors` | `--format <text\|json>` |
@@ -113,6 +113,7 @@ Per-harness fields:
 | Field | Description |
 |-------|-------------|
 | `name` | Harness name |
+| `kind` | Install kind: `local-fork` (pointer-shaped, registered via `ynh fork`), `local`, `registry`, `git`, or `-` for pre-migration entries |
 | `version_installed` | Version recorded in the harness manifest |
 | `version_available` | Latest version known upstream — **omitted** if `--check-updates` was not passed or the upstream check failed (the "unknown" state) |
 | `description` | Optional human description |
@@ -181,6 +182,14 @@ The `is_pinned` rule is the same on harnesses and includes:
 
 `forked_from` captures the upstream provenance of the harness at the time of the fork. If the source harness had no upstream (a bare local install), `forked_from.source_type` is `"local"` and `forked_from.source` is the installed directory path.
 
-`ynh update` refuses to run on a fork and prints an explanatory error. To incorporate upstream changes, re-install the original and fork again.
+`ynh fork` self-registers the new fork: a pointer file at `~/.ynh/installed/<name>.json` records `<path>` as the install location, and a launcher script is generated at `~/.ynh/bin/<name>`. The fork is immediately visible in `ynh ls` and runnable via `ynh run <name>` — no follow-up `ynh install` needed. Edits to the source tree are live; YNH never copies it.
 
-`ynh install <fork-path>` preserves `forked_from` when installing a forked harness into `~/.ynh/harnesses/`, so `ynh ls` surfaces the upstream provenance.
+`ynh fork` refuses to register if a flat install of the same name already exists (either a pointer or a tree at `~/.ynh/harnesses/<name>/`). Namespaced installs of the same name are unaffected — they remain accessible via `name@org/repo`. Uninstall the conflicting flat install first if you want the fork to take that name.
+
+**`--name <new>`** registers the fork under a different name without uninstalling the source — the common case where a user wants to keep the upstream installed and fork a copy alongside it. The fork tree's `.ynh-plugin/plugin.json` is rewritten so its `name` field matches the registration; upstream identity survives in `installed_from.forked_from`. The new name is validated against the same regex as harness names (`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`). If `--to` is omitted, the default destination uses the new name (`<cwd>/<new>`).
+
+`ynh uninstall <name>` for a fork removes the pointer file (and launcher, run dir, sources entry) but leaves the source tree on disk — the user owns it. To delete the tree as well, remove the directory after uninstalling.
+
+If the source path recorded in a pointer no longer exists when the fork is loaded, `ynh` prints an actionable error directing the user to either restore the directory or run `ynh uninstall <name>`. There is no auto-relocate in this version.
+
+`ynh update` refuses to run on a fork and prints an explanatory error. To incorporate upstream changes, re-install the original and fork again.

--- a/docs/tutorial/01-first-harness.md
+++ b/docs/tutorial/01-first-harness.md
@@ -137,10 +137,11 @@ ynh ls
 
 Expected:
 ```
-NAME        VENDOR  SOURCE                        ARTIFACTS    INCLUDES  DELEGATES TO
-my-harness  claude  /tmp/ynh-tutorial/my-harness  1s 1a 1r 1c  0         0
+NAME        KIND   VENDOR  SOURCE                        ARTIFACTS    INCLUDES  DELEGATES TO
+my-harness  local  claude  /tmp/ynh-tutorial/my-harness  1s 1a 1r 1c  0         0
 ```
 
+The KIND column classifies the install: `local` (installed from a local path), `git`, `registry`, or `local-fork` (a fork registered via `ynh fork`).
 The ARTIFACTS column shows a compact count: skills (s), agents (a), rules (r), commands (c).
 The SOURCE column shows where the harness was installed from.
 

--- a/docs/tutorial/04-delegation.md
+++ b/docs/tutorial/04-delegation.md
@@ -97,8 +97,8 @@ ynh ls
 
 Expected:
 ```
-NAME       VENDOR  SOURCE                          ARTIFACTS  INCLUDES  DELEGATES TO
-team-lead  claude  /tmp/ynh-tutorial/team-lead      ...        0         /tmp/ynh-tutorial/specialist, eyelock/assistants/ynh/researcher
+NAME       KIND   VENDOR  SOURCE                          ARTIFACTS  INCLUDES  DELEGATES TO
+team-lead  local  claude  /tmp/ynh-tutorial/team-lead      ...        0         /tmp/ynh-tutorial/specialist, eyelock/assistants/ynh/researcher
 ```
 
 ## T4.4: Inspect delegate agent files

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,16 @@ func HarnessesDir() string {
 	return filepath.Join(HomeDir(), "harnesses")
 }
 
+// PointersDir is where pointer files for local-fork installs live.
+// Each file is <name>.json and points at a user-owned source tree —
+// edits to that tree are live to ynh run with no copy step.
+//
+// Distinct from HarnessesDir(): tree-shaped installs (git/registry) live
+// under HarnessesDir(); pointer-shaped installs (local forks) live here.
+func PointersDir() string {
+	return filepath.Join(HomeDir(), "installed")
+}
+
 func CacheDir() string {
 	return filepath.Join(HomeDir(), "cache")
 }
@@ -96,6 +106,7 @@ func EnsureDirs() error {
 	dirs := []string{
 		HomeDir(),
 		HarnessesDir(),
+		PointersDir(),
 		CacheDir(),
 		BinDir(),
 		RunDir(),

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -19,6 +19,21 @@ import (
 // Must start with a letter or digit. Prevents path traversal and shell injection.
 var validName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
+// IsValidName reports whether s is a syntactically valid harness name.
+// Same rule LoadDir applies internally — exposed so callers (e.g. the
+// `ynh fork --name <new>` validator) can reject invalid input up front
+// instead of producing a half-installed harness.
+func IsValidName(s string) bool {
+	return validName.MatchString(s)
+}
+
+// ValidNamePattern returns the regex source string used to validate
+// harness names. Useful for error messages that want to show the
+// permitted shape.
+func ValidNamePattern() string {
+	return validName.String()
+}
+
 // GitSource holds the common fields for any include or delegate source.
 // Exactly one of Git (remote) or Local (filesystem path) is set at any
 // given time. Path is a subdirectory scoped within the source; Ref
@@ -140,10 +155,19 @@ func DetectFormat(dir string) string {
 // ErrNotFound is returned when a harness is not installed.
 var ErrNotFound = errors.New("harness not found")
 
-// Load finds and loads an installed harness by name. The migration chain
-// runs inside LoadDir so no legacy handling is needed here. If the flat
-// layout has the harness, use that; otherwise scan the namespaced layout.
+// Load finds and loads an installed harness by name. Resolution precedence:
+//  1. Pointer file at ~/.ynh/installed/<name>.json (local fork)
+//  2. Flat tree at ~/.ynh/harnesses/<name>/
+//  3. Namespaced tree at ~/.ynh/harnesses/<ns--repo>/<name>/
+//
+// The migration chain runs inside LoadDir so no legacy handling is needed
+// here.
 func Load(name string) (*Harness, error) {
+	if ptr, err := LoadPointer(name); err != nil {
+		return nil, err
+	} else if ptr != nil {
+		return loadFromPointer(ptr)
+	}
 	flatDir := InstalledDir(name)
 	if _, err := os.Stat(flatDir); err == nil {
 		return LoadDir(flatDir)
@@ -212,18 +236,38 @@ func List() ([]string, error) {
 	return names, nil
 }
 
-// ListAll returns all installed harnesses with namespace and directory information.
+// ListAll returns all installed harnesses with namespace and directory
+// information. Unions pointer-shaped installs (local forks) with
+// tree-shaped installs (git/registry). Pointer entries take precedence
+// when a name appears in both — a pre-1.0 invariant: ynh fork now refuses
+// to register if a tree of the same name exists, but legacy two-tree
+// installs from before this change may still be on disk.
 func ListAll() ([]ListEntry, error) {
+	pointers, err := ListPointers()
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(pointers))
+	for _, p := range pointers {
+		seen[p.Name] = true
+	}
+
 	harnessesDir := config.HarnessesDir()
 	entries, err := os.ReadDir(harnessesDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			sort.Slice(pointers, func(i, j int) bool {
+				if pointers[i].Namespace != pointers[j].Namespace {
+					return pointers[i].Namespace < pointers[j].Namespace
+				}
+				return pointers[i].Name < pointers[j].Name
+			})
+			return pointers, nil
 		}
 		return nil, err
 	}
 
-	var results []ListEntry
+	results := append([]ListEntry(nil), pointers...)
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -240,6 +284,9 @@ func ListAll() ([]ListEntry, error) {
 				if !child.IsDir() {
 					continue
 				}
+				if seen[child.Name()] {
+					continue
+				}
 				childDir := filepath.Join(entryPath, child.Name())
 				if DetectFormat(childDir) != "" {
 					results = append(results, ListEntry{
@@ -251,6 +298,9 @@ func ListAll() ([]ListEntry, error) {
 			}
 		} else {
 			// Flat entry (unmigrated or local install)
+			if seen[entry.Name()] {
+				continue
+			}
 			if DetectFormat(entryPath) != "" {
 				results = append(results, ListEntry{
 					Name: entry.Name(),

--- a/internal/harness/pointer.go
+++ b/internal/harness/pointer.go
@@ -1,0 +1,141 @@
+package harness
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/eyelock/ynh/internal/config"
+)
+
+// Pointer is the on-disk shape of ~/.ynh/installed/<name>.json.
+//
+// Pointer files register a user-owned source tree (a fork) into the YNH layer
+// without copying it. Load(name) prefers a pointer over the tree-shaped
+// install at ~/.ynh/harnesses/<name>/. Edits to the source tree are live to
+// ynh run with no sync step.
+//
+// Provenance (what the harness *is*) lives in the source tree at
+// .ynh-plugin/installed.json and is the authoritative source for
+// p.InstalledFrom. The pointer file's role is registration — name binding
+// and where to look — not provenance.
+type Pointer struct {
+	Name        string `json:"name"`
+	SourceType  string `json:"source_type"`
+	Source      string `json:"source"`
+	InstalledAt string `json:"installed_at"`
+}
+
+// PointerPath returns the on-disk path of the pointer file for name.
+// Local forks are flat — no namespaced pointer paths in v1.
+func PointerPath(name string) string {
+	return filepath.Join(config.PointersDir(), name+".json")
+}
+
+// LoadPointer reads and parses the pointer file for name. Returns
+// (nil, nil) when no pointer exists.
+func LoadPointer(name string) (*Pointer, error) {
+	path := PointerPath(name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading pointer %s: %w", path, err)
+	}
+	var p Pointer
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("invalid pointer %s: %w", path, err)
+	}
+	return &p, nil
+}
+
+// SavePointer writes p to its pointer-file path. Creates the pointers
+// directory if needed.
+func SavePointer(p *Pointer) error {
+	if err := os.MkdirAll(config.PointersDir(), 0o755); err != nil {
+		return fmt.Errorf("creating pointers dir: %w", err)
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling pointer: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(PointerPath(p.Name), data, 0o644); err != nil {
+		return fmt.Errorf("writing pointer: %w", err)
+	}
+	return nil
+}
+
+// RemovePointer deletes the pointer file for name. Returns nil if no
+// pointer exists — uninstall semantics: missing pointer is not an error
+// for the caller that already knows it wants the registration gone.
+func RemovePointer(name string) error {
+	err := os.Remove(PointerPath(name))
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing pointer: %w", err)
+	}
+	return nil
+}
+
+// ListPointers returns all pointer-shaped installs in name order.
+func ListPointers() ([]ListEntry, error) {
+	dir := config.PointersDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var results []ListEntry
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".json")
+		ptr, err := LoadPointer(name)
+		if err != nil || ptr == nil {
+			continue
+		}
+		// Always include the entry, even when the source path is missing.
+		// A broken pointer is still a registration the user owns — surfacing
+		// it in `ynh ls` (where LoadDir will produce a per-row error) is
+		// strictly better than silently showing a different install of the
+		// same name from the namespaced tree.
+		results = append(results, ListEntry{
+			Name: ptr.Name,
+			Dir:  ptr.Source,
+		})
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].Name < results[j].Name })
+	return results, nil
+}
+
+// ErrPointerSourceMissing is returned when a pointer file references a
+// source path that no longer exists on disk. Wrapped with an actionable
+// message at the call site.
+var ErrPointerSourceMissing = errors.New("pointer source path missing")
+
+// loadFromPointer resolves a pointer file to a fully-loaded Harness by
+// running LoadDir(ptr.Source). Returns (nil, ErrPointerSourceMissing,
+// wrapped with the user-facing relocate/uninstall hint) when the source
+// path is gone.
+func loadFromPointer(ptr *Pointer) (*Harness, error) {
+	if _, err := os.Stat(ptr.Source); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf(
+				"harness %q is registered but its source path no longer exists:\n"+
+					"  %s\n\n"+
+					"If you moved it, restore the directory.\n"+
+					"If it's gone for good, run: ynh uninstall %s",
+				ptr.Name, ptr.Source, ptr.Name)
+		}
+		return nil, fmt.Errorf("stat pointer source %s: %w", ptr.Source, err)
+	}
+	return LoadDir(ptr.Source)
+}

--- a/internal/harness/pointer_test.go
+++ b/internal/harness/pointer_test.go
@@ -1,0 +1,227 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// writeForkTree creates a minimal harness tree at dir with given name.
+func writeForkTree(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, plugin.PluginDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hj := `{"name":"` + name + `","version":"0.1.0","default_vendor":"claude"}`
+	if err := os.WriteFile(filepath.Join(dir, plugin.PluginDir, plugin.PluginFile), []byte(hj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ins := &plugin.InstalledJSON{
+		SourceType:  "local",
+		Source:      dir,
+		InstalledAt: "2026-05-01T00:00:00Z",
+		ForkedFrom: &plugin.ForkedFromJSON{
+			SourceType: "git",
+			Source:     "github.com/example/" + name,
+		},
+	}
+	if err := plugin.SaveInstalledJSON(dir, ins); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPointer_SaveLoadRoundTrip(t *testing.T) {
+	t.Setenv("YNH_HOME", t.TempDir())
+	ptr := &Pointer{
+		Name:        "researcher",
+		SourceType:  "local",
+		Source:      "/users/x/work/researcher",
+		InstalledAt: "2026-05-01T00:00:00Z",
+	}
+	if err := SavePointer(ptr); err != nil {
+		t.Fatalf("SavePointer: %v", err)
+	}
+	got, err := LoadPointer("researcher")
+	if err != nil {
+		t.Fatalf("LoadPointer: %v", err)
+	}
+	if got == nil {
+		t.Fatal("LoadPointer returned nil")
+	}
+	if got.Name != ptr.Name || got.Source != ptr.Source {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+}
+
+func TestPointer_LoadMissing(t *testing.T) {
+	t.Setenv("YNH_HOME", t.TempDir())
+	got, err := LoadPointer("nope")
+	if err != nil {
+		t.Fatalf("LoadPointer error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil pointer, got %+v", got)
+	}
+}
+
+func TestLoad_PointerBeatsTreePrecedence(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Create a tree-shaped install at ~/.ynh/harnesses/researcher
+	treeDir := filepath.Join(home, "harnesses", "researcher")
+	writeForkTree(t, treeDir, "researcher")
+
+	// Create a fork tree elsewhere and a pointer registering it
+	forkDir := filepath.Join(t.TempDir(), "researcher")
+	writeForkTree(t, forkDir, "researcher")
+	if err := SavePointer(&Pointer{
+		Name:        "researcher",
+		SourceType:  "local",
+		Source:      forkDir,
+		InstalledAt: "2026-05-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := Load("researcher")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Pointer must win — Dir resolves to forkDir, not the flat tree.
+	absFork, _ := filepath.Abs(forkDir)
+	if p.Dir != absFork {
+		t.Errorf("Load resolved to %q, want %q (pointer should beat flat tree)", p.Dir, absFork)
+	}
+}
+
+func TestLoad_PointerWithMissingSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Pointer references a path that doesn't exist
+	if err := SavePointer(&Pointer{
+		Name:        "ghost",
+		SourceType:  "local",
+		Source:      filepath.Join(t.TempDir(), "deleted"),
+		InstalledAt: "2026-05-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load("ghost")
+	if err == nil {
+		t.Fatal("expected error for missing pointer source")
+	}
+	msg := err.Error()
+	for _, want := range []string{"ghost", "no longer exists", "ynh uninstall"} {
+		if !contains(msg, want) {
+			t.Errorf("error missing %q substring: %v", want, msg)
+		}
+	}
+}
+
+func TestListAll_UnionsPointersAndTrees(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Tree-shaped install
+	treeDir := filepath.Join(home, "harnesses", "tree-one")
+	writeForkTree(t, treeDir, "tree-one")
+
+	// Pointer-shaped install
+	forkDir := filepath.Join(t.TempDir(), "fork-one")
+	writeForkTree(t, forkDir, "fork-one")
+	if err := SavePointer(&Pointer{
+		Name: "fork-one", SourceType: "local", Source: forkDir,
+		InstalledAt: "2026-05-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ListAll()
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	names := map[string]string{}
+	for _, e := range entries {
+		names[e.Name] = e.Dir
+	}
+	if _, ok := names["tree-one"]; !ok {
+		t.Errorf("ListAll missing tree entry; got %+v", names)
+	}
+	if got, ok := names["fork-one"]; !ok {
+		t.Errorf("ListAll missing pointer entry; got %+v", names)
+	} else if abs, _ := filepath.Abs(forkDir); got != abs {
+		t.Errorf("pointer entry Dir = %q, want %q", got, abs)
+	}
+}
+
+func TestListAll_PointerWinsOverTreeOnDuplicate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Both a flat tree and a pointer for the same name (legacy state).
+	treeDir := filepath.Join(home, "harnesses", "dup")
+	writeForkTree(t, treeDir, "dup")
+
+	forkDir := filepath.Join(t.TempDir(), "dup")
+	writeForkTree(t, forkDir, "dup")
+	if err := SavePointer(&Pointer{
+		Name: "dup", SourceType: "local", Source: forkDir,
+		InstalledAt: "2026-05-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ListAll()
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	count := 0
+	var dupDir string
+	for _, e := range entries {
+		if e.Name == "dup" {
+			count++
+			dupDir = e.Dir
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one entry for 'dup', got %d", count)
+	}
+	absFork, _ := filepath.Abs(forkDir)
+	if dupDir != absFork {
+		t.Errorf("dup entry Dir = %q, want %q (pointer should win)", dupDir, absFork)
+	}
+}
+
+func TestRemovePointer_Idempotent(t *testing.T) {
+	t.Setenv("YNH_HOME", t.TempDir())
+	if err := RemovePointer("nonexistent"); err != nil {
+		t.Errorf("RemovePointer on missing: %v", err)
+	}
+	if err := SavePointer(&Pointer{
+		Name: "x", SourceType: "local", Source: "/tmp/x", InstalledAt: "now",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemovePointer("x"); err != nil {
+		t.Errorf("RemovePointer: %v", err)
+	}
+	if got, _ := LoadPointer("x"); got != nil {
+		t.Errorf("pointer still present after remove: %+v", got)
+	}
+}
+
+// contains is a no-stdlib substring check to avoid pulling in strings.Contains
+// for a single helper. Keeps the test file small and obvious.
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- `ynh fork` self-registers via a pointer file at `~/.ynh/installed/<name>.json` — one tree (user-owned), no copy under `~/.ynh/harnesses/`. Edits to the source tree are live to `ynh run`; no follow-up `ynh install` needed.
- `ynh fork --name <new>` lets users fork while keeping upstream installed. The fork tree's `plugin.json` is rewritten so registration name and harness identity stay coherent. Upstream identity survives in `installed_from.forked_from`.
- `ynh ls` adds a `KIND` column (`local-fork`, `local`, `registry`, `git`, `-`) in both text and JSON output. `ynh info --format json` gains the same field.
- `ynh uninstall` on a fork removes the pointer + launcher + run dir + sources entry; the user's source tree is preserved.

## Why

Before this change, `ynh fork` produced a standalone tree that wasn't registered anywhere. Callers had to follow up with `ynh install <forkpath>`, which **copied** the tree into `~/.ynh/harnesses/<name>/` — leaving two divergent trees. Edits to the user's fork tree didn't surface in `ynh run` (which read the copy). Real footgun documented by TermQ.

The pointer-file model is OS-clean (no symlink/junction Windows fork), keeps install-as-pointer semantics for local sources, and leaves git/registry installs unchanged.

## Design background

[Original issue draft and back-and-forth design conversation in PR description above]

## Test plan

- [x] `make check` clean (build, lint, format, all tests with -race)
- [x] `/evals` PASS (8 tutorials + 22 edge cases, 0 failures)
- [x] Manual spot-check: fork → ls → edit source → info reflects → move source → actionable error → uninstall → tree preserved
- [x] Manual spot-check: `--name` keeps upstream installed, registers under new name, manifest rewritten, both visible in `ls`
- [x] Tested locally via TermQ Duplicate flow

## Out of scope (follow-ups)

- `ynh relocate <name> --to <newpath>` — pointer update for moved forks
- `ynh install --link <localpath>` — register an existing local dir without forking
- Migration command for legacy two-tree forks (pre-1.0; re-fork is the path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)