### PR TITLE
fix(uninstall,prune,ls): clean up orphan fork pointers

### DIFF
--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -221,6 +221,8 @@ func printListJSON(w io.Writer, checkUpdates bool) error {
 						Source:      ptr.Source,
 						InstalledAt: ptr.InstalledAt,
 					},
+					Includes:    []listInclude{},
+					DelegatesTo: []listDelegate{},
 				})
 			}
 			continue

--- a/cmd/ynh/list_test.go
+++ b/cmd/ynh/list_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/eyelock/ynh/internal/harness"
 )
 
 // installListTestHarness creates a harness with custom JSON in the harnesses dir.
@@ -481,5 +483,46 @@ func TestCmdListCheckUpdatesRequiresJSON(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String()+err.Error(), "--check-updates") {
 		t.Errorf("expected error to mention --check-updates; stderr: %s; err: %v", stderr.String(), err)
+	}
+}
+
+// Broken-pointer placeholder rows must emit [] not null for empty
+// includes/delegates_to. JSON consumers expect the canonical empty-array shape
+// regardless of whether the source tree could be loaded.
+func TestCmdListJSONOrphanPointerEmptyArrays(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	if err := harness.SavePointer(&harness.Pointer{
+		Name: "stranded", SourceType: "local",
+		Source: filepath.Join(t.TempDir(), "gone"), InstalledAt: "2026-05-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := cmdListTo([]string{"--format", "json"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdListTo: %v", err)
+	}
+	out := stdout.String()
+	if strings.Contains(out, `"includes": null`) {
+		t.Errorf("includes serialised as null; want []. output: %s", out)
+	}
+	if strings.Contains(out, `"delegates_to": null`) {
+		t.Errorf("delegates_to serialised as null; want []. output: %s", out)
+	}
+
+	var got listEnvelope
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, out)
+	}
+	if len(got.Harnesses) != 1 {
+		t.Fatalf("expected 1 harness, got %d; output: %s", len(got.Harnesses), out)
+	}
+	if got.Harnesses[0].Includes == nil {
+		t.Error("Includes is nil; want empty slice")
+	}
+	if got.Harnesses[0].DelegatesTo == nil {
+		t.Error("DelegatesTo is nil; want empty slice")
 	}
 }

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -427,25 +427,25 @@ func cmdUninstall(args []string) error {
 
 	ref := args[0]
 
-	// Load to resolve the actual on-disk directory (may be namespaced or
-	// pointer-shaped). Accepts plain "name" or qualified "name@org/repo".
-	p, err := harness.LoadQualified(ref)
-	if err != nil {
-		return fmt.Errorf("harness %q is not installed", ref)
-	}
-	bareName := p.Name // bare name for launcher/run/sources cleanup
-
-	// Pointer-shaped install: remove only the pointer file. The user owns
-	// the source tree — uninstall is a registration removal, not a
-	// destructive delete. Tree-shaped installs (the original code path) get
-	// the directory removed.
-	var pointerSource string
-	if ptr, err := harness.LoadPointer(bareName); err == nil && ptr != nil {
+	// Pointer-shaped install: take the pointer path first, before attempting
+	// to load the manifest. Removing a pointer is a metadata operation; it
+	// must succeed even when the pointed-to source tree is missing — that's
+	// the exact case where users most need to uninstall.
+	var bareName, pointerSource string
+	if ptr, err := harness.LoadPointer(ref); err == nil && ptr != nil {
+		bareName = ptr.Name
 		pointerSource = ptr.Source
 		if err := harness.RemovePointer(bareName); err != nil {
 			return fmt.Errorf("removing pointer: %w", err)
 		}
 	} else {
+		// Tree-shaped install: resolve the on-disk directory (may be flat or
+		// namespaced) via the manifest, then remove the directory.
+		p, err := harness.LoadQualified(ref)
+		if err != nil {
+			return fmt.Errorf("harness %q is not installed", ref)
+		}
+		bareName = p.Name
 		if err := os.RemoveAll(p.Dir); err != nil {
 			return fmt.Errorf("removing harness: %w", err)
 		}
@@ -1292,6 +1292,27 @@ func cmdPrune() error {
 		}
 	}
 
+	// Scan for orphan pointer files: pointer exists but its source tree is
+	// gone. The user owned the source — they likely deleted it without
+	// uninstalling first. Removing the pointer is a metadata operation, so
+	// we can do it without consent prompts.
+	orphanPointers := 0
+	if pointers, err := harness.ListPointers(); err == nil {
+		for _, e := range pointers {
+			if _, err := os.Stat(e.Dir); err == nil {
+				continue
+			} else if !os.IsNotExist(err) {
+				continue
+			}
+			if err := harness.RemovePointer(e.Name); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: removing pointer %q: %v\n", e.Name, err)
+				continue
+			}
+			fmt.Printf("Removed orphan pointer: %s (source missing: %s)\n", e.Name, e.Dir)
+			orphanPointers++
+		}
+	}
+
 	// Scan for stale launcher scripts in ~/.ynh/bin/
 	staleLaunchers := 0
 	binDir := config.BinDir()
@@ -1336,7 +1357,7 @@ func cmdPrune() error {
 		}
 	}
 
-	if len(orphans) == 0 && staleLaunchers == 0 && staleRuns == 0 {
+	if len(orphans) == 0 && orphanPointers == 0 && staleLaunchers == 0 && staleRuns == 0 {
 		fmt.Println("No orphaned installations found.")
 	}
 

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -889,3 +889,62 @@ func TestCmdPrune_NoOrphans(t *testing.T) {
 		t.Fatalf("cmdPrune failed: %v", err)
 	}
 }
+
+// Pointer registers a fork; user later deletes the source tree without
+// uninstalling. ynh uninstall must still remove the pointer — the operation
+// is metadata, not a delete of user-owned files.
+func TestCmdUninstall_OrphanPointerSourceMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	missing := filepath.Join(t.TempDir(), "gone")
+	if err := harness.SavePointer(&harness.Pointer{
+		Name: "stranded", SourceType: "local",
+		Source: missing, InstalledAt: "2026-05-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdUninstall([]string{"stranded"}); err != nil {
+		t.Fatalf("cmdUninstall failed: %v", err)
+	}
+
+	if _, err := os.Stat(harness.PointerPath("stranded")); !os.IsNotExist(err) {
+		t.Errorf("pointer file still exists after uninstall: err=%v", err)
+	}
+}
+
+// Prune must remove pointers whose source tree no longer exists, alongside
+// the existing symlink-orphan pass. Healthy pointers must survive.
+func TestCmdPrune_OrphanPointer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	healthySrc := t.TempDir()
+	if err := harness.SavePointer(&harness.Pointer{
+		Name: "healthy", SourceType: "local",
+		Source: healthySrc, InstalledAt: "2026-05-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := harness.SavePointer(&harness.Pointer{
+		Name: "stranded", SourceType: "local",
+		Source: filepath.Join(t.TempDir(), "gone"), InstalledAt: "2026-05-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdPrune(); err != nil {
+		t.Fatalf("cmdPrune failed: %v", err)
+	}
+
+	if _, err := os.Stat(harness.PointerPath("stranded")); !os.IsNotExist(err) {
+		t.Errorf("orphan pointer still present after prune: err=%v", err)
+	}
+	if _, err := os.Stat(harness.PointerPath("healthy")); err != nil {
+		t.Errorf("healthy pointer was removed by prune: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Three related fixes around fork-pointer-shaped installs whose source tree has gone missing — surfaced by TermQ integration testing.

- **`ynh uninstall <name>`** now succeeds when only the pointer file exists (source tree gone). Previously, `LoadQualified` failed first and returned "not installed", even though the pointer was right there in `~/.ynh/installed/`. Removing a pointer is a metadata operation and should not depend on the source being intact.
- **`ynh ls --format json`** now emits `[]` (not `null`) for empty `includes`/`delegates_to` on broken-pointer placeholder rows. Healthy rows already used `make([]…, 0, …)`; the placeholder branch was the outlier.
- **`ynh prune`** now also removes pointer files whose source path is missing, alongside the existing symlink-orphan and stale launcher/run-dir passes. Users can recover from "deleted the source dir without uninstalling first" without hand-editing `~/.ynh/installed/`.

## Test plan

- [x] `make check` — all gates green
- [x] `/evals` — PASS (23 tests, 0 failures)
- [x] New unit tests:
  - `TestCmdUninstall_OrphanPointerSourceMissing`
  - `TestCmdPrune_OrphanPointer`
  - `TestCmdListJSONOrphanPointerEmptyArrays`

🤖 Generated with [Claude Code](https://claude.com/claude-code)