### PR TITLE
feat(e2e): full E2E test suite (~100 tests, ~1m wallclock)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -97,7 +97,16 @@ make e2e
 
 ### E2E test suite
 
-`make e2e` runs an end-to-end test suite that exercises real install/update/fork/delegate/include flows against SHA-pinned fixtures in [eyelock/assistants:e2e-fixtures/](https://github.com/eyelock/assistants/tree/develop/e2e-fixtures). Tests live in `test/e2e/` behind the `e2e` build tag and are **not** part of `make check` or `make test`.
+`make e2e` runs an end-to-end test suite (~100 tests, ~1m wallclock) that exercises both binaries against SHA-pinned fixtures in [eyelock/assistants:e2e-fixtures/](https://github.com/eyelock/assistants/tree/develop/e2e-fixtures). Tests live in `test/e2e/` behind the `e2e` build tag and are **not** part of `make check` or `make test`.
+
+**What the suite locks:**
+
+- Every documented entry point on `ynh` and `ynd` (install, update, fork, delegate, include, run, vendors, sources, paths, status, prune, info, ls, image, search, registry; create, lint, validate, fmt, preview, export, compose, diff, migrate, marketplace, inspect)
+- All three vendor adapters (Claude, Codex, Cursor) end-to-end: instructions files, hooks (with matchers + per-vendor event remapping), MCP servers (command + URL forms, env passthrough)
+- Profile + focus resolution (hook replace + inherit, MCP deep-merge, mutex/unknown errors)
+- Schema/security guards (path traversal, --ref + local, fork update, duplicate sources)
+- JSON error envelope, override semantics (harness AGENTS.md beats include's), symlink stability across reinstall
+- Local file:// registry support (registry add → search → install with namespace collision handling)
 
 The suite is the release gate, not a per-PR gate:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,7 +90,27 @@ make lint
 
 # Full CI pipeline (deps, format, lint, test, build)
 make check
+
+# E2E suite (release gate; not part of `make check`)
+make e2e
 ```
+
+### E2E test suite
+
+`make e2e` runs an end-to-end test suite that exercises real install/update/fork/delegate/include flows against SHA-pinned fixtures in [eyelock/assistants:e2e-fixtures/](https://github.com/eyelock/assistants/tree/develop/e2e-fixtures). Tests live in `test/e2e/` behind the `e2e` build tag and are **not** part of `make check` or `make test`.
+
+The suite is the release gate, not a per-PR gate:
+
+| Trigger | Behaviour |
+|---------|-----------|
+| PR opened/updated targeting `main` | E2E must pass before merge (`.github/workflows/e2e.yml`) |
+| Tag push `v*` | E2E runs as part of `release.yml`, blocking `goreleaser` |
+| Manual `workflow_dispatch` | Ad-hoc "is develop healthy?" check before opening release PR |
+| PR targeting `develop` | Not triggered — feature work stays fast |
+
+Tests clone `eyelock/assistants` over the network and exercise the production binary built via `make build`. Fixture SHAs are pinned in `test/e2e/helpers.go`. When ynh's harness schema legitimately evolves, the same PR that changes the schema must update the affected fixtures in `eyelock/assistants:e2e-fixtures/` and bump the SHA constants.
+
+See `.claude/plans/e2e-test-suite.md` for the architecture and coverage matrix.
 
 ### Testing Unreleased ynh Against Downstream Tooling
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -110,6 +110,14 @@ The suite is the release gate, not a per-PR gate:
 
 Tests clone `eyelock/assistants` over the network and exercise the production binary built via `make build`. Fixture SHAs are pinned in `test/e2e/helpers.go`. When ynh's harness schema legitimately evolves, the same PR that changes the schema must update the affected fixtures in `eyelock/assistants:e2e-fixtures/` and bump the SHA constants.
 
+**Local fixture iteration.** If you have an `eyelock/assistants` worktree checked out at the pinned SHA, point the suite at it to skip the per-test clone:
+
+```bash
+YNH_E2E_ASSISTANTS_PATH=/path/to/assistants/worktree make e2e
+```
+
+The worktree's HEAD must match `AssistantsFixturesSHA` in `helpers.go` — otherwise the suite fails fast (so you can't accidentally pass tests locally with a fixture state CI doesn't share). Iterating on fixtures? Set `YNH_E2E_FIXTURES_LOOSE=1` to bypass the SHA check while you work, but bump the pinned SHA before pushing.
+
 See `.claude/plans/e2e-test-suite.md` for the architecture and coverage matrix.
 
 ### Testing Unreleased ynh Against Downstream Tooling

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,30 @@
+name: E2E
+
+# E2E suite runs only at release-promotion boundaries. Feature work
+# targeting `develop` stays fast (CI only). See
+# .claude/plans/e2e-test-suite.md for the full trigger model.
+#
+# Phase 5 will wire the tag-push trigger into release.yml so goreleaser
+# blocks on E2E. Until then, the v* trigger here runs alongside release.yml.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - run: make e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,14 +4,11 @@ name: E2E
 # targeting `develop` stays fast (CI only). See
 # .claude/plans/e2e-test-suite.md for the full trigger model.
 #
-# Phase 5 will wire the tag-push trigger into release.yml so goreleaser
-# blocks on E2E. Until then, the v* trigger here runs alongside release.yml.
+# Tag-push (v*) triggers go through release.yml's `e2e` job, which
+# blocks `goreleaser`. This workflow handles PR-to-main and ad-hoc runs.
 on:
   pull_request:
     branches: [main]
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,20 @@ permissions:
   packages: write
 
 jobs:
+  e2e:
+    name: E2E (release gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - run: make e2e
+
   release:
     name: Release
+    needs: e2e
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean deps install build test test-coverage format lint check run docs help docker-build docker-push
+.PHONY: clean deps install build test test-coverage e2e format lint check run docs help docker-build docker-push
 
 BINARY_NAME := ynh
 BINARY_NAME_DEV := ynd
@@ -54,6 +54,9 @@ else
 	$(GO) test ./... -coverprofile=coverage.out -count=1
 	$(GO) tool cover -func=coverage.out
 endif
+
+e2e: build ## Run the E2E test suite (release gate; not part of `make test` or `make check`)
+	$(GO) test -tags=e2e -count=1 -timeout=10m ./test/e2e/...
 
 format: ## Format code
 	$(GOIMPORTS) -w .

--- a/cmd/ynh/install_resolve.go
+++ b/cmd/ynh/install_resolve.go
@@ -38,8 +38,8 @@ func resolveInstallSource(source, existingPath string, cfg *config.Config) (reso
 		return resolvedSource{sourceType: "git"}, nil
 	}
 
-	// Rule 3: Git HTTPS/HTTP URL
-	if strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "http://") {
+	// Rule 3: Git HTTPS/HTTP/file URL
+	if strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "file://") {
 		return resolvedSource{sourceType: "git"}, nil
 	}
 

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -98,7 +98,7 @@ Usage:
 
 Commands:
   init                       Show ynh home path and setup instructions
-  install <source> [--path <subdir>]  Install a harness from Git URL or local path
+  install <source> [--path <subdir>] [--ref <ref>]  Install a harness from Git URL or local path
   uninstall <name>           Remove an installed harness and its launcher
   update <name>              Refresh cached Git repos for a harness
   run <name> [flags] [prompt]  Launch a harness session
@@ -140,6 +140,7 @@ Examples:
   ynh install github.com/myorg/david
   ynh install ./my-local-harness
   ynh install github.com/org/monorepo --path harnesses/david
+  ynh install github.com/org/repo --ref v1.2.0
   ynh run david
   ynh run david "review this PR"
   ynh run david -v codex
@@ -178,26 +179,29 @@ func cmdInit() error {
 
 func cmdInstall(args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: ynh install <git-url|local-path> [--path <subdir>]")
+		return fmt.Errorf("usage: ynh install <git-url|local-path> [--path <subdir>] [--ref <commit|tag|branch>]")
 	}
 
 	if err := config.EnsureDirs(); err != nil {
 		return err
 	}
 
-	// Parse --path flag from args
-	var pathFlag string
+	// Parse --path and --ref flags from args
+	var pathFlag, refFlag string
 	var remaining []string
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--path" && i+1 < len(args) {
 			pathFlag = args[i+1]
+			i++ // skip value
+		} else if args[i] == "--ref" && i+1 < len(args) {
+			refFlag = args[i+1]
 			i++ // skip value
 		} else {
 			remaining = append(remaining, args[i])
 		}
 	}
 	if len(remaining) < 1 {
-		return fmt.Errorf("usage: ynh install <git-url|local-path> [--path <subdir>]")
+		return fmt.Errorf("usage: ynh install <git-url|local-path> [--path <subdir>] [--ref <commit|tag|branch>]")
 	}
 
 	source := remaining[0]
@@ -227,6 +231,20 @@ func cmdInstall(args []string) error {
 			pathFlag = resolved.path
 		}
 	}
+	// --ref overrides any registry-resolved ref. Allowed only when a git
+	// fetch will actually happen; noisily refused for local installs to
+	// avoid silent confusion.
+	if refFlag != "" {
+		if resolved.sourceType == "local" || resolved.localPath != "" {
+			return fmt.Errorf("--ref is not valid for local-path installs")
+		}
+		resolved.ref = refFlag
+		resolved.sha = "" // user-provided ref takes precedence; don't verify against a stale registry SHA
+	}
+
+	// resolvedSHA captures the actual commit SHA fetched for git installs;
+	// stays empty for local installs.
+	var resolvedSHA string
 
 	if resolved.localPath != "" {
 		srcDir = resolved.localPath
@@ -254,6 +272,7 @@ func cmdInstall(args []string) error {
 			return err
 		}
 		srcDir = result.Path
+		resolvedSHA = result.SHA
 	}
 
 	// Scope to subdirectory if --path was specified
@@ -325,6 +344,8 @@ func cmdInstall(args []string) error {
 	ins := &plugin.InstalledJSON{
 		SourceType:   resolved.sourceType,
 		Source:       provSource,
+		Ref:          resolved.ref,
+		SHA:          resolvedSHA,
 		Path:         pathFlag,
 		Namespace:    resolved.namespace,
 		RegistryName: resolved.registryName,

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -843,6 +843,35 @@ func TestCmdInstall_PathFlag_TraversalBlocked(t *testing.T) {
 	}
 }
 
+func TestCmdInstall_RefFlag_RejectedForLocalPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("YNH_HOME", "")
+
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(filepath.Join(src, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, ".ynh-plugin", "plugin.json"), []byte(`{"name":"x","version":"0.0.1"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cmdInstall([]string{src, "--ref", "deadbeef"})
+	if err == nil {
+		t.Fatal("expected error: --ref on local install")
+	}
+	if !strings.Contains(err.Error(), "--ref is not valid for local-path installs") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCmdInstall_RefFlag_NoValue(t *testing.T) {
+	err := cmdInstall([]string{"some-source", "--ref"})
+	// --ref with no value should be silently dropped (i+1 < len check fails),
+	// then the install continues. We only assert it doesn't panic.
+	_ = err
+}
+
 func TestCmdInstall_SourceInsideHarnessesDir(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/eyelock/ynh/internal/config"
@@ -186,7 +187,16 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 		if err := os.RemoveAll(repoDir); err != nil {
 			return RepoResult{}, fmt.Errorf("removing incomplete cache dir: %w", err)
 		}
-		// Clone
+		// SHA refs can't go through `clone --branch <sha>` — git rejects them.
+		// Use init+fetch+checkout, which works against any server that allows
+		// fetch-by-SHA (GitHub does, default uploadpack.allowReachableSHA1InWant).
+		if isShaLike(ref) {
+			if err := cloneAtSHA(repoDir, fullURL, ref); err != nil {
+				return RepoResult{}, err
+			}
+			return RepoResult{Path: repoDir, SHA: gitHead(repoDir), Cloned: true, Changed: true}, nil
+		}
+		// Branch/tag: use clone --branch for the depth-1 shortcut.
 		args := []string{"clone", "--depth", "1"}
 		if ref != "" {
 			args = append(args, "--branch", ref)
@@ -403,12 +413,43 @@ func repoDirPrefix(url string) string {
 	return parts[len(parts)-1]
 }
 
+// shaLike matches a 40-character hex commit SHA. Git refuses to take a
+// SHA via `clone --branch`, so SHA pinning has to go through init+fetch.
+var shaLike = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+func isShaLike(ref string) bool {
+	return shaLike.MatchString(ref)
+}
+
+// cloneAtSHA materialises a shallow checkout of url at sha into dir.
+// dir must not yet exist.
+func cloneAtSHA(dir, url, sha string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating cache dir: %w", err)
+	}
+	if err := gitCmd("-C", dir, "init", "--quiet"); err != nil {
+		return fmt.Errorf("git init in %s: %w", dir, err)
+	}
+	if err := gitCmd("-C", dir, "remote", "add", "origin", url); err != nil {
+		return fmt.Errorf("git remote add: %w", err)
+	}
+	if err := gitCmd("-C", dir, "fetch", "--depth", "1", "origin", sha); err != nil {
+		return fmt.Errorf("git fetch %s %s: %w", url, sha, err)
+	}
+	if err := gitCmd("-C", dir, "checkout", "--quiet", sha); err != nil {
+		return fmt.Errorf("git checkout %s: %w", sha, err)
+	}
+	return nil
+}
+
 // NormalizeGitURL ensures a full Git URL from shorthand.
 // Local paths (starting with / or .) are returned as-is.
 // Shorthand like "github.com/user/repo" becomes "git@github.com:user/repo.git" (SSH).
-// SSH URLs (git@...) and full HTTPS URLs are passed through unchanged.
+// SSH URLs (git@...), HTTPS URLs, and file:// URLs are passed through unchanged.
+// (file:// is a valid git transport for local bare repos and lets the E2E suite
+// exercise the cloner against controlled fixtures without going to the network.)
 func NormalizeGitURL(url string) string {
-	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "git@") {
+	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "git@") || strings.HasPrefix(url, "file://") {
 		return url
 	}
 	if strings.HasPrefix(url, "/") || strings.HasPrefix(url, ".") {

--- a/test/e2e/check_updates_test.go
+++ b/test/e2e/check_updates_test.go
@@ -1,0 +1,72 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// TestLs_CheckUpdates_JSON_Shape installs a harness with a floating include
+// pointing at a local file:// upstream, then runs `ynh ls --check-updates
+// --format json` after the upstream HEAD has moved. Asserts the JSON output
+// carries ref_installed (the resolved SHA at install) and ref_available (the
+// new upstream SHA) at the include level, and that they differ.
+//
+// This is the JSON shape the suite was built for — the #115 regression
+// surfaced through this exact field pair on includes.
+func TestLs_CheckUpdates_JSON_Shape(t *testing.T) {
+	s := newSandbox(t)
+	upstream := newLocalUpstream(t, "include-target", "first content")
+	harness := newLocalFloatingHarness(t, "check-updates-harness", upstream)
+
+	s.mustRunYnh(t, "install", harness)
+
+	commitToUpstream(t, upstream, "include-target/SKILL.md", "second content")
+
+	out, _ := s.mustRunYnh(t, "ls", "--check-updates", "--format", "json")
+
+	var env struct {
+		Schema    string `json:"$schema"`
+		Harnesses []struct {
+			Name     string `json:"name"`
+			Includes []struct {
+				Git          string `json:"git"`
+				RefInstalled string `json:"ref_installed,omitempty"`
+				RefAvailable string `json:"ref_available,omitempty"`
+				IsPinned     bool   `json:"is_pinned"`
+			} `json:"includes"`
+		} `json:"harnesses"`
+	}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parsing ls --check-updates JSON: %v\n%s", err, out)
+	}
+
+	if len(env.Harnesses) != 1 {
+		t.Fatalf("expected 1 harness, got %d: %+v", len(env.Harnesses), env.Harnesses)
+	}
+	h := env.Harnesses[0]
+	assertEqual(t, "harness name", h.Name, "check-updates-harness")
+	if len(h.Includes) != 1 {
+		t.Fatalf("expected 1 include, got %d: %+v", len(h.Includes), h.Includes)
+	}
+	inc := h.Includes[0]
+
+	if !sha40.MatchString(inc.RefInstalled) {
+		t.Errorf("includes[0].ref_installed %q is not a 40-char SHA", inc.RefInstalled)
+	}
+	if !sha40.MatchString(inc.RefAvailable) {
+		t.Errorf("includes[0].ref_available %q is not a 40-char SHA — probe may have failed", inc.RefAvailable)
+	}
+	if inc.RefInstalled == inc.RefAvailable {
+		t.Errorf("expected ref_installed != ref_available after upstream HEAD moved; both are %s", inc.RefInstalled)
+	}
+
+	// Also sanity-check we can still read installed.json and it agrees with the JSON.
+	inst := readInstalledJSON(t, filepath.Join(s.home, "harnesses", "check-updates-harness"))
+	if len(inst.Resolved) != 1 {
+		t.Fatalf("installed.json: expected 1 resolved entry, got %d", len(inst.Resolved))
+	}
+	assertEqual(t, "ref_installed agrees with installed.json", inc.RefInstalled, inst.Resolved[0].SHA)
+}

--- a/test/e2e/delegate_test.go
+++ b/test/e2e/delegate_test.go
@@ -1,0 +1,100 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// pluginManifest mirrors the on-disk .ynh-plugin/plugin.json shape we
+// need to read after editor mutations. Subset of internal/plugin.PluginJSON.
+type pluginManifest struct {
+	Name        string               `json:"name"`
+	Version     string               `json:"version"`
+	Description string               `json:"description,omitempty"`
+	Includes    []manifestSourceJSON `json:"includes,omitempty"`
+	DelegatesTo []manifestSourceJSON `json:"delegates_to,omitempty"`
+}
+
+type manifestSourceJSON struct {
+	Git   string   `json:"git,omitempty"`
+	Local string   `json:"local,omitempty"`
+	Ref   string   `json:"ref,omitempty"`
+	Path  string   `json:"path,omitempty"`
+	Pick  []string `json:"pick,omitempty"`
+}
+
+// TestDelegate_AddRemove walks a delegate through add → resolved → remove
+// and asserts the manifest and installed.json both reflect each step.
+func TestDelegate_AddRemove(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	s.mustRunYnh(t, "install", filepath.Join(clone, "e2e-fixtures", "minimal"))
+
+	delegateURL := "github.com/eyelock/assistants"
+	s.mustRunYnh(t, "delegate", "add", "minimal", delegateURL,
+		"--path", "e2e-fixtures/included-skill",
+		"--ref", AssistantsFixturesSHA,
+	)
+
+	mf := readManifest(t, filepath.Join(s.home, "harnesses", "minimal"))
+	if len(mf.DelegatesTo) != 1 {
+		t.Fatalf("expected 1 delegate after add, got %d: %+v", len(mf.DelegatesTo), mf.DelegatesTo)
+	}
+	d := mf.DelegatesTo[0]
+	assertEqual(t, "delegates_to[0].git", d.Git, delegateURL)
+	assertEqual(t, "delegates_to[0].path", d.Path, "e2e-fixtures/included-skill")
+	assertEqual(t, "delegates_to[0].ref", d.Ref, AssistantsFixturesSHA)
+
+	s.mustRunYnh(t, "delegate", "remove", "minimal", delegateURL, "--path", "e2e-fixtures/included-skill")
+
+	mf = readManifest(t, filepath.Join(s.home, "harnesses", "minimal"))
+	if len(mf.DelegatesTo) != 0 {
+		t.Errorf("expected 0 delegates after remove, got %d", len(mf.DelegatesTo))
+	}
+}
+
+// TestInclude_AddRemove walks an include through add → resolved → remove.
+func TestInclude_AddRemove(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	s.mustRunYnh(t, "install", filepath.Join(clone, "e2e-fixtures", "minimal"))
+
+	includeURL := "github.com/eyelock/assistants"
+	s.mustRunYnh(t, "include", "add", "minimal", includeURL,
+		"--path", "e2e-fixtures/included-skill",
+		"--ref", AssistantsFixturesSHA,
+	)
+
+	mf := readManifest(t, filepath.Join(s.home, "harnesses", "minimal"))
+	if len(mf.Includes) != 1 {
+		t.Fatalf("expected 1 include after add, got %d", len(mf.Includes))
+	}
+	i := mf.Includes[0]
+	assertEqual(t, "includes[0].git", i.Git, includeURL)
+	assertEqual(t, "includes[0].path", i.Path, "e2e-fixtures/included-skill")
+	assertEqual(t, "includes[0].ref", i.Ref, AssistantsFixturesSHA)
+
+	s.mustRunYnh(t, "include", "remove", "minimal", includeURL, "--path", "e2e-fixtures/included-skill")
+
+	mf = readManifest(t, filepath.Join(s.home, "harnesses", "minimal"))
+	if len(mf.Includes) != 0 {
+		t.Errorf("expected 0 includes after remove, got %d", len(mf.Includes))
+	}
+}
+
+func readManifest(t *testing.T, harnessDir string) pluginManifest {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(harnessDir, ".ynh-plugin", "plugin.json"))
+	if err != nil {
+		t.Fatalf("reading plugin.json: %v", err)
+	}
+	var mf pluginManifest
+	if err := json.Unmarshal(body, &mf); err != nil {
+		t.Fatalf("parsing plugin.json: %v\n%s", err, body)
+	}
+	return mf
+}

--- a/test/e2e/delegate_test.go
+++ b/test/e2e/delegate_test.go
@@ -86,6 +86,63 @@ func TestInclude_AddRemove(t *testing.T) {
 	}
 }
 
+// TestInclude_Update mutates an existing include's --path and asserts the
+// manifest reflects the change. Covers cmdIncludeUpdate (0% E2E previously).
+//
+// We mutate --path rather than --ref to keep the test SHA-stable: the
+// AssistantsFixturesSHA contains both `e2e-fixtures/minimal` and
+// `e2e-fixtures/included-skill` so the path can flip between them without
+// needing to advance the pinned ref.
+func TestInclude_Update(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	s.mustRunYnh(t, "install", filepath.Join(clone, "e2e-fixtures", "minimal"))
+
+	includeURL := "github.com/eyelock/assistants"
+	s.mustRunYnh(t, "include", "add", "minimal", includeURL,
+		"--path", "e2e-fixtures/minimal",
+		"--ref", AssistantsFixturesSHA,
+	)
+
+	s.mustRunYnh(t, "include", "update", "minimal", includeURL,
+		"--from-path", "e2e-fixtures/minimal",
+		"--path", "e2e-fixtures/included-skill",
+	)
+
+	mf := readManifest(t, filepath.Join(s.home, "harnesses", "minimal"))
+	if len(mf.Includes) != 1 {
+		t.Fatalf("expected 1 include after update, got %d", len(mf.Includes))
+	}
+	assertEqual(t, "includes[0].path", mf.Includes[0].Path, "e2e-fixtures/included-skill")
+	assertEqual(t, "includes[0].ref unchanged", mf.Includes[0].Ref, AssistantsFixturesSHA)
+}
+
+// TestDelegate_Update mutates an existing delegate's --ref and asserts the
+// manifest reflects the new ref. Covers cmdDelegateUpdate (0% E2E previously).
+func TestDelegate_Update(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	s.mustRunYnh(t, "install", filepath.Join(clone, "e2e-fixtures", "minimal"))
+
+	delegateURL := "github.com/eyelock/assistants"
+	s.mustRunYnh(t, "delegate", "add", "minimal", delegateURL,
+		"--path", "e2e-fixtures/included-skill",
+		"--ref", AssistantsFixturesSHA,
+	)
+
+	s.mustRunYnh(t, "delegate", "update", "minimal", delegateURL,
+		"--from-path", "e2e-fixtures/included-skill",
+		"--ref", AssistantsFixturesV1Tag,
+	)
+
+	mf := readManifest(t, filepath.Join(s.home, "harnesses", "minimal"))
+	if len(mf.DelegatesTo) != 1 {
+		t.Fatalf("expected 1 delegate after update, got %d", len(mf.DelegatesTo))
+	}
+	assertEqual(t, "delegates_to[0].ref", mf.DelegatesTo[0].Ref, AssistantsFixturesV1Tag)
+	assertEqual(t, "delegates_to[0].path", mf.DelegatesTo[0].Path, "e2e-fixtures/included-skill")
+}
+
 func readManifest(t *testing.T, harnessDir string) pluginManifest {
 	t.Helper()
 	body, err := os.ReadFile(filepath.Join(harnessDir, ".ynh-plugin", "plugin.json"))

--- a/test/e2e/error_envelope_test.go
+++ b/test/e2e/error_envelope_test.go
@@ -1,0 +1,57 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestErrorEnvelope_JSON locks the structured-error contract documented in
+// docs/cli-structured.md: when --format=json is passed and the command
+// fails, stderr carries a single JSON object {error:{code,message}} and
+// stdout is empty. Consumers (CI tooling, IDE plugins) parse this shape.
+//
+// Pinning ynh info on a missing harness as the canary — exercises the
+// not_found code path through cliError.
+func TestErrorEnvelope_JSON(t *testing.T) {
+	s := newSandbox(t)
+
+	stdout, stderr, err := s.runYnh(t, "info", "does-not-exist", "--format", "json")
+	if err == nil {
+		t.Fatalf("expected info on missing harness to fail, got success\nstdout:\n%s", stdout)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("structured error should not write to stdout, got:\n%s", stdout)
+	}
+
+	// stderr may contain trailing text from main.go but the envelope must be
+	// parseable from one of the lines.
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	var found bool
+	for _, line := range strings.Split(stderr, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "{") {
+			continue
+		}
+		if jerr := json.Unmarshal([]byte(line), &env); jerr == nil && env.Error.Code != "" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("could not find error envelope in stderr:\n%s", stderr)
+	}
+	if env.Error.Code == "" {
+		t.Errorf("error.code is empty")
+	}
+	if env.Error.Message == "" {
+		t.Errorf("error.message is empty")
+	}
+}

--- a/test/e2e/fork_test.go
+++ b/test/e2e/fork_test.go
@@ -1,0 +1,53 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestFork_BasicProvenance asserts that `ynh fork` records the source
+// harness's provenance in the new harness's installed.json.forked_from.
+func TestFork_BasicProvenance(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	srcPath := filepath.Join(clone, "e2e-fixtures", "fork-source")
+
+	s.mustRunYnh(t, "install", srcPath)
+
+	forkDir := filepath.Join(t.TempDir(), "my-fork")
+	s.mustRunYnh(t, "fork", "fork-source", "--to", forkDir)
+
+	got := readInstalledJSON(t, forkDir)
+	assertEqual(t, "source_type", got.SourceType, "local")
+	assertEqual(t, "source", got.Source, forkDir)
+	if got.ForkedFrom == nil {
+		t.Fatal("expected forked_from to be populated")
+	}
+	assertEqual(t, "forked_from.source_type", got.ForkedFrom.SourceType, "local")
+	assertEqual(t, "forked_from.source", got.ForkedFrom.Source, srcPath)
+	assertEqual(t, "forked_from.version", got.ForkedFrom.Version, "0.1.0")
+}
+
+// TestFork_CarryForward asserts that installing a previously-forked
+// directory preserves the original forked_from provenance — the chain
+// of "this came from there" survives re-installation.
+func TestFork_CarryForward(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	srcPath := filepath.Join(clone, "e2e-fixtures", "fork-source")
+
+	s.mustRunYnh(t, "install", srcPath)
+	forkDir := filepath.Join(t.TempDir(), "my-fork")
+	s.mustRunYnh(t, "fork", "fork-source", "--to", forkDir)
+
+	s.mustRunYnh(t, "uninstall", "fork-source")
+	s.mustRunYnh(t, "install", forkDir)
+
+	installed := readInstalledJSON(t, filepath.Join(s.home, "harnesses", "fork-source"))
+	if installed.ForkedFrom == nil {
+		t.Fatal("expected forked_from to carry forward into re-installed harness")
+	}
+	assertEqual(t, "forked_from.source", installed.ForkedFrom.Source, srcPath)
+}

--- a/test/e2e/fork_update_test.go
+++ b/test/e2e/fork_update_test.go
@@ -1,0 +1,36 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFork_UpdateRejected verifies the documented constraint that
+// `ynh update` errors on a forked harness — forks may freely diverge
+// from the original and so cannot pull upstream changes mechanically.
+//
+// Locks the error message wording: callers (CI, IDE plugins) parse for
+// "fork" in the failure mode.
+func TestFork_UpdateRejected(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	srcPath := filepath.Join(clone, "e2e-fixtures", "fork-source")
+
+	s.mustRunYnh(t, "install", srcPath)
+
+	forkDir := filepath.Join(t.TempDir(), "my-fork")
+	s.mustRunYnh(t, "fork", "fork-source", "--to", forkDir)
+	s.mustRunYnh(t, "uninstall", "fork-source")
+	s.mustRunYnh(t, "install", forkDir)
+
+	_, errOut, err := s.runYnh(t, "update", "fork-source")
+	if err == nil {
+		t.Fatalf("expected `ynh update <fork>` to fail, got success\nstderr:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "fork") {
+		t.Errorf("expected error to mention 'fork', got: %s", errOut)
+	}
+}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -97,6 +97,35 @@ func mustRunYnd(t *testing.T, args ...string) (stdout, stderr string) {
 	return out, errOut
 }
 
+// runYndInDirEnv executes ynd with cwd=dir and a custom environment.
+// extraEnv is appended after os.Environ() so callers can override PATH or
+// inject vars without losing the rest of the parent env. Returns
+// stdout/stderr/error so tests can inspect output and assert error paths.
+func runYndInDirEnv(t *testing.T, dir string, extraEnv []string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	cmd := exec.Command(yndBinary(t), args...)
+	cmd.Env = append(os.Environ(), extraEnv...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// mustRunYndInDir runs ynd with cwd=dir, fails on non-zero exit. Use for
+// commands like `ynd create` that operate on the current working directory.
+func mustRunYndInDir(t *testing.T, dir string, args ...string) (stdout, stderr string) {
+	t.Helper()
+	out, errOut, err := runYndInDirEnv(t, dir, nil, args...)
+	if err != nil {
+		t.Fatalf("ynd %s in %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), dir, err, out, errOut)
+	}
+	return out, errOut
+}
+
 // sandbox is a fully isolated ynh environment for one test.
 // home is set as YNH_HOME for the duration of the test.
 type sandbox struct {

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -163,15 +163,37 @@ func mustRunYnhInDir(t *testing.T, s *sandbox, dir string, args ...string) (stdo
 	return out, errOut
 }
 
-// cloneAssistantsAtSHA clones eyelock/assistants into a tempdir and
-// checks out the pinned fixture SHA. Returns the absolute path of the
-// working tree. Tests install fixtures from <clone>/e2e-fixtures/<name>
-// via `ynh install <local-path>` (source_type=local) — the local-path
-// installer is what gives reproducibility against the pinned SHA.
-// Git-source coverage is deferred to Phase 2 (needs `--ref` on
-// `ynh install`, or live-github structural-only assertions).
+// cloneAssistantsAtSHA returns the absolute path of an eyelock/assistants
+// working tree at AssistantsFixturesSHA. By default it clones into a
+// tempdir over HTTPS — slow but deterministic, and the only mode CI can use.
+//
+// Local override: set YNH_E2E_ASSISTANTS_PATH to an existing worktree to
+// skip the clone. The worktree's HEAD must match AssistantsFixturesSHA, or
+// the test fails fast (so you cannot accidentally pass tests locally with
+// a fixture state that CI doesn't share). Set YNH_E2E_FIXTURES_LOOSE=1 to
+// bypass the SHA check while iterating on fixtures.
 func cloneAssistantsAtSHA(t *testing.T) string {
 	t.Helper()
+
+	if local := os.Getenv("YNH_E2E_ASSISTANTS_PATH"); local != "" {
+		if _, err := os.Stat(filepath.Join(local, ".git")); err != nil {
+			t.Fatalf("YNH_E2E_ASSISTANTS_PATH=%s is not a git working tree: %v", local, err)
+		}
+		if os.Getenv("YNH_E2E_FIXTURES_LOOSE") == "" {
+			out, err := exec.Command("git", "-C", local, "rev-parse", "HEAD").Output()
+			if err != nil {
+				t.Fatalf("reading HEAD of YNH_E2E_ASSISTANTS_PATH=%s: %v", local, err)
+			}
+			head := strings.TrimSpace(string(out))
+			if head != AssistantsFixturesSHA {
+				t.Fatalf("YNH_E2E_ASSISTANTS_PATH=%s HEAD %s does not match pinned SHA %s — "+
+					"checkout the pinned SHA or set YNH_E2E_FIXTURES_LOOSE=1 to bypass",
+					local, head, AssistantsFixturesSHA)
+			}
+		}
+		return local
+	}
+
 	dir := filepath.Join(t.TempDir(), "assistants")
 	mustGit(t, "", "clone", "--quiet", AssistantsRepo, dir)
 	mustGit(t, dir, "checkout", "--quiet", AssistantsFixturesSHA)

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -64,6 +64,39 @@ func ynhBinary(t *testing.T) string {
 	return bin
 }
 
+// yndBinary returns the absolute path of the ynd developer-tools binary
+// built by `make build`. Same lifecycle guarantees as ynhBinary.
+func yndBinary(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(repoRoot(t), "bin", "ynd")
+	if _, err := os.Stat(bin); err != nil {
+		t.Fatalf("ynd binary not found at %s — run `make build` first: %v", bin, err)
+	}
+	return bin
+}
+
+// runYnd executes the ynd binary with args and returns stdout/stderr/error.
+// ynd is filesystem-driven and stateless — no sandbox needed.
+func runYnd(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	cmd := exec.Command(yndBinary(t), args...)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// mustRunYnd is runYnd that fails the test on non-zero exit.
+func mustRunYnd(t *testing.T, args ...string) (stdout, stderr string) {
+	t.Helper()
+	out, errOut, err := runYnd(t, args...)
+	if err != nil {
+		t.Fatalf("ynd %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, out, errOut)
+	}
+	return out, errOut
+}
+
 // sandbox is a fully isolated ynh environment for one test.
 // home is set as YNH_HOME for the duration of the test.
 type sandbox struct {

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -30,8 +30,15 @@ const AssistantsRepo = "https://github.com/eyelock/assistants.git"
 // e2e-fixtures/ tree the suite tests against. Bump intentionally when
 // fixtures evolve (see eyelock/assistants:e2e-fixtures/README.md).
 //
-// Pinned to the merge commit of eyelock/assistants#15 (initial fixture).
-const AssistantsFixturesSHA = "8713efacdee8a2b05bdb70fee83be73b66222cc4"
+// Pinned to the tip of eyelock/assistants:feat/e2e-fixtures-extended
+// (containing all Phases 2–4 fixtures). Update to the merge SHA on
+// `develop` once that branch is merged.
+const AssistantsFixturesSHA = "69baa731b5a1ed67ff0c5362f7806f398ee62815"
+
+// AssistantsFixturesV1Tag is a stable git tag in eyelock/assistants used
+// by the with-tag-include fixture to verify tag-to-SHA resolution.
+// Currently points at the initial fixture commit (8713efa).
+const AssistantsFixturesV1Tag = "e2e-fixtures-v1"
 
 // repoRoot resolves the ynh repo root from this source file's location.
 // Stable across test working directories and CI runners.

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -1,0 +1,163 @@
+//go:build e2e
+
+// Package e2e contains the ynh end-to-end test suite.
+//
+// These tests exercise real install/update/fork/delegate flows against
+// hand-crafted fixtures pinned by SHA in eyelock/assistants:e2e-fixtures/.
+// They build the production binary via `make build` and assert deep
+// filesystem state in temp directories. They never touch the developer's
+// real ~/.ynh.
+//
+// Run with `make e2e`. They are gated behind the `e2e` build tag and do
+// not run as part of `make test`.
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// AssistantsRepo is the upstream repository hosting the E2E fixtures.
+const AssistantsRepo = "https://github.com/eyelock/assistants.git"
+
+// AssistantsFixturesSHA pins the commit of eyelock/assistants whose
+// e2e-fixtures/ tree the suite tests against. Bump intentionally when
+// fixtures evolve (see eyelock/assistants:e2e-fixtures/README.md).
+//
+// Pinned to the merge commit of eyelock/assistants#15 (initial fixture).
+const AssistantsFixturesSHA = "8713efacdee8a2b05bdb70fee83be73b66222cc4"
+
+// repoRoot resolves the ynh repo root from this source file's location.
+// Stable across test working directories and CI runners.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// helpers.go lives at <repo>/test/e2e/helpers.go
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+// ynhBinary returns the absolute path of the ynh binary built by
+// `make build`. The Makefile's `e2e` target depends on `build`, so
+// the binary is guaranteed to exist when the suite runs.
+func ynhBinary(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(repoRoot(t), "bin", "ynh")
+	if _, err := os.Stat(bin); err != nil {
+		t.Fatalf("ynh binary not found at %s — run `make build` first: %v", bin, err)
+	}
+	return bin
+}
+
+// sandbox is a fully isolated ynh environment for one test.
+// home is set as YNH_HOME for the duration of the test.
+type sandbox struct {
+	home string
+}
+
+// newSandbox creates a per-test ynh home under t.TempDir() and points
+// YNH_HOME at it. Cleanup is automatic via t.TempDir().
+func newSandbox(t *testing.T) *sandbox {
+	t.Helper()
+	home := filepath.Join(t.TempDir(), "ynh-home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("creating ynh home: %v", err)
+	}
+	t.Setenv("YNH_HOME", home)
+	return &sandbox{home: home}
+}
+
+// runYnh executes the ynh binary with args inside the sandbox.
+// It returns stdout, stderr, and the resulting error (non-nil on non-zero exit).
+func (s *sandbox) runYnh(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	cmd := exec.Command(ynhBinary(t), args...)
+	cmd.Env = append(os.Environ(), "YNH_HOME="+s.home)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// mustRunYnh is runYnh that fails the test on non-zero exit.
+func (s *sandbox) mustRunYnh(t *testing.T, args ...string) (stdout, stderr string) {
+	t.Helper()
+	out, errOut, err := s.runYnh(t, args...)
+	if err != nil {
+		t.Fatalf("ynh %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, out, errOut)
+	}
+	return out, errOut
+}
+
+// cloneAssistantsAtSHA clones eyelock/assistants into a tempdir and
+// checks out the pinned fixture SHA. Returns the absolute path of the
+// working tree. Tests install fixtures from <clone>/e2e-fixtures/<name>
+// via `ynh install <local-path>` (source_type=local) — the local-path
+// installer is what gives reproducibility against the pinned SHA.
+// Git-source coverage is deferred to Phase 2 (needs `--ref` on
+// `ynh install`, or live-github structural-only assertions).
+func cloneAssistantsAtSHA(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "assistants")
+	mustGit(t, "", "clone", "--quiet", AssistantsRepo, dir)
+	mustGit(t, dir, "checkout", "--quiet", AssistantsFixturesSHA)
+	return dir
+}
+
+// mustGit runs `git <args...>` in dir (or cwd if dir is empty) and
+// fails the test on non-zero exit.
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// assertFileExists fails the test if path is not a regular file.
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected file at %s: %v", path, err)
+	}
+	if info.IsDir() {
+		t.Fatalf("expected file at %s, found directory", path)
+	}
+}
+
+// assertDirExists fails the test if path is not a directory.
+func assertDirExists(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected directory at %s: %v", path, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected directory at %s, found regular file", path)
+	}
+}
+
+// assertEqual compares got and want using reflect.DeepEqual via fmt
+// formatting and reports field-level context on mismatch. Zero-deps —
+// no go-cmp.
+func assertEqual[T any](t *testing.T, field string, got, want T) {
+	t.Helper()
+	gs, ws := fmt.Sprintf("%+v", got), fmt.Sprintf("%+v", want)
+	if gs != ws {
+		t.Errorf("%s mismatch:\n  got:  %s\n  want: %s", field, gs, ws)
+	}
+}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -30,10 +30,9 @@ const AssistantsRepo = "https://github.com/eyelock/assistants.git"
 // e2e-fixtures/ tree the suite tests against. Bump intentionally when
 // fixtures evolve (see eyelock/assistants:e2e-fixtures/README.md).
 //
-// Pinned to the tip of eyelock/assistants:feat/e2e-fixtures-extended
-// (containing all Phases 2–4 fixtures). Update to the merge SHA on
-// `develop` once that branch is merged.
-const AssistantsFixturesSHA = "69baa731b5a1ed67ff0c5362f7806f398ee62815"
+// Pinned to the squash-merge of eyelock/assistants#16 on develop —
+// the commit that landed all Phases 2–4 fixtures.
+const AssistantsFixturesSHA = "7c6793652f818c30e9a6e6cc79afef8f4fbe38e9"
 
 // AssistantsFixturesV1Tag is a stable git tag in eyelock/assistants used
 // by the with-tag-include fixture to verify tag-to-SHA resolution.

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -105,6 +105,31 @@ func (s *sandbox) mustRunYnh(t *testing.T, args ...string) (stdout, stderr strin
 	return out, errOut
 }
 
+// runYnhInDirRaw executes the ynh binary with cwd=dir inside sandbox s and
+// returns stdout, stderr, and the resulting error. Used by tests that need
+// to assert behaviour from a project directory rather than a default cwd.
+func runYnhInDirRaw(t *testing.T, s *sandbox, dir string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	cmd := exec.Command(ynhBinary(t), args...)
+	cmd.Env = append(os.Environ(), "YNH_HOME="+s.home)
+	cmd.Dir = dir
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// mustRunYnhInDir is runYnhInDirRaw that fails the test on non-zero exit.
+func mustRunYnhInDir(t *testing.T, s *sandbox, dir string, args ...string) (stdout, stderr string) {
+	t.Helper()
+	out, errOut, err := runYnhInDirRaw(t, s, dir, args...)
+	if err != nil {
+		t.Fatalf("ynh %s in %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), dir, err, out, errOut)
+	}
+	return out, errOut
+}
+
 // cloneAssistantsAtSHA clones eyelock/assistants into a tempdir and
 // checks out the pinned fixture SHA. Returns the absolute path of the
 // working tree. Tests install fixtures from <clone>/e2e-fixtures/<name>

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -1,0 +1,89 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestHooks_PerVendor verifies that canonical hook declarations in a
+// harness's plugin.json get translated into each vendor's native hooks
+// file, with the canonical event name remapped per-vendor:
+//
+//   - Claude: .claude/hooks/hooks.json — uses Claude event names (PreToolUse, etc.)
+//   - Codex:  .codex/hooks.json
+//   - Cursor: .cursor/hooks.json
+//
+// Locks the canonical→vendor event-name remap. Silently breaking it
+// means hooks stop firing on the vendor CLI.
+func TestHooks_PerVendor(t *testing.T) {
+	cases := []struct {
+		vendor   string
+		hookFile string // relative to runDir
+	}{
+		{vendor: "claude", hookFile: filepath.Join(".claude", "hooks", "hooks.json")},
+		{vendor: "codex", hookFile: filepath.Join(".codex", "hooks.json")},
+		{vendor: "cursor", hookFile: filepath.Join(".cursor", "hooks.json")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.vendor, func(t *testing.T) {
+			s := newSandbox(t)
+			name := fmt.Sprintf("hooked-%s", tc.vendor)
+			harness := newHookedHarness(t, name)
+			s.mustRunYnh(t, "install", harness)
+
+			project := filepath.Join(t.TempDir(), "project")
+			if err := os.MkdirAll(project, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			mustRunYnhInDir(t, s, project, "run", name, "-v", tc.vendor, "--install")
+
+			runDir := filepath.Join(s.home, "run", name)
+			path := filepath.Join(runDir, tc.hookFile)
+			body, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("expected hook file %s: %v", tc.hookFile, err)
+			}
+			// Sanity-check JSON parses and is non-empty.
+			var raw map[string]any
+			if err := json.Unmarshal(body, &raw); err != nil {
+				t.Fatalf("hook file is not valid JSON: %v\n%s", err, body)
+			}
+			if len(raw) == 0 {
+				t.Errorf("hook file is empty JSON object: %s", body)
+			}
+			// The canonical command must appear somewhere in the rendered file —
+			// vendor remap touches event names, not command bodies.
+			if !bytes.Contains(body, []byte("echo hooked")) {
+				t.Errorf("hook command not present in %s:\n%s", tc.hookFile, body)
+			}
+		})
+	}
+}
+
+func newHookedHarness(t *testing.T, name string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := fmt.Sprintf(`{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": %q,
+  "version": "0.1.0",
+  "hooks": {
+    "before_tool": [{"command": "echo hooked"}]
+  }
+}
+`, name)
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}

--- a/test/e2e/image_test.go
+++ b/test/e2e/image_test.go
@@ -1,0 +1,46 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestImage_DryRun asserts `ynh image <name> --dry-run` renders a Dockerfile
+// to stdout containing the harness's identity (FROM, COPY, ENV, LABEL lines
+// referencing the harness name). Pure file-generation — no docker build,
+// so the test runs without docker installed.
+func TestImage_DryRun(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "imaged")
+	s.mustRunYnh(t, "install", harness)
+
+	out, _ := s.mustRunYnh(t, "image", "imaged", "--dry-run")
+
+	for _, want := range []string{
+		"FROM ghcr.io/eyelock/ynh:latest",
+		"COPY --link --chown=ynh:ynh vendors/claude/",
+		"COPY --link --chown=ynh:ynh vendors/codex/",
+		"COPY --link --chown=ynh:ynh vendors/cursor/",
+		"ENV YNH_VENDOR=claude",
+		`dev.ynh.harness="imaged"`,
+		`ENTRYPOINT ["tini", "-s", "--", "ynh", "run", "imaged"]`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Dockerfile missing line %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestImage_DryRun_CustomBase asserts --base overrides the FROM line.
+func TestImage_DryRun_CustomBase(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "imaged-custom")
+	s.mustRunYnh(t, "install", harness)
+
+	out, _ := s.mustRunYnh(t, "image", "imaged-custom", "--base", "myorg/ynh:dev", "--dry-run")
+	if !strings.Contains(out, "FROM myorg/ynh:dev") {
+		t.Errorf("Dockerfile should honour --base, got:\n%s", out)
+	}
+}

--- a/test/e2e/install_extras_test.go
+++ b/test/e2e/install_extras_test.go
@@ -1,0 +1,94 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestInstall_MigratesLegacyHarnessJson covers the migration path: a source
+// directory containing only the legacy `.harness.json` (pre-1.0 layout) must
+// be transparently migrated to `.ynh-plugin/plugin.json` during install.
+//
+// Lifts coverage of internal/migration which is otherwise only exercised
+// by unit tests.
+func TestInstall_MigratesLegacyHarnessJson(t *testing.T) {
+	s := newSandbox(t)
+
+	srcDir := filepath.Join(t.TempDir(), "legacy")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := `{"$schema":"https://eyelock.github.io/ynh/schema/harness.schema.json","name":"legacy","version":"0.1.0"}`
+	if err := os.WriteFile(filepath.Join(srcDir, ".harness.json"), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s.mustRunYnh(t, "install", srcDir)
+
+	// In the install dir, the legacy file must be gone and the new layout present.
+	installDir := filepath.Join(s.home, "harnesses", "legacy")
+	if _, err := os.Stat(filepath.Join(installDir, ".harness.json")); !os.IsNotExist(err) {
+		t.Errorf("legacy .harness.json should have been removed in install dir, err=%v", err)
+	}
+	assertFileExists(t, filepath.Join(installDir, ".ynh-plugin", "plugin.json"))
+
+	// And ynh ls should see it under its declared name.
+	out, _ := s.mustRunYnh(t, "ls", "--format", "json")
+	var got envelopeLs
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing ls JSON: %v\n%s", err, out)
+	}
+	if len(got.Harnesses) != 1 || got.Harnesses[0].Name != "legacy" {
+		t.Fatalf("expected one harness named 'legacy', got %+v", got.Harnesses)
+	}
+}
+
+// TestInstall_ReinstallReplaces verifies that re-installing a local harness
+// of the same name overwrites in place — no duplicates appear in `ynh ls`,
+// and the install dir reflects the second source's content.
+//
+// Behavioural backstop for the alreadyInstalled / RemoveAll branch in the
+// install flow.
+func TestInstall_ReinstallReplaces(t *testing.T) {
+	s := newSandbox(t)
+
+	// First install — minimal harness.
+	srcA := filepath.Join(t.TempDir(), "first")
+	if err := os.MkdirAll(filepath.Join(srcA, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pluginA := `{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"twin","version":"0.1.0","description":"first"}`
+	if err := os.WriteFile(filepath.Join(srcA, ".ynh-plugin", "plugin.json"), []byte(pluginA), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.mustRunYnh(t, "install", srcA)
+
+	// Second install — same name, different description, different source dir.
+	srcB := filepath.Join(t.TempDir(), "second")
+	if err := os.MkdirAll(filepath.Join(srcB, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pluginB := `{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"twin","version":"0.2.0","description":"second"}`
+	if err := os.WriteFile(filepath.Join(srcB, ".ynh-plugin", "plugin.json"), []byte(pluginB), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.mustRunYnh(t, "install", srcB)
+
+	// ls must show exactly one entry — the second one.
+	out, _ := s.mustRunYnh(t, "ls", "--format", "json")
+	var got envelopeLs
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing ls JSON: %v\n%s", err, out)
+	}
+	if len(got.Harnesses) != 1 {
+		t.Fatalf("expected 1 harness after reinstall, got %d: %+v", len(got.Harnesses), got.Harnesses)
+	}
+	h := got.Harnesses[0]
+	assertEqual(t, "name", h.Name, "twin")
+	assertEqual(t, "version_installed", h.VersionInstalled, "0.2.0")
+	assertEqual(t, "description", h.Description, "second")
+}

--- a/test/e2e/install_extras_test.go
+++ b/test/e2e/install_extras_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -44,6 +45,63 @@ func TestInstall_MigratesLegacyHarnessJson(t *testing.T) {
 	}
 	if len(got.Harnesses) != 1 || got.Harnesses[0].Name != "legacy" {
 		t.Fatalf("expected one harness named 'legacy', got %+v", got.Harnesses)
+	}
+}
+
+// TestInstall_BareAgentsMd asserts that a directory containing only an
+// AGENTS.md file (no manifest) is installable — install synthesizes a
+// minimal plugin.json named after the directory. Locks the documented
+// "drop AGENTS.md in any folder and ynh install ./" entry point.
+func TestInstall_BareAgentsMd(t *testing.T) {
+	s := newSandbox(t)
+
+	srcDir := filepath.Join(t.TempDir(), "bare-agents")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "AGENTS.md"),
+		[]byte("# Bare\n\nInstructions.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s.mustRunYnh(t, "install", srcDir)
+
+	installDir := filepath.Join(s.home, "harnesses", "bare-agents")
+	assertFileExists(t, filepath.Join(installDir, ".ynh-plugin", "plugin.json"))
+	assertFileExists(t, filepath.Join(installDir, "AGENTS.md"))
+
+	out, _ := s.mustRunYnh(t, "ls", "--format", "json")
+	var got envelopeLs
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing ls JSON: %v\n%s", err, out)
+	}
+	if len(got.Harnesses) != 1 || got.Harnesses[0].Name != "bare-agents" {
+		t.Fatalf("expected one harness named 'bare-agents', got %+v", got.Harnesses)
+	}
+}
+
+// TestInstall_RejectsNonHarnessDir asserts that installing a directory
+// with no manifest, no AGENTS.md, and no instructions.md fails with a
+// clear error message rather than producing a malformed install.
+func TestInstall_RejectsNonHarnessDir(t *testing.T) {
+	s := newSandbox(t)
+
+	srcDir := filepath.Join(t.TempDir(), "not-a-harness")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Drop in a random file unrelated to the harness format.
+	if err := os.WriteFile(filepath.Join(srcDir, "README.md"),
+		[]byte("# Not a harness\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, errOut, err := s.runYnh(t, "install", srcDir)
+	if err == nil {
+		t.Fatalf("expected install of non-harness dir to fail, got success")
+	}
+	if !strings.Contains(errOut, "manifest") && !strings.Contains(errOut, "AGENTS.md") {
+		t.Errorf("expected error to mention manifest or AGENTS.md, got: %s", errOut)
 	}
 }
 

--- a/test/e2e/install_safety_test.go
+++ b/test/e2e/install_safety_test.go
@@ -1,0 +1,112 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRun_RejectsLocalPathTraversal verifies the security guard documented
+// in pathutil.CheckSubpath: a relative `local:` path containing `..` must
+// be rejected when the include is resolved (during `ynh run`). Without
+// this, a malicious harness manifest could escape its directory.
+//
+// Note: install accepts the manifest (it only validates structure, not
+// resolution). The check fires when the include is actually resolved.
+func TestRun_RejectsLocalPathTraversal(t *testing.T) {
+	s := newSandbox(t)
+
+	harness := filepath.Join(t.TempDir(), "evil")
+	if err := os.MkdirAll(filepath.Join(harness, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "evil",
+  "version": "0.1.0",
+  "includes": [{"local": "../../../etc"}]
+}
+`
+	if err := os.WriteFile(filepath.Join(harness, ".ynh-plugin", "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.mustRunYnh(t, "install", harness)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, errOut, err := runYnhInDirRaw(t, s, project, "run", "evil", "-v", "cursor", "--install")
+	if err == nil {
+		t.Fatalf("expected run with .. in local include to fail, got success")
+	}
+	if !strings.Contains(errOut, "traverse") && !strings.Contains(errOut, "..") {
+		t.Errorf("expected error to mention traversal, got: %s", errOut)
+	}
+}
+
+// TestInstall_TransitiveAgentsMd verifies the documented "later sources
+// override earlier" rule for AGENTS.md / instructions.md: when both an
+// include and the harness itself carry instructions, the harness wins.
+//
+// This is critical correctness — silently swapping the order would mean
+// users' own AGENTS.md gets clobbered by an include's.
+func TestInstall_TransitiveAgentsMd(t *testing.T) {
+	s := newSandbox(t)
+
+	// Include source carries its own AGENTS.md (and a skill so the include is non-empty).
+	include := filepath.Join(t.TempDir(), "include-source")
+	if err := os.MkdirAll(filepath.Join(include, "skills", "from-include"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(include, "skills", "from-include", "SKILL.md"),
+		[]byte("---\nname: from-include\ndescription: stub.\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(include, "AGENTS.md"),
+		[]byte("INCLUDE_INSTRUCTIONS\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Harness has its own AGENTS.md plus the include.
+	harness := filepath.Join(t.TempDir(), "transitive")
+	if err := os.MkdirAll(filepath.Join(harness, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := fmt.Sprintf(`{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "transitive",
+  "version": "0.1.0",
+  "includes": [{"local": %q}]
+}
+`, include)
+	if err := os.WriteFile(filepath.Join(harness, ".ynh-plugin", "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(harness, "AGENTS.md"),
+		[]byte("HARNESS_INSTRUCTIONS\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s.mustRunYnh(t, "install", harness)
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunYnhInDir(t, s, project, "run", "transitive", "-v", "cursor", "--install")
+
+	body, err := os.ReadFile(filepath.Join(s.home, "run", "transitive", ".cursorrules"))
+	if err != nil {
+		t.Fatalf("reading .cursorrules: %v", err)
+	}
+	if !strings.Contains(string(body), "HARNESS_INSTRUCTIONS") {
+		t.Errorf(".cursorrules should contain harness's own instructions, got:\n%s", body)
+	}
+	if strings.Contains(string(body), "INCLUDE_INSTRUCTIONS") {
+		t.Errorf(".cursorrules contains include's instructions — harness should override:\n%s", body)
+	}
+}

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 )
@@ -15,6 +16,26 @@ import (
 // fields the suite asserts on. Kept as a local type so the test does
 // not import internal/* (treats the binary as a black box).
 type installedJSONShape struct {
+	SourceType   string                `json:"source_type"`
+	Source       string                `json:"source"`
+	Ref          string                `json:"ref,omitempty"`
+	SHA          string                `json:"sha,omitempty"`
+	Path         string                `json:"path,omitempty"`
+	Namespace    string                `json:"namespace,omitempty"`
+	RegistryName string                `json:"registry_name,omitempty"`
+	InstalledAt  string                `json:"installed_at"`
+	ForkedFrom   *forkedFromShape      `json:"forked_from,omitempty"`
+	Resolved     []resolvedSourceShape `json:"resolved,omitempty"`
+}
+
+type resolvedSourceShape struct {
+	Git  string `json:"git"`
+	Ref  string `json:"ref,omitempty"`
+	Path string `json:"path,omitempty"`
+	SHA  string `json:"sha"`
+}
+
+type forkedFromShape struct {
 	SourceType   string `json:"source_type"`
 	Source       string `json:"source"`
 	Ref          string `json:"ref,omitempty"`
@@ -22,22 +43,15 @@ type installedJSONShape struct {
 	Path         string `json:"path,omitempty"`
 	Namespace    string `json:"namespace,omitempty"`
 	RegistryName string `json:"registry_name,omitempty"`
-	InstalledAt  string `json:"installed_at"`
+	Version      string `json:"version,omitempty"`
 }
+
+var sha40 = regexp.MustCompile(`^[0-9a-f]{40}$`)
 
 // TestInstall_Local_Minimal proves the end-to-end loop: a minimal
 // harness on the local filesystem installs cleanly, lays down the
 // expected directory structure, and records a well-formed installed.json
 // with source_type=local.
-//
-// Reproducibility: the test clones eyelock/assistants into a tempdir,
-// checks out AssistantsFixturesSHA, and installs from the resulting
-// local path. The fixture content is therefore frozen to the pinned SHA
-// regardless of what HEAD of develop looks like at test time.
-//
-// Coverage of git/registry source types lands in Phase 2. Git-source
-// reproducibility requires either a `--ref` flag on `ynh install` or
-// structural-only assertions against live github.com — see Phase 2 plan.
 func TestInstall_Local_Minimal(t *testing.T) {
 	s := newSandbox(t)
 	clone := cloneAssistantsAtSHA(t)
@@ -67,6 +81,118 @@ func TestInstall_Local_Minimal(t *testing.T) {
 	assertEqual(t, "path", got.Path, "")
 	assertEqual(t, "namespace", got.Namespace, "")
 	assertEqual(t, "registry_name", got.RegistryName, "")
+	if len(got.Resolved) != 0 {
+		t.Errorf("expected no resolved entries, got %d", len(got.Resolved))
+	}
+}
+
+// TestInstall_Git_Minimal exercises the git install path with --ref
+// pinning to AssistantsFixturesSHA. Asserts source_type=git, the
+// recorded SHA matches the pin, and --path is preserved.
+func TestInstall_Git_Minimal(t *testing.T) {
+	s := newSandbox(t)
+	out, _ := s.mustRunYnh(t,
+		"install", "https://github.com/eyelock/assistants",
+		"--path", "e2e-fixtures/minimal",
+		"--ref", AssistantsFixturesSHA,
+	)
+	if !strings.Contains(out, `Installed harness "minimal"`) {
+		t.Errorf("install stdout missing success line:\n%s", out)
+	}
+
+	harnessDir := filepath.Join(s.home, "harnesses", "minimal")
+	got := readInstalledJSON(t, harnessDir)
+
+	assertEqual(t, "source_type", got.SourceType, "git")
+	assertEqual(t, "source", got.Source, "https://github.com/eyelock/assistants")
+	assertEqual(t, "path", got.Path, "e2e-fixtures/minimal")
+	assertEqual(t, "ref", got.Ref, AssistantsFixturesSHA)
+	assertEqual(t, "sha", got.SHA, AssistantsFixturesSHA)
+	if !sha40.MatchString(got.SHA) {
+		t.Errorf("sha %q is not 40-char hex", got.SHA)
+	}
+}
+
+// TestInstall_FloatingInclude verifies that an include with no ref pin
+// resolves to a concrete SHA at install time and gets recorded in
+// installed.json.resolved[].
+func TestInstall_FloatingInclude(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	fixturePath := filepath.Join(clone, "e2e-fixtures", "with-floating-include")
+
+	s.mustRunYnh(t, "install", fixturePath)
+	got := readInstalledJSON(t, filepath.Join(s.home, "harnesses", "with-floating-include"))
+
+	if len(got.Resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry, got %d: %+v", len(got.Resolved), got.Resolved)
+	}
+	r := got.Resolved[0]
+	assertEqual(t, "resolved[0].git", r.Git, "github.com/eyelock/assistants")
+	assertEqual(t, "resolved[0].ref", r.Ref, "")
+	assertEqual(t, "resolved[0].path", r.Path, "e2e-fixtures/included-skill")
+	if !sha40.MatchString(r.SHA) {
+		t.Errorf("resolved[0].sha %q is not 40-char hex", r.SHA)
+	}
+}
+
+// TestInstall_PinnedInclude verifies that a SHA-pinned include records
+// exactly the pinned commit in installed.json.resolved[].
+func TestInstall_PinnedInclude(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	fixturePath := filepath.Join(clone, "e2e-fixtures", "with-pinned-include")
+
+	s.mustRunYnh(t, "install", fixturePath)
+	got := readInstalledJSON(t, filepath.Join(s.home, "harnesses", "with-pinned-include"))
+
+	if len(got.Resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry, got %d", len(got.Resolved))
+	}
+	const pinnedSHA = "8713efacdee8a2b05bdb70fee83be73b66222cc4"
+	r := got.Resolved[0]
+	assertEqual(t, "resolved[0].ref", r.Ref, pinnedSHA)
+	assertEqual(t, "resolved[0].sha", r.SHA, pinnedSHA)
+}
+
+// TestInstall_TagInclude verifies that a tag-pinned include resolves
+// the tag to a concrete commit SHA at install time.
+func TestInstall_TagInclude(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	fixturePath := filepath.Join(clone, "e2e-fixtures", "with-tag-include")
+
+	s.mustRunYnh(t, "install", fixturePath)
+	got := readInstalledJSON(t, filepath.Join(s.home, "harnesses", "with-tag-include"))
+
+	if len(got.Resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry, got %d", len(got.Resolved))
+	}
+	r := got.Resolved[0]
+	assertEqual(t, "resolved[0].ref", r.Ref, AssistantsFixturesV1Tag)
+	if !sha40.MatchString(r.SHA) {
+		t.Errorf("resolved[0].sha %q is not 40-char hex (tag did not resolve)", r.SHA)
+	}
+	// The tag points at the initial-fixture commit (8713efa…). Verify exact match
+	// to catch regressions in tag resolution.
+	const tagCommitSHA = "8713efacdee8a2b05bdb70fee83be73b66222cc4"
+	assertEqual(t, "resolved[0].sha", r.SHA, tagCommitSHA)
+}
+
+// TestInstall_InvalidSchema_Rejected verifies that ynh refuses a harness
+// with an unknown top-level field (DisallowUnknownFields enforcement).
+func TestInstall_InvalidSchema_Rejected(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	fixturePath := filepath.Join(clone, "e2e-fixtures", "invalid-schema")
+
+	_, stderr, err := s.runYnh(t, "install", fixturePath)
+	if err == nil {
+		t.Fatal("expected install to fail for invalid-schema fixture")
+	}
+	if !strings.Contains(stderr, "this_field_does_not_exist") && !strings.Contains(stderr, "unknown field") {
+		t.Errorf("expected stderr to mention the rejected field; got:\n%s", stderr)
+	}
 }
 
 func readInstalledJSON(t *testing.T, harnessDir string) installedJSONShape {

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -1,0 +1,84 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+)
+
+// installedJSONShape mirrors internal/plugin.InstalledJSON for the
+// fields the suite asserts on. Kept as a local type so the test does
+// not import internal/* (treats the binary as a black box).
+type installedJSONShape struct {
+	SourceType   string `json:"source_type"`
+	Source       string `json:"source"`
+	Ref          string `json:"ref,omitempty"`
+	SHA          string `json:"sha,omitempty"`
+	Path         string `json:"path,omitempty"`
+	Namespace    string `json:"namespace,omitempty"`
+	RegistryName string `json:"registry_name,omitempty"`
+	InstalledAt  string `json:"installed_at"`
+}
+
+// TestInstall_Local_Minimal proves the end-to-end loop: a minimal
+// harness on the local filesystem installs cleanly, lays down the
+// expected directory structure, and records a well-formed installed.json
+// with source_type=local.
+//
+// Reproducibility: the test clones eyelock/assistants into a tempdir,
+// checks out AssistantsFixturesSHA, and installs from the resulting
+// local path. The fixture content is therefore frozen to the pinned SHA
+// regardless of what HEAD of develop looks like at test time.
+//
+// Coverage of git/registry source types lands in Phase 2. Git-source
+// reproducibility requires either a `--ref` flag on `ynh install` or
+// structural-only assertions against live github.com — see Phase 2 plan.
+func TestInstall_Local_Minimal(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	fixturePath := filepath.Join(clone, "e2e-fixtures", "minimal")
+
+	out, _ := s.mustRunYnh(t, "install", fixturePath)
+	if !regexp.MustCompile(`Installed harness "minimal"`).MatchString(out) {
+		t.Errorf("install stdout missing success line:\n%s", out)
+	}
+
+	harnessDir := filepath.Join(s.home, "harnesses", "minimal")
+	assertDirExists(t, harnessDir)
+	assertDirExists(t, filepath.Join(harnessDir, ".ynh-plugin"))
+	assertFileExists(t, filepath.Join(harnessDir, ".ynh-plugin", "plugin.json"))
+	assertFileExists(t, filepath.Join(harnessDir, ".ynh-plugin", "installed.json"))
+	assertFileExists(t, filepath.Join(s.home, "bin", "minimal"))
+
+	got := readInstalledJSON(t, harnessDir)
+
+	assertEqual(t, "source_type", got.SourceType, "local")
+	assertEqual(t, "source", got.Source, fixturePath)
+	if _, err := time.Parse(time.RFC3339, got.InstalledAt); err != nil {
+		t.Errorf("installed_at %q is not RFC3339: %v", got.InstalledAt, err)
+	}
+	assertEqual(t, "ref", got.Ref, "")
+	assertEqual(t, "sha", got.SHA, "")
+	assertEqual(t, "path", got.Path, "")
+	assertEqual(t, "namespace", got.Namespace, "")
+	assertEqual(t, "registry_name", got.RegistryName, "")
+}
+
+func readInstalledJSON(t *testing.T, harnessDir string) installedJSONShape {
+	t.Helper()
+	path := filepath.Join(harnessDir, ".ynh-plugin", "installed.json")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading installed.json: %v", err)
+	}
+	var got installedJSONShape
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("parsing installed.json: %v\n%s", err, body)
+	}
+	return got
+}

--- a/test/e2e/install_test.go
+++ b/test/e2e/install_test.go
@@ -181,12 +181,23 @@ func TestInstall_TagInclude(t *testing.T) {
 
 // TestInstall_InvalidSchema_Rejected verifies that ynh refuses a harness
 // with an unknown top-level field (DisallowUnknownFields enforcement).
+//
+// Synthesised in-test rather than checked into eyelock/assistants so the
+// assistants repo's own `ynd validate` CI doesn't trip on a deliberately
+// invalid file.
 func TestInstall_InvalidSchema_Rejected(t *testing.T) {
 	s := newSandbox(t)
-	clone := cloneAssistantsAtSHA(t)
-	fixturePath := filepath.Join(clone, "e2e-fixtures", "invalid-schema")
 
-	_, stderr, err := s.runYnh(t, "install", fixturePath)
+	dir := filepath.Join(t.TempDir(), "invalid-schema")
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"invalid","version":"0.1.0","this_field_does_not_exist":true}`
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stderr, err := s.runYnh(t, "install", dir)
 	if err == nil {
 		t.Fatal("expected install to fail for invalid-schema fixture")
 	}

--- a/test/e2e/install_validation_test.go
+++ b/test/e2e/install_validation_test.go
@@ -1,0 +1,85 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInstall_RefRejectedWithLocalPath verifies the documented constraint
+// that --ref only applies to git-source installs. A local-path install
+// with --ref must error clearly rather than silently ignoring the ref.
+func TestInstall_RefRejectedWithLocalPath(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "ref-local")
+
+	_, errOut, err := s.runYnh(t, "install", harness, "--ref", "v1.0.0")
+	if err == nil {
+		t.Fatalf("expected --ref + local path to fail, got success")
+	}
+	if !strings.Contains(errOut, "--ref") || !strings.Contains(errOut, "local") {
+		t.Errorf("expected error to mention '--ref' and 'local', got: %s", errOut)
+	}
+}
+
+// TestInstall_PickFiltersFiles asserts that includes[].pick selects a
+// subset of artifacts from the source. Files outside the pick list must
+// not appear in the assembled run directory.
+//
+// Uses a local-path include (no git needed) — exercises the same
+// resolver+assembler pick path as git-source includes.
+func TestInstall_PickFiltersFiles(t *testing.T) {
+	s := newSandbox(t)
+
+	// Build an "upstream" directory containing two skills.
+	upstream := filepath.Join(t.TempDir(), "upstream")
+	for _, name := range []string{"keep", "drop"} {
+		dir := filepath.Join(upstream, "skills", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := fmt.Sprintf("---\nname: %s\ndescription: marker for %s skill.\n---\n", name, name)
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Harness picks only skills/keep.
+	harness := filepath.Join(t.TempDir(), "picky")
+	if err := os.MkdirAll(filepath.Join(harness, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := fmt.Sprintf(`{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "picky",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "includes": [{"local": %q, "pick": ["skills/keep"]}]
+}
+`, upstream)
+	if err := os.WriteFile(filepath.Join(harness, ".ynh-plugin", "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.mustRunYnh(t, "install", harness)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunYnhInDir(t, s, project, "run", "picky", "-v", "claude", "--install")
+
+	runDir := filepath.Join(s.home, "run", "picky")
+	keep := filepath.Join(runDir, ".claude", "skills", "keep", "SKILL.md")
+	drop := filepath.Join(runDir, ".claude", "skills", "drop", "SKILL.md")
+
+	if _, err := os.Stat(keep); err != nil {
+		t.Errorf("expected skills/keep to be assembled, got err=%v", err)
+	}
+	if _, err := os.Stat(drop); err == nil {
+		t.Errorf("skills/drop should have been filtered out by pick")
+	}
+}

--- a/test/e2e/json_envelope_test.go
+++ b/test/e2e/json_envelope_test.go
@@ -1,0 +1,115 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// envelopeLs is a subset of the `ynh ls --format json` shape.
+type envelopeLs struct {
+	Capabilities string         `json:"capabilities"`
+	YnhVersion   string         `json:"ynh_version"`
+	Harnesses    []envelopeItem `json:"harnesses"`
+}
+
+type envelopeItem struct {
+	Name             string             `json:"name"`
+	VersionInstalled string             `json:"version_installed"`
+	Description      string             `json:"description,omitempty"`
+	DefaultVendor    string             `json:"default_vendor,omitempty"`
+	Path             string             `json:"path"`
+	IsPinned         bool               `json:"is_pinned"`
+	InstalledFrom    installedJSONShape `json:"installed_from"`
+	Includes         []any              `json:"includes"`
+	DelegatesTo      []any              `json:"delegates_to"`
+}
+
+type envelopeInfo struct {
+	Capabilities string `json:"capabilities"`
+	YnhVersion   string `json:"ynh_version"`
+	Harness      struct {
+		envelopeItem
+		Manifest map[string]any `json:"manifest"`
+	} `json:"harness"`
+}
+
+func TestLs_JSON_Shape(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	s.mustRunYnh(t, "install", filepath.Join(clone, "e2e-fixtures", "minimal"))
+
+	out, _ := s.mustRunYnh(t, "ls", "--format", "json")
+
+	var got envelopeLs
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing ls JSON: %v\n%s", err, out)
+	}
+	if got.Capabilities == "" {
+		t.Error("capabilities field empty")
+	}
+	if got.YnhVersion == "" {
+		t.Error("ynh_version field empty")
+	}
+	if len(got.Harnesses) != 1 {
+		t.Fatalf("expected 1 harness, got %d", len(got.Harnesses))
+	}
+	h := got.Harnesses[0]
+	assertEqual(t, "harnesses[0].name", h.Name, "minimal")
+	assertEqual(t, "harnesses[0].version_installed", h.VersionInstalled, "0.1.0")
+	assertEqual(t, "harnesses[0].default_vendor", h.DefaultVendor, "claude")
+	assertEqual(t, "harnesses[0].installed_from.source_type", h.InstalledFrom.SourceType, "local")
+}
+
+func TestInfo_JSON_Shape(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	s.mustRunYnh(t, "install", filepath.Join(clone, "e2e-fixtures", "minimal"))
+
+	out, _ := s.mustRunYnh(t, "info", "minimal", "--format", "json")
+
+	var got envelopeInfo
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing info JSON: %v\n%s", err, out)
+	}
+	if got.Capabilities == "" {
+		t.Error("capabilities field empty")
+	}
+	assertEqual(t, "harness.name", got.Harness.Name, "minimal")
+	if got.Harness.Manifest == nil {
+		t.Fatal("expected manifest to be populated")
+	}
+	// Manifest is a verbatim echo of plugin.json — assert a few fields.
+	if name, _ := got.Harness.Manifest["name"].(string); name != "minimal" {
+		t.Errorf("manifest.name = %v, want minimal", got.Harness.Manifest["name"])
+	}
+	if got.Harness.Manifest["default_vendor"] != "claude" {
+		t.Errorf("manifest.default_vendor = %v, want claude", got.Harness.Manifest["default_vendor"])
+	}
+}
+
+func TestVendors_JSON_Shape(t *testing.T) {
+	s := newSandbox(t)
+	out, _ := s.mustRunYnh(t, "vendors", "--format", "json")
+
+	var vendors []struct {
+		Name      string `json:"name"`
+		ConfigDir string `json:"config_dir"`
+	}
+	if err := json.Unmarshal([]byte(out), &vendors); err != nil {
+		t.Fatalf("parsing vendors JSON: %v\n%s", err, out)
+	}
+	want := map[string]bool{"claude": false, "codex": false, "cursor": false}
+	for _, v := range vendors {
+		if _, ok := want[v.Name]; ok {
+			want[v.Name] = true
+		}
+	}
+	for name, present := range want {
+		if !present {
+			t.Errorf("vendors output missing %q", name)
+		}
+	}
+}

--- a/test/e2e/ls_text_test.go
+++ b/test/e2e/ls_text_test.go
@@ -1,0 +1,27 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLs_TextOutput asserts the human-readable form of `ynh ls`. JSON shape
+// is covered elsewhere; the table form is what shell users see and is part
+// of the documented UX. Locks column headers + the harness row presence.
+func TestLs_TextOutput(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "list-me")
+	s.mustRunYnh(t, "install", harness)
+
+	out, _ := s.mustRunYnh(t, "ls")
+
+	// Header columns documented in cmd/ynh/list.go: NAME / VENDOR / SOURCE /
+	// ARTIFACTS / INCLUDES / DELEGATES TO. Plus the harness row.
+	for _, want := range []string{"NAME", "VENDOR", "SOURCE", "ARTIFACTS", "list-me"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ls text output missing %q\n%s", want, out)
+		}
+	}
+}

--- a/test/e2e/mcp_env_hooks_matcher_test.go
+++ b/test/e2e/mcp_env_hooks_matcher_test.go
@@ -1,0 +1,98 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMcp_EnvPassthrough asserts that env vars declared on an MCP server
+// reach the rendered vendor MCP file. Tooling depends on this — losing
+// env passthrough silently means MCP servers run with the wrong config.
+func TestMcp_EnvPassthrough(t *testing.T) {
+	s := newSandbox(t)
+	name := "mcp-env"
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := fmt.Sprintf(`{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": %q,
+  "version": "0.1.0",
+  "mcp_servers": {
+    "withenv": {
+      "command": "echo",
+      "env": {"API_KEY_NAME": "TEST_TOKEN_VALUE"}
+    }
+  }
+}
+`, name)
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.mustRunYnh(t, "install", dir)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunYnhInDir(t, s, project, "run", name, "-v", "claude", "--install")
+
+	mcp, err := os.ReadFile(filepath.Join(s.home, "run", name, ".claude", ".mcp.json"))
+	if err != nil {
+		t.Fatalf("reading MCP file: %v", err)
+	}
+	for _, want := range []string{"API_KEY_NAME", "TEST_TOKEN_VALUE"} {
+		if !bytes.Contains(mcp, []byte(want)) {
+			t.Errorf("MCP env var %q missing from rendered file:\n%s", want, mcp)
+		}
+	}
+}
+
+// TestHooks_Matcher asserts that the optional `matcher` field on a hook
+// entry is preserved in the rendered vendor hook file. matcher narrows
+// which tool calls a hook applies to (Claude's "PreToolUse: Bash" etc.) —
+// dropping it silently would mean hooks fire too broadly.
+func TestHooks_Matcher(t *testing.T) {
+	s := newSandbox(t)
+	name := "hooks-matcher"
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := fmt.Sprintf(`{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": %q,
+  "version": "0.1.0",
+  "hooks": {
+    "before_tool": [{"matcher": "Bash", "command": "echo with-matcher"}]
+  }
+}
+`, name)
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.mustRunYnh(t, "install", dir)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunYnhInDir(t, s, project, "run", name, "-v", "claude", "--install")
+
+	hooks, err := os.ReadFile(filepath.Join(s.home, "run", name, ".claude", "hooks", "hooks.json"))
+	if err != nil {
+		t.Fatalf("reading hooks file: %v", err)
+	}
+	if !bytes.Contains(hooks, []byte("Bash")) {
+		t.Errorf("matcher field 'Bash' missing from rendered hooks:\n%s", hooks)
+	}
+	if !bytes.Contains(hooks, []byte("with-matcher")) {
+		t.Errorf("hook command missing from rendered hooks:\n%s", hooks)
+	}
+}

--- a/test/e2e/mcp_test.go
+++ b/test/e2e/mcp_test.go
@@ -1,0 +1,82 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMcp_PerVendor verifies that mcp_servers declared in plugin.json get
+// translated into each vendor's native MCP config file:
+//
+//   - Claude: .claude/.mcp.json
+//   - Codex:  .mcp.json (plugin root)
+//   - Cursor: .cursor/mcp.json
+//
+// Locks the per-vendor file path. Silently breaking it means MCP servers
+// stop being discovered by the vendor CLI.
+func TestMcp_PerVendor(t *testing.T) {
+	cases := []struct {
+		vendor string
+		mcpRel string // path relative to runDir
+	}{
+		{vendor: "claude", mcpRel: filepath.Join(".claude", ".mcp.json")},
+		{vendor: "codex", mcpRel: ".mcp.json"},
+		{vendor: "cursor", mcpRel: filepath.Join(".cursor", "mcp.json")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.vendor, func(t *testing.T) {
+			s := newSandbox(t)
+			name := fmt.Sprintf("mcp-%s", tc.vendor)
+			harness := newMcpHarness(t, name)
+			s.mustRunYnh(t, "install", harness)
+
+			project := filepath.Join(t.TempDir(), "project")
+			if err := os.MkdirAll(project, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			mustRunYnhInDir(t, s, project, "run", name, "-v", tc.vendor, "--install")
+
+			runDir := filepath.Join(s.home, "run", name)
+			body, err := os.ReadFile(filepath.Join(runDir, tc.mcpRel))
+			if err != nil {
+				t.Fatalf("expected MCP file %s: %v", tc.mcpRel, err)
+			}
+			var raw map[string]any
+			if err := json.Unmarshal(body, &raw); err != nil {
+				t.Fatalf("MCP file is not valid JSON: %v\n%s", err, body)
+			}
+			// Server name "echoer" appears as a key somewhere in the rendered file.
+			if !bytes.Contains(body, []byte("echoer")) {
+				t.Errorf("MCP file missing server name 'echoer':\n%s", body)
+			}
+		})
+	}
+}
+
+func newMcpHarness(t *testing.T, name string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := fmt.Sprintf(`{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": %q,
+  "version": "0.1.0",
+  "mcp_servers": {
+    "echoer": {"command": "echo", "args": ["hello"]}
+  }
+}
+`, name)
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}

--- a/test/e2e/paths_test.go
+++ b/test/e2e/paths_test.go
@@ -1,0 +1,73 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// envelopePaths mirrors cmd/ynh.resolvedPaths for JSON-shape assertions.
+type envelopePaths struct {
+	Home      string `json:"home"`
+	Config    string `json:"config"`
+	Harnesses string `json:"harnesses"`
+	Symlinks  string `json:"symlinks"`
+	Cache     string `json:"cache"`
+	Run       string `json:"run"`
+	Bin       string `json:"bin"`
+}
+
+// TestPaths_JSON_Shape asserts `ynh paths --format json` emits all seven
+// path keys with non-empty values. Order is fixed by the struct definition
+// in cmd/ynh/paths.go.
+func TestPaths_JSON_Shape(t *testing.T) {
+	s := newSandbox(t)
+	out, _ := s.mustRunYnh(t, "paths", "--format", "json")
+
+	var got envelopePaths
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing paths JSON: %v\n%s", err, out)
+	}
+
+	for k, v := range map[string]string{
+		"home":      got.Home,
+		"config":    got.Config,
+		"harnesses": got.Harnesses,
+		"symlinks":  got.Symlinks,
+		"cache":     got.Cache,
+		"run":       got.Run,
+		"bin":       got.Bin,
+	} {
+		if v == "" {
+			t.Errorf("paths.%s is empty", k)
+		}
+	}
+}
+
+// TestPaths_HonorsYnhHome asserts the sandbox's YNH_HOME is reflected in
+// every resolved path — proves env-var override actually controls path
+// resolution end-to-end (not just for one entry).
+func TestPaths_HonorsYnhHome(t *testing.T) {
+	s := newSandbox(t)
+	out, _ := s.mustRunYnh(t, "paths", "--format", "json")
+
+	var got envelopePaths
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing paths JSON: %v\n%s", err, out)
+	}
+
+	assertEqual(t, "home", got.Home, s.home)
+	assertEqual(t, "harnesses", got.Harnesses, filepath.Join(s.home, "harnesses"))
+	assertEqual(t, "run", got.Run, filepath.Join(s.home, "run"))
+	assertEqual(t, "bin", got.Bin, filepath.Join(s.home, "bin"))
+
+	// Other paths should at least live under YNH_HOME.
+	for _, p := range []string{got.Config, got.Symlinks, got.Cache} {
+		if !strings.HasPrefix(p, s.home) {
+			t.Errorf("path %q is not under YNH_HOME (%s)", p, s.home)
+		}
+	}
+}

--- a/test/e2e/profile_focus_test.go
+++ b/test/e2e/profile_focus_test.go
@@ -1,0 +1,95 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const profileHarnessTmpl = `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": %q,
+  "version": "0.1.0",
+  "hooks": {
+    "before_tool": [{"command": "echo BASE"}]
+  },
+  "profiles": {
+    "review": {
+      "hooks": {
+        "before_tool": [{"command": "echo REVIEW"}]
+      }
+    }
+  },
+  "focus": {
+    "audit": {"profile": "review", "prompt": "audit the diff"}
+  }
+}
+`
+
+// TestRun_ProfileOverridesHooks verifies the documented profile merge rule:
+// a profile's hooks REPLACE the base hooks at the event level. Running
+// with --profile review must yield the profile's hook (REVIEW), not BASE.
+func TestRun_ProfileOverridesHooks(t *testing.T) {
+	s := newSandbox(t)
+	harness := newProfileHarness(t, "with-profile")
+	s.mustRunYnh(t, "install", harness)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunYnhInDir(t, s, project, "run", "with-profile", "-v", "cursor", "--profile", "review", "--install")
+
+	hookFile := filepath.Join(s.home, "run", "with-profile", ".cursor", "hooks.json")
+	body, err := os.ReadFile(hookFile)
+	if err != nil {
+		t.Fatalf("reading hook file: %v", err)
+	}
+	if !bytes.Contains(body, []byte("REVIEW")) {
+		t.Errorf("hook file missing profile override REVIEW:\n%s", body)
+	}
+	if bytes.Contains(body, []byte("BASE")) {
+		t.Errorf("hook file should not contain base hook BASE after profile override:\n%s", body)
+	}
+}
+
+// TestRun_FocusResolvesProfile verifies that --focus <name> resolves to
+// the named focus's profile, applying the same hook override as --profile
+// would. Locks focus → profile resolution.
+func TestRun_FocusResolvesProfile(t *testing.T) {
+	s := newSandbox(t)
+	harness := newProfileHarness(t, "with-focus")
+	s.mustRunYnh(t, "install", harness)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunYnhInDir(t, s, project, "run", "with-focus", "-v", "cursor", "--focus", "audit", "--install")
+
+	hookFile := filepath.Join(s.home, "run", "with-focus", ".cursor", "hooks.json")
+	body, err := os.ReadFile(hookFile)
+	if err != nil {
+		t.Fatalf("reading hook file: %v", err)
+	}
+	if !bytes.Contains(body, []byte("REVIEW")) {
+		t.Errorf("focus did not apply profile — hook file missing REVIEW:\n%s", body)
+	}
+}
+
+func newProfileHarness(t *testing.T, name string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := fmt.Sprintf(profileHarnessTmpl, name)
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}

--- a/test/e2e/profile_merge_test.go
+++ b/test/e2e/profile_merge_test.go
@@ -1,0 +1,162 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestProfile_HookInheritsBaseEvent verifies the documented merge rule:
+// hooks use per-event replace, so events the profile does NOT declare are
+// inherited from the base. A profile that overrides only `before_tool`
+// must leave `after_tool` carrying the base's hook command.
+func TestProfile_HookInheritsBaseEvent(t *testing.T) {
+	s := newSandbox(t)
+
+	dir := filepath.Join(t.TempDir(), "hook-inherit")
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "hook-inherit",
+  "version": "0.1.0",
+  "hooks": {
+    "before_tool": [{"command": "echo BASE_BEFORE"}],
+    "after_tool":  [{"command": "echo BASE_AFTER"}]
+  },
+  "profiles": {
+    "p": {
+      "hooks": {
+        "before_tool": [{"command": "echo PROFILE_BEFORE"}]
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.mustRunYnh(t, "install", dir)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunYnhInDir(t, s, project, "run", "hook-inherit", "-v", "cursor", "--profile", "p", "--install")
+
+	hookFile := filepath.Join(s.home, "run", "hook-inherit", ".cursor", "hooks.json")
+	got, err := os.ReadFile(hookFile)
+	if err != nil {
+		t.Fatalf("reading hook file: %v", err)
+	}
+	if !bytes.Contains(got, []byte("PROFILE_BEFORE")) {
+		t.Errorf("profile override missing — expected PROFILE_BEFORE in:\n%s", got)
+	}
+	if !bytes.Contains(got, []byte("BASE_AFTER")) {
+		t.Errorf("base event not inherited — expected BASE_AFTER in:\n%s", got)
+	}
+	if bytes.Contains(got, []byte("BASE_BEFORE")) {
+		t.Errorf("profile-overridden event leaked base hook BASE_BEFORE:\n%s", got)
+	}
+}
+
+// TestProfile_McpDeepMerge verifies the documented MCP merge rule: profile
+// servers add to / override base servers; absent servers are inherited.
+// Base has server "alpha"; profile adds "beta". Both must appear in the
+// rendered MCP file when the profile is active.
+func TestProfile_McpDeepMerge(t *testing.T) {
+	s := newSandbox(t)
+
+	dir := filepath.Join(t.TempDir(), "mcp-merge")
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "mcp-merge",
+  "version": "0.1.0",
+  "mcp_servers": {
+    "alpha": {"command": "echo", "args": ["alpha"]}
+  },
+  "profiles": {
+    "p": {
+      "mcp_servers": {
+        "beta": {"command": "echo", "args": ["beta"]}
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.mustRunYnh(t, "install", dir)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunYnhInDir(t, s, project, "run", "mcp-merge", "-v", "cursor", "--profile", "p", "--install")
+
+	mcpFile := filepath.Join(s.home, "run", "mcp-merge", ".cursor", "mcp.json")
+	got, err := os.ReadFile(mcpFile)
+	if err != nil {
+		t.Fatalf("reading MCP file: %v", err)
+	}
+	for _, want := range []string{"alpha", "beta"} {
+		if !bytes.Contains(got, []byte(want)) {
+			t.Errorf("MCP file missing server %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestMcp_HttpUrl exercises the `url:` branch of MCP server validation —
+// an HTTP-transport server (no command, just URL). Locks the alternative
+// validation branch and confirms the URL passes through to the rendered
+// vendor file.
+func TestMcp_HttpUrl(t *testing.T) {
+	s := newSandbox(t)
+	name := "mcp-http"
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := fmt.Sprintf(`{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": %q,
+  "version": "0.1.0",
+  "mcp_servers": {
+    "remote": {"url": "https://mcp.example.invalid/v1"}
+  }
+}
+`, name)
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.mustRunYnh(t, "install", dir)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunYnhInDir(t, s, project, "run", name, "-v", "claude", "--install")
+
+	mcpFile := filepath.Join(s.home, "run", name, ".claude", ".mcp.json")
+	body2, err := os.ReadFile(mcpFile)
+	if err != nil {
+		t.Fatalf("reading MCP file: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(body2, &raw); err != nil {
+		t.Fatalf("MCP file is not valid JSON: %v\n%s", err, body2)
+	}
+	if !bytes.Contains(body2, []byte("mcp.example.invalid")) {
+		t.Errorf("MCP file missing URL:\n%s", body2)
+	}
+}

--- a/test/e2e/prune_extras_test.go
+++ b/test/e2e/prune_extras_test.go
@@ -1,0 +1,59 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPrune_StaleLaunchers asserts `ynh prune` removes launcher scripts
+// in ~/.ynh/bin/ for harnesses that no longer exist. Distinct from
+// orphan-symlink sweeping (covered by TestPrune_Orphans).
+func TestPrune_StaleLaunchers(t *testing.T) {
+	s := newSandbox(t)
+
+	// Drop a fake launcher script into bin/ that points at a nonexistent harness.
+	binDir := filepath.Join(s.home, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stalePath := filepath.Join(binDir, "ghost")
+	stale := "#!/bin/sh\nexec ynh run ghost\n"
+	if err := os.WriteFile(stalePath, []byte(stale), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _ := s.mustRunYnh(t, "prune")
+	if !strings.Contains(out, "stale launcher") && !strings.Contains(out, "Removed stale launcher") {
+		t.Errorf("expected prune output to mention removed stale launcher, got:\n%s", out)
+	}
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Errorf("stale launcher should be gone after prune, err=%v", err)
+	}
+}
+
+// TestPrune_StaleRunDirs asserts `ynh prune` removes run directories under
+// ~/.ynh/run/ for harnesses that no longer exist.
+func TestPrune_StaleRunDirs(t *testing.T) {
+	s := newSandbox(t)
+
+	// Drop a fake run dir for a harness that doesn't exist.
+	runDir := filepath.Join(s.home, "run", "ghost-run")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "marker"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _ := s.mustRunYnh(t, "prune")
+	if !strings.Contains(out, "stale run dir") && !strings.Contains(out, "Removed stale run") {
+		t.Errorf("expected prune output to mention removed stale run dir, got:\n%s", out)
+	}
+	if _, err := os.Stat(runDir); !os.IsNotExist(err) {
+		t.Errorf("stale run dir should be gone after prune, err=%v", err)
+	}
+}

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -26,8 +26,8 @@ func TestPrune_Orphans(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	runYnhInDir(t, s, live, "run", "prunable", "-v", "cursor", "--install")
-	runYnhInDir(t, s, orphan, "run", "prunable", "-v", "cursor", "--install")
+	mustRunYnhInDir(t, s, live, "run", "prunable", "-v", "cursor", "--install")
+	mustRunYnhInDir(t, s, orphan, "run", "prunable", "-v", "cursor", "--install")
 
 	// Confirm both installations are recorded by status.
 	out, _ := s.mustRunYnh(t, "status")

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -1,0 +1,54 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPrune_Orphans asserts that `ynh prune` detects and removes
+// installations whose project directory no longer exists, while leaving
+// live installations alone.
+func TestPrune_Orphans(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "prunable")
+	s.mustRunYnh(t, "install", harness)
+
+	live := filepath.Join(t.TempDir(), "live")
+	orphan := filepath.Join(t.TempDir(), "orphan")
+	if err := os.MkdirAll(live, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(orphan, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runYnhInDir(t, s, live, "run", "prunable", "-v", "cursor", "--install")
+	runYnhInDir(t, s, orphan, "run", "prunable", "-v", "cursor", "--install")
+
+	// Confirm both installations are recorded by status.
+	out, _ := s.mustRunYnh(t, "status")
+	if !strings.Contains(out, live) || !strings.Contains(out, orphan) {
+		t.Fatalf("status missing one of the install paths:\n%s", out)
+	}
+
+	if err := os.RemoveAll(orphan); err != nil {
+		t.Fatal(err)
+	}
+
+	pruneOut, _ := s.mustRunYnh(t, "prune")
+	if !strings.Contains(pruneOut, orphan) {
+		t.Errorf("prune output should mention orphan project %q:\n%s", orphan, pruneOut)
+	}
+
+	out, _ = s.mustRunYnh(t, "status")
+	if strings.Contains(out, orphan) {
+		t.Errorf("post-prune status still references orphan %q:\n%s", orphan, out)
+	}
+	if !strings.Contains(out, live) {
+		t.Errorf("post-prune status no longer references live install %q:\n%s", live, out)
+	}
+}

--- a/test/e2e/registry_local_test.go
+++ b/test/e2e/registry_local_test.go
@@ -1,0 +1,156 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRegistry_FetchAndUpdate sets up a local file:// git registry with one
+// harness and verifies `ynh registry update` parses it and `ynh search`
+// surfaces the entry. This finally exercises internal/registry, which
+// was at 0% E2E coverage before.
+func TestRegistry_FetchAndUpdate(t *testing.T) {
+	s := newSandbox(t)
+	regURL := buildLocalRegistry(t, "Reg One", []registryEntry{
+		{name: "harness-a", desc: "first harness from registry"},
+	})
+
+	s.mustRunYnh(t, "registry", "add", regURL)
+	s.mustRunYnh(t, "registry", "update")
+
+	out, _ := s.mustRunYnh(t, "search", "harness-a")
+	if !strings.Contains(out, "harness-a") {
+		t.Errorf("search did not find registry entry, got:\n%s", out)
+	}
+	if !strings.Contains(out, "first harness from registry") {
+		t.Errorf("search did not surface description, got:\n%s", out)
+	}
+}
+
+// TestInstall_FromRegistryName resolves `ynh install <name>` through the
+// configured registry: clones the registry repo, navigates to the entry's
+// path, installs into a namespaced directory under ~/.ynh/harnesses/.
+//
+// Locks the runtime registry-resolution path (cmd/ynh/install_resolve.go
+// rules 4 + 6) and gives non-zero coverage to internal/namespace.
+func TestInstall_FromRegistryName(t *testing.T) {
+	s := newSandbox(t)
+	regURL := buildLocalRegistry(t, "Reg Two", []registryEntry{
+		{name: "regd", desc: "registry-installed harness"},
+	})
+	s.mustRunYnh(t, "registry", "add", regURL)
+
+	s.mustRunYnh(t, "install", "regd")
+
+	// Harness installed under a namespaced directory derived from the
+	// registry URL. Locate the install via `ynh ls --format json` rather
+	// than guessing the namespace path.
+	out, _ := s.mustRunYnh(t, "ls", "--format", "json")
+	if !strings.Contains(out, "regd") {
+		t.Fatalf("expected regd in ls output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "registry") {
+		t.Errorf("expected install to record source_type=registry, got:\n%s", out)
+	}
+}
+
+// TestRegistry_NamespaceCollision verifies that two registries publishing a
+// harness of the same name install into distinct namespaced directories,
+// so neither shadows the other. The previously-deferred namespace test —
+// finally landed.
+func TestRegistry_NamespaceCollision(t *testing.T) {
+	s := newSandbox(t)
+
+	regA := buildLocalRegistry(t, "Reg A", []registryEntry{
+		{name: "shared", desc: "from-a"},
+	})
+	regB := buildLocalRegistry(t, "Reg B", []registryEntry{
+		{name: "shared", desc: "from-b"},
+	})
+
+	s.mustRunYnh(t, "registry", "add", regA)
+	s.mustRunYnh(t, "registry", "add", regB)
+
+	// `ynh install shared` is ambiguous when two registries publish the same
+	// name. The user must qualify with `name@<namespace-or-label>`.
+	// Namespaces are URL-derived; for file:// URLs they end in the parent
+	// directory's basename. Look up via the stored URL — find each by listing
+	// the registry namespaces.
+	nsA := registryNamespace(regA)
+	nsB := registryNamespace(regB)
+
+	s.mustRunYnh(t, "install", "shared@"+nsA)
+	s.mustRunYnh(t, "install", "shared@"+nsB)
+
+	// Both installations must be visible in ls.
+	out, _ := s.mustRunYnh(t, "ls")
+	count := strings.Count(out, "shared")
+	if count < 2 {
+		t.Errorf("expected two shared harnesses (one per registry), got %d in:\n%s", count, out)
+	}
+}
+
+// registryEntry describes a harness to seed into a local registry.
+type registryEntry struct {
+	name string
+	desc string
+}
+
+// buildLocalRegistry writes a git registry with one or more harness entries
+// and returns the file:// URL pointing at it. Each entry's source is a
+// relative path inside the registry repo.
+func buildLocalRegistry(t *testing.T, regName string, entries []registryEntry) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "registry")
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var harnessJSON strings.Builder
+	for i, e := range entries {
+		hdir := filepath.Join(dir, e.name)
+		if err := os.MkdirAll(filepath.Join(hdir, ".ynh-plugin"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := fmt.Sprintf(`{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":%q,"version":"0.1.0","description":%q}`, e.name, e.desc)
+		if err := os.WriteFile(filepath.Join(hdir, ".ynh-plugin", "plugin.json"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if i > 0 {
+			harnessJSON.WriteString(",")
+		}
+		fmt.Fprintf(&harnessJSON, `{"name":%q,"source":%q,"description":%q}`, e.name, e.name, e.desc)
+	}
+
+	mp := fmt.Sprintf(`{"name":%q,"owner":{"name":"e2e","email":"e2e@example.invalid"},"harnesses":[%s]}`, regName, harnessJSON.String())
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "marketplace.json"), []byte(mp), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mustGit(t, dir, "init", "--quiet", "--initial-branch=main")
+	mustGit(t, dir, "config", "user.email", "e2e@example.invalid")
+	mustGit(t, dir, "config", "user.name", "e2e")
+	mustGit(t, dir, "config", "uploadpack.allowReachableSHA1InWant", "true")
+	mustGit(t, dir, "add", "-A")
+	mustGit(t, dir, "commit", "--quiet", "-m", "init registry")
+
+	return "file://" + dir
+}
+
+// registryNamespace returns the URL-derived namespace ynh uses for a registry —
+// for file:// URLs, the last two path segments joined with "/". Mirrors
+// namespace.DeriveFromURL behaviour for tests.
+func registryNamespace(url string) string {
+	u := strings.TrimPrefix(url, "file://")
+	u = strings.TrimSuffix(u, "/")
+	parts := strings.Split(u, "/")
+	if len(parts) >= 2 {
+		return parts[len(parts)-2] + "/" + parts[len(parts)-1]
+	}
+	return parts[len(parts)-1]
+}

--- a/test/e2e/registry_search_test.go
+++ b/test/e2e/registry_search_test.go
@@ -1,0 +1,59 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRegistry_AddListRemove walks `ynh registry add/list/remove` for a
+// fake URL — the add path doesn't actually fetch, so this exercises the
+// config plumbing without needing a real registry endpoint. Locks the
+// graceful empty-list message too.
+func TestRegistry_AddListRemove(t *testing.T) {
+	s := newSandbox(t)
+
+	out, _ := s.mustRunYnh(t, "registry", "list")
+	if !strings.Contains(out, "No registries configured") {
+		t.Errorf("expected empty-list message, got:\n%s", out)
+	}
+
+	fakeURL := "https://registry.example.invalid"
+	out, _ = s.mustRunYnh(t, "registry", "add", fakeURL)
+	if !strings.Contains(out, "Added registry") {
+		t.Errorf("expected 'Added registry', got: %s", out)
+	}
+
+	// Duplicate add must error.
+	_, errOut, err := s.runYnh(t, "registry", "add", fakeURL)
+	if err == nil {
+		t.Errorf("expected duplicate registry add to fail")
+	} else if !strings.Contains(errOut, "already") {
+		t.Errorf("expected 'already' in duplicate error, got: %s", errOut)
+	}
+
+	out, _ = s.mustRunYnh(t, "registry", "list")
+	if !strings.Contains(out, fakeURL) {
+		t.Errorf("registry list missing %q\n%s", fakeURL, out)
+	}
+
+	s.mustRunYnh(t, "registry", "remove", fakeURL)
+
+	out, _ = s.mustRunYnh(t, "registry", "list")
+	if !strings.Contains(out, "No registries") {
+		t.Errorf("expected empty-list message after remove, got:\n%s", out)
+	}
+}
+
+// TestSearch_EmptyResult asserts `ynh search <name>` with no registries
+// configured prints the documented "No harnesses found" message rather
+// than erroring or emitting an empty table.
+func TestSearch_EmptyResult(t *testing.T) {
+	s := newSandbox(t)
+
+	out, _ := s.mustRunYnh(t, "search")
+	if !strings.Contains(out, "No harnesses found") {
+		t.Errorf("expected 'No harnesses found' message, got:\n%s", out)
+	}
+}

--- a/test/e2e/run_claude_test.go
+++ b/test/e2e/run_claude_test.go
@@ -1,0 +1,52 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRun_Claude_InstallClean asserts that `ynh run -v claude --install`
+// assembles a Claude-native plugin layout under ~/.ynh/run/<harness>/ and
+// reports that no symlink installation is needed (Claude uses native plugin
+// loading via --plugin-dir, not symlinks like Cursor/Codex).
+//
+// `--clean` is likewise a no-op message — there are no symlinks to remove.
+func TestRun_Claude_InstallClean(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "with-skill-claude")
+	s.mustRunYnh(t, "install", harness)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _ := mustRunYnhInDir(t, s, project, "run", "with-skill-claude", "-v", "claude", "--install")
+	if !strings.Contains(out, "native plugin loading") {
+		t.Errorf("expected 'native plugin loading' message, got:\n%s", out)
+	}
+
+	// Assembly happened — assert the Claude-native layout exists in the run dir.
+	runDir := filepath.Join(s.home, "run", "with-skill-claude")
+	assertFileExists(t, filepath.Join(runDir, ".claude-plugin", "plugin.json"))
+	assertFileExists(t, filepath.Join(runDir, ".claude", "skills", "hello", "SKILL.md"))
+
+	// CLAUDE.md is only generated when the harness has an instructions file
+	// (AGENTS.md / instructions.md). The synthetic harness has none, so we
+	// don't assert on it here — the @AGENTS.md import is covered by unit tests.
+
+	// --clean is a no-op for native vendors but should still exit 0.
+	out, _ = mustRunYnhInDir(t, s, project, "run", "with-skill-claude", "-v", "claude", "--clean")
+	if !strings.Contains(out, "no symlinks to clean") {
+		t.Errorf("expected 'no symlinks to clean' message, got:\n%s", out)
+	}
+
+	// Project dir should NOT have a .claude/ — Claude uses --plugin-dir, not symlinks.
+	if _, err := os.Stat(filepath.Join(project, ".claude")); err == nil {
+		t.Errorf("project should not have .claude/ — Claude uses native plugin loading")
+	}
+}

--- a/test/e2e/run_codex_test.go
+++ b/test/e2e/run_codex_test.go
@@ -1,0 +1,66 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRun_Codex_InstallClean asserts that `ynh run -v codex --install`
+// from a project directory creates the expected symlink layout under
+// .codex/ (Codex uses symlinks like Cursor), and that `--clean` removes
+// the symlinks.
+func TestRun_Codex_InstallClean(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "with-skill-codex")
+	s.mustRunYnh(t, "install", harness)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mustRunYnhInDir(t, s, project, "run", "with-skill-codex", "-v", "codex", "--install")
+
+	codexSkillsDir := filepath.Join(project, ".codex", "skills")
+	assertDirExists(t, codexSkillsDir)
+	entries, err := os.ReadDir(codexSkillsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Errorf(".codex/skills/ should contain at least one entry, got 0")
+	}
+	for _, e := range entries {
+		full := filepath.Join(codexSkillsDir, e.Name())
+		info, err := os.Lstat(full)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("%s expected to be a symlink, got mode %v", full, info.Mode())
+		}
+		target, err := os.Readlink(full)
+		if err != nil {
+			t.Fatalf("readlink %s: %v", full, err)
+		}
+		if !strings.Contains(target, "with-skill-codex") || !strings.HasPrefix(target, s.home) {
+			t.Errorf("symlink %s points to %s — expected something under YNH_HOME containing 'with-skill-codex'", full, target)
+		}
+	}
+
+	mustRunYnhInDir(t, s, project, "run", "with-skill-codex", "-v", "codex", "--clean")
+
+	if _, err := os.Stat(codexSkillsDir); err == nil {
+		entries, _ := os.ReadDir(codexSkillsDir)
+		for _, e := range entries {
+			info, _ := os.Lstat(filepath.Join(codexSkillsDir, e.Name()))
+			if info != nil && info.Mode()&os.ModeSymlink != 0 {
+				t.Errorf(".codex/skills/%s still a symlink after --clean", e.Name())
+			}
+		}
+	}
+}

--- a/test/e2e/run_inline_test.go
+++ b/test/e2e/run_inline_test.go
@@ -1,0 +1,59 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRun_InlineHarness covers the documented `--harness-file <path>` mode:
+// run a harness directly from a single .harness.json file without installing
+// it into ~/.ynh/harnesses/ first. Used by CI runners and ephemeral
+// environments where installing globally is undesirable.
+func TestRun_InlineHarness(t *testing.T) {
+	s := newSandbox(t)
+
+	// Author a single-file legacy harness manifest in a project directory.
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	harnessFile := filepath.Join(project, "ephemeral.harness.json")
+	body := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/harness.schema.json",
+  "name": "ephemeral",
+  "version": "0.1.0",
+  "default_vendor": "cursor"
+}
+`
+	if err := os.WriteFile(harnessFile, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run with --install in cursor (creates symlinks but doesn't launch the CLI).
+	mustRunYnhInDir(t, s, project, "run", "--harness-file", harnessFile, "-v", "cursor", "--install")
+
+	// Inline runs use a hash-based stable run dir name prefixed with "_inline-".
+	runRoot := filepath.Join(s.home, "run")
+	entries, err := os.ReadDir(runRoot)
+	if err != nil {
+		t.Fatalf("reading run dir: %v", err)
+	}
+	var inlineDirs []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "_inline-") {
+			inlineDirs = append(inlineDirs, e.Name())
+		}
+	}
+	if len(inlineDirs) == 0 {
+		t.Fatalf("expected at least one _inline-* run dir, got entries: %v", entries)
+	}
+
+	// Inline harness should NOT have been installed under harnesses/.
+	if _, err := os.Stat(filepath.Join(s.home, "harnesses", "ephemeral")); err == nil {
+		t.Errorf("inline run should not install into harnesses/ — found ephemeral/")
+	}
+}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1,0 +1,107 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRun_Cursor_InstallClean asserts that `ynh run -v cursor --install`
+// from a project directory creates the expected symlink layout under
+// .cursor/, and that `--clean` removes it without leaving orphans.
+func TestRun_Cursor_InstallClean(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "with-skill")
+	s.mustRunYnh(t, "install", harness)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runYnhInDir(t, s, project, "run", "with-skill", "-v", "cursor", "--install")
+
+	cursorSkillsDir := filepath.Join(project, ".cursor", "skills")
+	assertDirExists(t, cursorSkillsDir)
+	entries, err := os.ReadDir(cursorSkillsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Errorf(".cursor/skills/ should contain at least one entry, got 0")
+	}
+	for _, e := range entries {
+		full := filepath.Join(cursorSkillsDir, e.Name())
+		info, err := os.Lstat(full)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("%s expected to be a symlink, got mode %v", full, info.Mode())
+		}
+		target, err := os.Readlink(full)
+		if err != nil {
+			t.Fatalf("readlink %s: %v", full, err)
+		}
+		if !strings.Contains(target, "with-skill") || !strings.HasPrefix(target, s.home) {
+			t.Errorf("symlink %s points to %s — expected something under YNH_HOME containing 'with-skill'", full, target)
+		}
+	}
+
+	runYnhInDir(t, s, project, "run", "with-skill", "-v", "cursor", "--clean")
+
+	if _, err := os.Stat(cursorSkillsDir); err == nil {
+		// The dir may legitimately remain empty after clean — only fail if it still has symlinks.
+		entries, _ := os.ReadDir(cursorSkillsDir)
+		for _, e := range entries {
+			info, _ := os.Lstat(filepath.Join(cursorSkillsDir, e.Name()))
+			if info != nil && info.Mode()&os.ModeSymlink != 0 {
+				t.Errorf(".cursor/skills/%s still a symlink after --clean", e.Name())
+			}
+		}
+	}
+}
+
+// runYnhInDir runs `ynh args...` with cwd=dir inside sandbox s.
+func runYnhInDir(t *testing.T, s *sandbox, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(ynhBinary(t), args...)
+	cmd.Env = append(os.Environ(), "YNH_HOME="+s.home)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ynh %s failed in %s: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+}
+
+// newSyntheticSkillHarness writes a harness directory with one skill,
+// suitable for symlink-layout assertions.
+func newSyntheticSkillHarness(t *testing.T, name string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "skills", "hello"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "` + name + `",
+  "version": "0.1.0",
+  "default_vendor": "claude"
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(plugin), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skill := "---\nname: hello\ndescription: A trivial skill for E2E symlink-layout tests.\n---\n\n# hello\n"
+	if err := os.WriteFile(filepath.Join(dir, "skills", "hello", "SKILL.md"), []byte(skill), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -23,7 +22,7 @@ func TestRun_Cursor_InstallClean(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	runYnhInDir(t, s, project, "run", "with-skill", "-v", "cursor", "--install")
+	mustRunYnhInDir(t, s, project, "run", "with-skill", "-v", "cursor", "--install")
 
 	cursorSkillsDir := filepath.Join(project, ".cursor", "skills")
 	assertDirExists(t, cursorSkillsDir)
@@ -52,7 +51,7 @@ func TestRun_Cursor_InstallClean(t *testing.T) {
 		}
 	}
 
-	runYnhInDir(t, s, project, "run", "with-skill", "-v", "cursor", "--clean")
+	mustRunYnhInDir(t, s, project, "run", "with-skill", "-v", "cursor", "--clean")
 
 	if _, err := os.Stat(cursorSkillsDir); err == nil {
 		// The dir may legitimately remain empty after clean — only fail if it still has symlinks.
@@ -63,18 +62,6 @@ func TestRun_Cursor_InstallClean(t *testing.T) {
 				t.Errorf(".cursor/skills/%s still a symlink after --clean", e.Name())
 			}
 		}
-	}
-}
-
-// runYnhInDir runs `ynh args...` with cwd=dir inside sandbox s.
-func runYnhInDir(t *testing.T, s *sandbox, dir string, args ...string) {
-	t.Helper()
-	cmd := exec.Command(ynhBinary(t), args...)
-	cmd.Env = append(os.Environ(), "YNH_HOME="+s.home)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("ynh %s failed in %s: %v\n%s", strings.Join(args, " "), dir, err, out)
 	}
 }
 

--- a/test/e2e/run_validation_test.go
+++ b/test/e2e/run_validation_test.go
@@ -1,0 +1,57 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRun_FocusAndProfileMutex locks the documented constraint that --focus
+// and --profile cannot be combined: focus already includes a profile, so
+// the combination is ambiguous. Error path covers cmd/ynh/main.go:594.
+func TestRun_FocusAndProfileMutex(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "mutex-test")
+	s.mustRunYnh(t, "install", harness)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, errOut, err := runYnhInDirRaw(t, s, project,
+		"run", "mutex-test", "-v", "cursor",
+		"--focus", "f", "--profile", "p", "--install")
+	if err == nil {
+		t.Fatalf("expected --focus + --profile to fail, got success")
+	}
+	if !strings.Contains(errOut, "focus") || !strings.Contains(errOut, "profile") {
+		t.Errorf("expected error to mention both 'focus' and 'profile', got: %s", errOut)
+	}
+}
+
+// TestRun_FocusUnknown_Errors verifies that --focus referencing a name
+// not declared in the harness manifest fails with a clear error. Locks
+// the resolver path at cmd/ynh/main.go:655.
+func TestRun_FocusUnknown_Errors(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "no-focus")
+	s.mustRunYnh(t, "install", harness)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, errOut, err := runYnhInDirRaw(t, s, project,
+		"run", "no-focus", "-v", "cursor", "--focus", "phantom", "--install")
+	if err == nil {
+		t.Fatalf("expected unknown --focus to fail, got success")
+	}
+	if !strings.Contains(errOut, "focus") || !strings.Contains(errOut, "phantom") {
+		t.Errorf("expected error to mention 'focus' and the bad name 'phantom', got: %s", errOut)
+	}
+}

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -1,0 +1,53 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// productionSmokeHarnesses are real harnesses on the HEAD of
+// eyelock/assistants:develop. The smoke layer asserts only that they
+// install successfully and produce a well-formed installed.json — no
+// byte-exact assertions. The point is to catch "we changed something
+// subtle that breaks real harnesses but happens to still pass against
+// the synthetic fixtures."
+var productionSmokeHarnesses = []string{
+	"ynh/ynh-dev",
+}
+
+// TestSmoke_LiveAssistants installs each production harness against the
+// current HEAD of eyelock/assistants:develop. Runs at release-promotion
+// time; if upstream is broken the gate blocks, surfacing the issue
+// before goreleaser publishes.
+func TestSmoke_LiveAssistants(t *testing.T) {
+	for _, path := range productionSmokeHarnesses {
+		t.Run(path, func(t *testing.T) {
+			s := newSandbox(t)
+			out, _ := s.mustRunYnh(t,
+				"install", "https://github.com/eyelock/assistants",
+				"--path", path,
+			)
+			name := lastSegment(path)
+			if !strings.Contains(out, `Installed harness "`+name+`"`) {
+				t.Errorf("install stdout missing success line for %q:\n%s", name, out)
+			}
+
+			got := readInstalledJSON(t, filepath.Join(s.home, "harnesses", name))
+			assertEqual(t, "source_type", got.SourceType, "git")
+			assertEqual(t, "path", got.Path, path)
+			if !sha40.MatchString(got.SHA) {
+				t.Errorf("smoke install: sha %q is not 40-char hex", got.SHA)
+			}
+		})
+	}
+}
+
+func lastSegment(p string) string {
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}

--- a/test/e2e/sources_test.go
+++ b/test/e2e/sources_test.go
@@ -71,3 +71,28 @@ func TestSources_AddListRemove(t *testing.T) {
 		t.Errorf("expected sources list to be empty after remove, got %d entries", len(after))
 	}
 }
+
+// TestSources_AddRejectsDuplicate verifies that adding a source with a name
+// that already exists fails with a clear error. The duplicate guard prevents
+// silent overrides of registered sources.
+func TestSources_AddRejectsDuplicate(t *testing.T) {
+	s := newSandbox(t)
+
+	srcA := filepath.Join(t.TempDir(), "a")
+	srcB := filepath.Join(t.TempDir(), "b")
+	for _, d := range []string{srcA, srcB} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s.mustRunYnh(t, "sources", "add", srcA, "--name", "shared")
+
+	_, errOut, err := s.runYnh(t, "sources", "add", srcB, "--name", "shared")
+	if err == nil {
+		t.Fatalf("expected duplicate-name add to fail, got success")
+	}
+	if !strings.Contains(errOut, "already exists") {
+		t.Errorf("expected error to mention 'already exists', got: %s", errOut)
+	}
+}

--- a/test/e2e/sources_test.go
+++ b/test/e2e/sources_test.go
@@ -1,0 +1,73 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type envelopeSourcesEntry struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Description string `json:"description,omitempty"`
+	Harnesses   int    `json:"harnesses"`
+}
+
+// TestSources_AddListRemove exercises the full sources lifecycle: add a
+// directory containing a discoverable harness, list (JSON) to verify
+// the entry appears with harness count, remove, list again to verify
+// the entry is gone.
+func TestSources_AddListRemove(t *testing.T) {
+	s := newSandbox(t)
+
+	// Build a directory with one discoverable harness in it.
+	srcRoot := filepath.Join(t.TempDir(), "my-sources")
+	harnessDir := filepath.Join(srcRoot, "demo")
+	if err := os.MkdirAll(filepath.Join(harnessDir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := `{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"demo","version":"0.1.0"}`
+	if err := os.WriteFile(filepath.Join(harnessDir, ".ynh-plugin", "plugin.json"), []byte(plugin), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add the source.
+	out, _ := s.mustRunYnh(t, "sources", "add", srcRoot, "--name", "mine", "--description", "test source")
+	if !strings.Contains(out, "Added source") {
+		t.Errorf("expected 'Added source' in output, got: %s", out)
+	}
+
+	// List as JSON — must contain the entry with harness count = 1.
+	out, _ = s.mustRunYnh(t, "sources", "list", "--format", "json")
+	var entries []envelopeSourcesEntry
+	if err := json.Unmarshal([]byte(out), &entries); err != nil {
+		t.Fatalf("parsing sources list JSON: %v\n%s", err, out)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 source entry, got %d: %+v", len(entries), entries)
+	}
+	e := entries[0]
+	assertEqual(t, "name", e.Name, "mine")
+	assertEqual(t, "description", e.Description, "test source")
+	assertEqual(t, "harnesses", e.Harnesses, 1)
+	if !strings.HasSuffix(e.Path, "my-sources") {
+		t.Errorf("path = %q, expected to end with my-sources", e.Path)
+	}
+
+	// Remove the source.
+	s.mustRunYnh(t, "sources", "remove", "mine")
+
+	// Re-list — must be empty now.
+	out, _ = s.mustRunYnh(t, "sources", "list", "--format", "json")
+	var after []envelopeSourcesEntry
+	if err := json.Unmarshal([]byte(out), &after); err != nil {
+		t.Fatalf("parsing post-remove sources list JSON: %v\n%s", err, out)
+	}
+	if len(after) != 0 {
+		t.Errorf("expected sources list to be empty after remove, got %d entries", len(after))
+	}
+}

--- a/test/e2e/status_test.go
+++ b/test/e2e/status_test.go
@@ -1,0 +1,41 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStatus_Text verifies `ynh status` reflects symlink installations made
+// by `ynh run -v <vendor> --install`. Status only supports text output; this
+// test pins the column header line and checks the row's harness/vendor/project
+// fields appear after a Cursor install.
+func TestStatus_Text(t *testing.T) {
+	s := newSandbox(t)
+
+	// Empty case first.
+	out, _ := s.mustRunYnh(t, "status")
+	if !strings.Contains(out, "No symlink installations") {
+		t.Errorf("empty status should report 'No symlink installations', got:\n%s", out)
+	}
+
+	// Install + run --install to register a symlink installation.
+	harness := newSyntheticSkillHarness(t, "with-skill-status")
+	s.mustRunYnh(t, "install", harness)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunYnhInDir(t, s, project, "run", "with-skill-status", "-v", "cursor", "--install")
+
+	out, _ = s.mustRunYnh(t, "status")
+	for _, want := range []string{"HARNESS", "VENDOR", "PROJECT", "with-skill-status", "cursor", project} {
+		if !strings.Contains(out, want) {
+			t.Errorf("status output missing %q\n%s", want, out)
+		}
+	}
+}

--- a/test/e2e/symlink_stable_test.go
+++ b/test/e2e/symlink_stable_test.go
@@ -1,0 +1,60 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSymlinks_StableAcrossReinstall verifies that a project's vendor
+// symlinks (created by `ynh run -v <vendor> --install`) remain functional
+// after the harness is reinstalled. Previously this would silently break
+// if reinstall changed paths under ~/.ynh/run/ — users would lose tooling
+// and not know why.
+//
+// Cursor uses symlinks (Codex too). Reinstall the source, re-run --install,
+// then walk the project's symlinks and confirm they all resolve.
+func TestSymlinks_StableAcrossReinstall(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "stable")
+	s.mustRunYnh(t, "install", harness)
+
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunYnhInDir(t, s, project, "run", "stable", "-v", "cursor", "--install")
+
+	skillsDir := filepath.Join(project, ".cursor", "skills")
+	before, err := os.ReadDir(skillsDir)
+	if err != nil {
+		t.Fatalf("reading skills dir: %v", err)
+	}
+	if len(before) == 0 {
+		t.Fatal("setup: expected at least one skill symlink after first install")
+	}
+
+	// Reinstall the same harness — installs to the same dir, recreates content.
+	s.mustRunYnh(t, "install", harness)
+
+	// Re-run to refresh assembled output (matches the documented post-reinstall workflow).
+	mustRunYnhInDir(t, s, project, "run", "stable", "-v", "cursor", "--install")
+
+	// Every project symlink must resolve to a real file under YNH_HOME.
+	after, err := os.ReadDir(skillsDir)
+	if err != nil {
+		t.Fatalf("reading skills dir after reinstall: %v", err)
+	}
+	if len(after) == 0 {
+		t.Fatal("expected skills to remain after reinstall")
+	}
+	for _, e := range after {
+		full := filepath.Join(skillsDir, e.Name())
+		// Stat (not Lstat) follows the symlink; if it fails, the link is dangling.
+		if _, err := os.Stat(full); err != nil {
+			t.Errorf("symlink %s does not resolve after reinstall: %v", full, err)
+		}
+	}
+}

--- a/test/e2e/text_outputs_test.go
+++ b/test/e2e/text_outputs_test.go
@@ -1,0 +1,110 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSources_TextOutput asserts the human-readable form of `ynh sources list`.
+// JSON is covered by TestSources_AddListRemove; this locks the table form
+// (column headers and the entry row).
+func TestSources_TextOutput(t *testing.T) {
+	s := newSandbox(t)
+
+	srcDir := filepath.Join(t.TempDir(), "my-src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s.mustRunYnh(t, "sources", "add", srcDir, "--name", "shown")
+
+	out, _ := s.mustRunYnh(t, "sources", "list")
+	for _, want := range []string{"NAME", "PATH", "shown"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("sources list text output missing %q\n%s", want, out)
+		}
+	}
+}
+
+// TestPaths_TextOutput asserts the table form of `ynh paths`. JSON is
+// already covered; this locks the row labels (home/config/harnesses/etc.)
+// scripts may scrape.
+func TestPaths_TextOutput(t *testing.T) {
+	s := newSandbox(t)
+
+	out, _ := s.mustRunYnh(t, "paths")
+	for _, want := range []string{"home", "config", "harnesses", "symlinks", "cache", "run", "bin"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("paths text output missing row %q\n%s", want, out)
+		}
+	}
+	// And the resolved values must reflect the sandbox.
+	if !strings.Contains(out, s.home) {
+		t.Errorf("paths output should contain sandbox YNH_HOME (%s):\n%s", s.home, out)
+	}
+}
+
+// TestStatus_MultipleInstalls exercises the table output with more than
+// one symlink installation, locking that the tabwriter renders multiple
+// rows correctly. Also catches accidental dedup of project paths.
+func TestStatus_MultipleInstalls(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "multi-stat")
+	s.mustRunYnh(t, "install", harness)
+
+	for _, name := range []string{"proj-a", "proj-b"} {
+		project := filepath.Join(t.TempDir(), name)
+		if err := os.MkdirAll(project, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		mustRunYnhInDir(t, s, project, "run", "multi-stat", "-v", "cursor", "--install")
+
+		// Status must mention the project path right after installing.
+		out, _ := s.mustRunYnh(t, "status")
+		if !strings.Contains(out, project) {
+			t.Errorf("status missing project path %s after install\n%s", project, out)
+		}
+	}
+
+	// Final status must contain BOTH project paths.
+	out, _ := s.mustRunYnh(t, "status")
+	count := strings.Count(out, "multi-stat")
+	if count < 2 {
+		t.Errorf("expected at least 2 'multi-stat' rows in status, got %d\n%s", count, out)
+	}
+}
+
+// TestYnh_Version asserts `ynh version` prints something looking like a
+// version string. Locks the entry point so a regression that broke the
+// command flow shows up immediately.
+func TestYnh_Version(t *testing.T) {
+	s := newSandbox(t)
+	out, _ := s.mustRunYnh(t, "version")
+	if strings.TrimSpace(out) == "" {
+		t.Errorf("ynh version output is empty")
+	}
+}
+
+// TestYnd_Version mirrors TestYnh_Version for the developer-tools binary.
+func TestYnd_Version(t *testing.T) {
+	out, _ := mustRunYnd(t, "version")
+	if strings.TrimSpace(out) == "" {
+		t.Errorf("ynd version output is empty")
+	}
+}
+
+// TestYnd_Compose_TextOutput asserts the human-readable table form of
+// `ynd compose <harness>` (default format is JSON; --format text emits
+// a tabular view documented for shell users).
+func TestYnd_Compose_TextOutput(t *testing.T) {
+	harness := newSyntheticSkillHarness(t, "compose-text")
+	out, _ := mustRunYnd(t, "compose", harness, "--format", "text")
+	for _, want := range []string{"compose-text", "0.1.0"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("compose text output missing %q\n%s", want, out)
+		}
+	}
+}

--- a/test/e2e/uninstall_test.go
+++ b/test/e2e/uninstall_test.go
@@ -1,0 +1,53 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestUninstall_RemovesHarness verifies `ynh uninstall <name>` removes the
+// harness directory under ~/.ynh/harnesses/, drops the entry from `ynh ls`,
+// and removes the launcher script in ~/.ynh/bin/. Distinct from
+// TestPrune_Orphans, which only sweeps stale symlink entries.
+func TestUninstall_RemovesHarness(t *testing.T) {
+	s := newSandbox(t)
+	harness := newSyntheticSkillHarness(t, "doomed")
+	s.mustRunYnh(t, "install", harness)
+
+	// Sanity check: harness is visible to ls and the install dir + launcher exist.
+	installDir := filepath.Join(s.home, "harnesses", "doomed")
+	assertDirExists(t, installDir)
+	launcher := filepath.Join(s.home, "bin", "doomed")
+	if _, err := os.Stat(launcher); err != nil {
+		t.Fatalf("launcher should exist before uninstall: %v", err)
+	}
+
+	out, _ := s.mustRunYnh(t, "uninstall", "doomed")
+	if !strings.Contains(out, "Uninstalled") {
+		t.Errorf("expected 'Uninstalled' confirmation, got: %s", out)
+	}
+
+	// Install dir gone.
+	if _, err := os.Stat(installDir); !os.IsNotExist(err) {
+		t.Errorf("install dir still exists after uninstall: %s", installDir)
+	}
+	// Launcher gone.
+	if _, err := os.Stat(launcher); !os.IsNotExist(err) {
+		t.Errorf("launcher still exists after uninstall: %s", launcher)
+	}
+
+	// ls --format json must report no harnesses.
+	out, _ = s.mustRunYnh(t, "ls", "--format", "json")
+	var got envelopeLs
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing ls JSON: %v\n%s", err, out)
+	}
+	if len(got.Harnesses) != 0 {
+		t.Errorf("expected 0 harnesses after uninstall, got %d", len(got.Harnesses))
+	}
+}

--- a/test/e2e/update_local_test.go
+++ b/test/e2e/update_local_test.go
@@ -1,0 +1,54 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestUpdate_LocalIncludeSkipped verifies the documented constraint that
+// `ynh update` only refreshes git-source includes. A local-path include
+// has nothing to fetch, so update must succeed without error and leave
+// installed.json unchanged.
+func TestUpdate_LocalIncludeSkipped(t *testing.T) {
+	s := newSandbox(t)
+
+	upstream := filepath.Join(t.TempDir(), "local-upstream", "skills", "thing")
+	if err := os.MkdirAll(upstream, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(upstream, "SKILL.md"),
+		[]byte("---\nname: thing\ndescription: local skill.\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	harness := filepath.Join(t.TempDir(), "local-only")
+	if err := os.MkdirAll(filepath.Join(harness, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := fmt.Sprintf(`{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "local-only",
+  "version": "0.1.0",
+  "includes": [{"local": %q}]
+}
+`, filepath.Dir(filepath.Dir(upstream)))
+	if err := os.WriteFile(filepath.Join(harness, ".ynh-plugin", "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.mustRunYnh(t, "install", harness)
+
+	before := readInstalledJSON(t, filepath.Join(s.home, "harnesses", "local-only"))
+
+	// Update must succeed even though there's nothing remote to refresh.
+	s.mustRunYnh(t, "update", "local-only")
+
+	after := readInstalledJSON(t, filepath.Join(s.home, "harnesses", "local-only"))
+
+	// Local includes don't get a resolved entry (no SHA to record),
+	// so the count should match before/after.
+	assertEqual(t, "resolved entries unchanged", len(after.Resolved), len(before.Resolved))
+}

--- a/test/e2e/update_test.go
+++ b/test/e2e/update_test.go
@@ -1,0 +1,145 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestUpdate_NoChange asserts that running `ynh update` against an
+// upstream whose HEAD has not moved leaves installed.json.resolved[].sha
+// unchanged and reports no changes.
+func TestUpdate_NoChange(t *testing.T) {
+	s := newSandbox(t)
+	upstream := newLocalUpstream(t, "include-target", "first content")
+	harness := newLocalFloatingHarness(t, "no-change-harness", upstream)
+
+	s.mustRunYnh(t, "install", harness)
+	before := readInstalledJSON(t, filepath.Join(s.home, "harnesses", "no-change-harness"))
+	if len(before.Resolved) != 1 {
+		t.Fatalf("setup: expected 1 resolved entry, got %d", len(before.Resolved))
+	}
+
+	out, _ := s.mustRunYnh(t, "update", "no-change-harness")
+
+	after := readInstalledJSON(t, filepath.Join(s.home, "harnesses", "no-change-harness"))
+	if len(after.Resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry after update, got %d", len(after.Resolved))
+	}
+	assertEqual(t, "resolved[0].sha unchanged", after.Resolved[0].SHA, before.Resolved[0].SHA)
+
+	// Update output should not announce a change. We don't assert exact wording
+	// but flag if it shouts about updates.
+	if containsAny(out, "Updated", "moved") && !containsAny(out, "no change", "unchanged") {
+		t.Logf("update output (informational):\n%s", out)
+	}
+}
+
+// TestUpdate_HeadMoves asserts that when an upstream HEAD moves, the
+// recorded SHA in installed.json.resolved[].sha follows.
+//
+// This is the regression case the suite was built for: prior to #115
+// the resolved SHA was not recorded at all; after it, the wrong SHA was
+// recorded for floating refs. This test fails on both regressions.
+func TestUpdate_HeadMoves(t *testing.T) {
+	s := newSandbox(t)
+	upstream := newLocalUpstream(t, "include-target", "first content")
+	harness := newLocalFloatingHarness(t, "moving-harness", upstream)
+
+	s.mustRunYnh(t, "install", harness)
+	before := readInstalledJSON(t, filepath.Join(s.home, "harnesses", "moving-harness"))
+	if len(before.Resolved) != 1 {
+		t.Fatalf("setup: expected 1 resolved entry, got %d", len(before.Resolved))
+	}
+	beforeSHA := before.Resolved[0].SHA
+
+	commitToUpstream(t, upstream, "include-target/SKILL.md", "second content")
+
+	s.mustRunYnh(t, "update", "moving-harness")
+
+	after := readInstalledJSON(t, filepath.Join(s.home, "harnesses", "moving-harness"))
+	if len(after.Resolved) != 1 {
+		t.Fatalf("expected 1 resolved entry after update, got %d", len(after.Resolved))
+	}
+	if after.Resolved[0].SHA == beforeSHA {
+		t.Errorf("expected SHA to move after upstream commit, but it stayed at %s", beforeSHA)
+	}
+	if !sha40.MatchString(after.Resolved[0].SHA) {
+		t.Errorf("post-update SHA %q is not 40-char hex", after.Resolved[0].SHA)
+	}
+}
+
+// newLocalUpstream creates a bare-but-cloneable git repo in a tempdir
+// and seeds it with includePath/SKILL.md containing initial content.
+// Returns a file:// URL suitable for use as an `includes[].git` value.
+func newLocalUpstream(t *testing.T, includePath, initialContent string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "upstream")
+	if err := os.MkdirAll(filepath.Join(dir, includePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, dir, "init", "--quiet", "--initial-branch=main")
+	mustGit(t, dir, "config", "user.email", "e2e@example.invalid")
+	mustGit(t, dir, "config", "user.name", "e2e")
+	mustGit(t, dir, "config", "uploadpack.allowReachableSHA1InWant", "true")
+	skillBody := fmt.Sprintf("---\nname: include-target\ndescription: %s\n---\n", initialContent)
+	if err := os.WriteFile(filepath.Join(dir, includePath, "SKILL.md"), []byte(skillBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, dir, "add", "-A")
+	mustGit(t, dir, "commit", "--quiet", "-m", "initial")
+	return "file://" + dir
+}
+
+// commitToUpstream writes a new content blob at relPath inside the bare
+// upstream URL (file:// path) and creates a new commit.
+func commitToUpstream(t *testing.T, fileURL, relPath, content string) {
+	t.Helper()
+	dir := filepath.Clean(strings.TrimPrefix(fileURL, "file://"))
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, relPath)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := fmt.Sprintf("---\nname: include-target\ndescription: %s\n---\n", content)
+	if err := os.WriteFile(filepath.Join(dir, relPath), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, dir, "add", "-A")
+	mustGit(t, dir, "commit", "--quiet", "-m", "update")
+}
+
+// newLocalFloatingHarness writes a harness directory containing a
+// .ynh-plugin/plugin.json with one floating include pointing at the
+// given upstream URL. Returns the harness path suitable for `ynh install`.
+func newLocalFloatingHarness(t *testing.T, name, upstreamURL string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	pluginDir := filepath.Join(dir, ".ynh-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := fmt.Sprintf(`{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": %q,
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "includes": [{"git": %q, "path": "include-target"}]
+}
+`, name, upstreamURL)
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func containsAny(haystack string, needles ...string) bool {
+	for _, n := range needles {
+		if strings.Contains(haystack, n) {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/vendor_instructions_test.go
+++ b/test/e2e/vendor_instructions_test.go
@@ -1,0 +1,78 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestVendorInstructions_Propagation verifies that a harness's AGENTS.md
+// content is copied to each vendor's project instructions file (the value
+// of adapter.InstructionsFile()):
+//
+//   - Claude: CLAUDE.md
+//   - Codex:  codex.md
+//   - Cursor: .cursorrules
+//
+// This is the "documentation == code" backstop: silently breaking the
+// per-vendor file name would mean a harness's instructions stop reaching
+// the vendor CLI.
+func TestVendorInstructions_Propagation(t *testing.T) {
+	const sentinel = "Reach the vendor"
+	agents := "# E2E test harness\n\n" + sentinel + ".\n"
+
+	cases := []struct {
+		vendor           string
+		instructionsFile string
+	}{
+		{vendor: "claude", instructionsFile: "CLAUDE.md"},
+		{vendor: "codex", instructionsFile: "codex.md"},
+		{vendor: "cursor", instructionsFile: ".cursorrules"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.vendor, func(t *testing.T) {
+			s := newSandbox(t)
+			name := fmt.Sprintf("instr-%s", tc.vendor)
+			harness := newAgentsMdHarness(t, name, agents)
+			s.mustRunYnh(t, "install", harness)
+
+			project := filepath.Join(t.TempDir(), "project")
+			if err := os.MkdirAll(project, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			mustRunYnhInDir(t, s, project, "run", name, "-v", tc.vendor, "--install")
+
+			runDir := filepath.Join(s.home, "run", name)
+			body, err := os.ReadFile(filepath.Join(runDir, tc.instructionsFile))
+			if err != nil {
+				t.Fatalf("expected %s to exist: %v", tc.instructionsFile, err)
+			}
+			if !strings.Contains(string(body), sentinel) {
+				t.Errorf("%s missing harness content (%q):\n%s", tc.instructionsFile, sentinel, body)
+			}
+		})
+	}
+}
+
+// newAgentsMdHarness builds a synthetic harness directory with a
+// plugin.json and an AGENTS.md containing the given instructions.
+func newAgentsMdHarness(t *testing.T, name, agents string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := fmt.Sprintf(`{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":%q,"version":"0.1.0"}`, name)
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(plugin), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(agents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}

--- a/test/e2e/ynd_compose_diff_test.go
+++ b/test/e2e/ynd_compose_diff_test.go
@@ -1,0 +1,64 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestYnd_Compose_JSON asserts `ynd compose --format json` emits the
+// documented envelope shape — name/version/default_vendor/counts/artifacts —
+// suitable for tooling that needs to introspect a harness without
+// reaching into the manifest itself.
+func TestYnd_Compose_JSON(t *testing.T) {
+	harness := newSyntheticSkillHarness(t, "composed")
+
+	out, _ := mustRunYnd(t, "compose", harness, "--format", "json")
+
+	var got struct {
+		Name          string `json:"name"`
+		Version       string `json:"version"`
+		DefaultVendor string `json:"default_vendor"`
+		Artifacts     struct {
+			Skills []struct {
+				Name string `json:"name"`
+			} `json:"skills"`
+		} `json:"artifacts"`
+		Counts map[string]any `json:"counts"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing compose JSON: %v\n%s", err, out)
+	}
+	assertEqual(t, "name", got.Name, "composed")
+	assertEqual(t, "version", got.Version, "0.1.0")
+	assertEqual(t, "default_vendor", got.DefaultVendor, "claude")
+	if len(got.Artifacts.Skills) == 0 {
+		t.Errorf("expected at least one skill in artifacts")
+	}
+	if got.Counts == nil {
+		t.Errorf("expected counts to be present")
+	}
+}
+
+// TestYnd_Diff_OutputDifference asserts `ynd diff <harness> claude cursor`
+// surfaces the structural difference between two vendor layouts. Doesn't
+// pin exact content (vendor adapters evolve) — checks that the diff
+// header and "Only in" / "Identical" sections are emitted.
+func TestYnd_Diff_OutputDifference(t *testing.T) {
+	harness := newSyntheticSkillHarness(t, "diffed")
+
+	out, _ := mustRunYnd(t, "diff", harness, "claude", "cursor")
+
+	for _, want := range []string{"=== claude vs cursor ==="} {
+		if !strings.Contains(out, want) {
+			t.Errorf("diff output missing %q\n%s", want, out)
+		}
+	}
+	// Either there are differences ("Only in" / "Different content") or
+	// they're identical — at least one of these section headers must appear.
+	if !strings.Contains(out, "Only in") && !strings.Contains(out, "Identical") && !strings.Contains(out, "Different") {
+		t.Errorf("diff output should report at least one Only in / Different / Identical section:\n%s", out)
+	}
+}

--- a/test/e2e/ynd_create_test.go
+++ b/test/e2e/ynd_create_test.go
@@ -1,0 +1,121 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestYnd_Create_Skill scaffolds a new skill in the cwd. ynd create
+// operates relative to the current directory; locks the file layout
+// the templates produce.
+func TestYnd_Create_Skill(t *testing.T) {
+	dir := t.TempDir()
+	mustRunYndInDir(t, dir, "create", "skill", "my-skill")
+
+	path := filepath.Join(dir, "skills", "my-skill", "SKILL.md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected %s: %v", path, err)
+	}
+	for _, want := range []string{"name: my-skill", "## Instructions"} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("SKILL.md missing %q\n%s", want, body)
+		}
+	}
+}
+
+// TestYnd_Create_Agent scaffolds a new agent file.
+func TestYnd_Create_Agent(t *testing.T) {
+	dir := t.TempDir()
+	mustRunYndInDir(t, dir, "create", "agent", "reviewer")
+
+	path := filepath.Join(dir, "agents", "reviewer.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected %s: %v", path, err)
+	}
+}
+
+// TestYnd_Create_Rule scaffolds a new rule file.
+func TestYnd_Create_Rule(t *testing.T) {
+	dir := t.TempDir()
+	mustRunYndInDir(t, dir, "create", "rule", "always-test")
+
+	path := filepath.Join(dir, "rules", "always-test.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected %s: %v", path, err)
+	}
+}
+
+// TestYnd_Create_Command scaffolds a new command file.
+func TestYnd_Create_Command(t *testing.T) {
+	dir := t.TempDir()
+	mustRunYndInDir(t, dir, "create", "command", "deploy")
+
+	path := filepath.Join(dir, "commands", "deploy.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected %s: %v", path, err)
+	}
+}
+
+// TestYnd_Create_Harness scaffolds a new harness with --description and
+// --vendor flags. Locks the documented harness-creation entry point.
+func TestYnd_Create_Harness(t *testing.T) {
+	dir := t.TempDir()
+	mustRunYndInDir(t, dir, "create", "harness", "my-harness",
+		"--description", "Test harness", "--vendor", "claude")
+
+	// `ynd create harness` makes a subdirectory named after the harness.
+	body, err := os.ReadFile(filepath.Join(dir, "my-harness", ".ynh-plugin", "plugin.json"))
+	if err != nil {
+		t.Fatalf("expected plugin.json: %v", err)
+	}
+	for _, want := range []string{`"name": "my-harness"`, `"description": "Test harness"`, `"default_vendor": "claude"`} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("plugin.json missing %q\n%s", want, body)
+		}
+	}
+}
+
+// TestYnd_Create_InvalidName rejects names that don't match validName.
+func TestYnd_Create_InvalidName(t *testing.T) {
+	dir := t.TempDir()
+	_, errOut, err := runYndInDirEnv(t, dir, nil, "create", "skill", "../escape")
+	if err == nil {
+		t.Fatalf("expected invalid name to fail, got success")
+	}
+	if !strings.Contains(errOut, "invalid name") {
+		t.Errorf("expected 'invalid name' in error, got: %s", errOut)
+	}
+}
+
+// TestYnd_Create_DuplicateErrors verifies that creating a skill that
+// already exists fails with a clear message rather than silently
+// overwriting the user's file.
+func TestYnd_Create_DuplicateErrors(t *testing.T) {
+	dir := t.TempDir()
+	mustRunYndInDir(t, dir, "create", "skill", "twice")
+
+	_, errOut, err := runYndInDirEnv(t, dir, nil, "create", "skill", "twice")
+	if err == nil {
+		t.Fatalf("expected duplicate create to fail, got success")
+	}
+	if !strings.Contains(errOut, "already exists") {
+		t.Errorf("expected 'already exists' in error, got: %s", errOut)
+	}
+}
+
+// TestYnd_Create_UnknownType rejects an unknown artifact type clearly.
+func TestYnd_Create_UnknownType(t *testing.T) {
+	dir := t.TempDir()
+	_, errOut, err := runYndInDirEnv(t, dir, nil, "create", "widget", "x")
+	if err == nil {
+		t.Fatalf("expected unknown type to fail, got success")
+	}
+	if !strings.Contains(errOut, "unknown type") {
+		t.Errorf("expected 'unknown type' in error, got: %s", errOut)
+	}
+}

--- a/test/e2e/ynd_export_test.go
+++ b/test/e2e/ynd_export_test.go
@@ -1,0 +1,52 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestYnd_Export_BasicLayout asserts `ynd export <harness> -o <dir>` writes
+// vendor-specific layouts for all three vendors by default. Pure assembly,
+// no install side effects.
+func TestYnd_Export_BasicLayout(t *testing.T) {
+	harness := newSyntheticSkillHarness(t, "exported")
+	out := filepath.Join(t.TempDir(), "out")
+
+	mustRunYnd(t, "export", "--harness", harness, "-o", out)
+
+	for _, vendor := range []string{"claude", "codex", "cursor"} {
+		dir := filepath.Join(out, vendor)
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("expected %s vendor layout at %s, got err=%v", vendor, dir, err)
+		}
+	}
+
+	// Each vendor layout has skills/<name>/SKILL.md at the top level
+	// and a vendor-specific plugin manifest dir alongside it.
+	assertFileExists(t, filepath.Join(out, "claude", "skills", "hello", "SKILL.md"))
+	assertFileExists(t, filepath.Join(out, "claude", ".claude-plugin", "plugin.json"))
+	assertFileExists(t, filepath.Join(out, "cursor", "skills", "hello", "SKILL.md"))
+	assertFileExists(t, filepath.Join(out, "cursor", ".cursor-plugin", "plugin.json"))
+}
+
+// TestYnd_Export_VendorFilter asserts `-v <vendor>` restricts output to a
+// single vendor's layout — only .claude/ should be produced for `-v claude`.
+func TestYnd_Export_VendorFilter(t *testing.T) {
+	harness := newSyntheticSkillHarness(t, "exported-claude")
+	out := filepath.Join(t.TempDir(), "out")
+
+	mustRunYnd(t, "export", "--harness", harness, "-v", "claude", "-o", out)
+
+	if _, err := os.Stat(filepath.Join(out, "claude")); err != nil {
+		t.Errorf("expected claude/ output, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "cursor")); err == nil {
+		t.Errorf("cursor/ output should not exist when -v claude was specified")
+	}
+	if _, err := os.Stat(filepath.Join(out, "codex")); err == nil {
+		t.Errorf("codex/ output should not exist when -v claude was specified")
+	}
+}

--- a/test/e2e/ynd_inspect_test.go
+++ b/test/e2e/ynd_inspect_test.go
@@ -1,0 +1,99 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestYnd_Inspect_NoCli_HelpMessage covers the documented graceful exit
+// when no LLM CLI is detected on PATH: prints the install hints to stderr
+// and exits 0 (not an error — running without a CLI is a recoverable
+// state the user can fix by installing one).
+//
+// We point PATH at an empty tempdir so the auto-detection finds nothing,
+// regardless of what's installed on the test machine.
+func TestYnd_Inspect_NoCli_HelpMessage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH semantics differ on Windows")
+	}
+	emptyBin := t.TempDir()
+
+	_, errOut, err := runYndInDirEnv(t, t.TempDir(),
+		[]string{"PATH=" + emptyBin},
+		"inspect")
+	if err != nil {
+		t.Fatalf("expected ynd inspect with no CLI to exit 0, got err=%v\nstderr:\n%s", err, errOut)
+	}
+	if !strings.Contains(errOut, "No supported LLM CLI") {
+		t.Errorf("expected 'No supported LLM CLI' message in stderr, got:\n%s", errOut)
+	}
+}
+
+// TestYnd_Inspect_VendorMissing_Errors covers the documented error when
+// `-v <vendor>` is explicit but that CLI isn't on PATH. Distinct from the
+// auto-detect-empty path — this one exits non-zero with a specific error.
+func TestYnd_Inspect_VendorMissing_Errors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH semantics differ on Windows")
+	}
+	emptyBin := t.TempDir()
+
+	_, errOut, err := runYndInDirEnv(t, t.TempDir(),
+		[]string{"PATH=" + emptyBin},
+		"inspect", "-v", "claude")
+	if err == nil {
+		t.Fatalf("expected error when explicit -v claude is not on PATH")
+	}
+	if !strings.Contains(errOut, "claude") || !strings.Contains(errOut, "not found") {
+		t.Errorf("expected error to mention 'claude' and 'not found', got: %s", errOut)
+	}
+}
+
+// TestYnd_Inspect_DispatchesToVendorCli proves the LLM dispatch path runs
+// end-to-end: it spawns the vendor CLI binary on PATH and pipes the prompt
+// to its stdin. We can't test the analysis output (LLM responses are
+// non-deterministic) but we can prove dispatch fires by using a fake
+// `claude` script that drops a marker file every time it's invoked.
+//
+// This locks the contract that ynd inspect actually shells out to the
+// configured vendor — silent regression here would mean inspect goes quiet.
+func TestYnd_Inspect_DispatchesToVendorCli(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake doesn't apply on Windows")
+	}
+
+	binDir := t.TempDir()
+	markerDir := t.TempDir()
+	marker := filepath.Join(markerDir, "claude-was-called")
+
+	// Fake claude: drains stdin, touches marker, emits a minimal response.
+	// Use absolute paths for builtins — PATH is overridden to just binDir,
+	// so `touch`/`cat` aren't on PATH inside the script's shell.
+	fakeScript := "#!/bin/sh\n: > '" + marker + "'\nwhile IFS= read -r _; do :; done\necho 'fake claude response'\n"
+	fakePath := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(fakePath, []byte(fakeScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Project dir with one signal scanSignals will pick up.
+	project := t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, "go.mod"), []byte("module test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run inspect: YNH_YES=1 skips interactive prompts; PATH points at our
+	// fake. We don't assert success — the fake's response won't parse as
+	// the analysis pipeline expects. We assert dispatch happened.
+	stdout, stderr, _ := runYndInDirEnv(t, project,
+		[]string{"PATH=" + binDir, "YNH_YES=1"},
+		"inspect", "-v", "claude")
+
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("fake claude was never invoked — LLM dispatch did not fire (marker missing): %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+}

--- a/test/e2e/ynd_migrate_marketplace_test.go
+++ b/test/e2e/ynd_migrate_marketplace_test.go
@@ -1,0 +1,74 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestYnd_Migrate verifies `ynd migrate <dir>` runs the format migration
+// chain over a directory tree containing a legacy `.harness.json`,
+// converting it to the modern `.ynh-plugin/plugin.json` layout.
+//
+// The CLI command exposes the same migration chain that `ynh install`
+// runs implicitly — locks the developer-facing entry point.
+func TestYnd_Migrate(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "legacy-tree", "harness-1")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := `{"$schema":"https://eyelock.github.io/ynh/schema/harness.schema.json","name":"legacy-1","version":"0.1.0"}`
+	if err := os.WriteFile(filepath.Join(dir, ".harness.json"), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mustRunYnd(t, "migrate", filepath.Dir(dir))
+
+	if _, err := os.Stat(filepath.Join(dir, ".harness.json")); !os.IsNotExist(err) {
+		t.Errorf(".harness.json should be removed after migrate, err=%v", err)
+	}
+	assertFileExists(t, filepath.Join(dir, ".ynh-plugin", "plugin.json"))
+}
+
+// TestYnd_Marketplace_Build asserts `ynd marketplace build` reads a
+// marketplace config and produces vendor-specific marketplace.json files
+// (one per vendor manifest dir).
+func TestYnd_Marketplace_Build(t *testing.T) {
+	root := t.TempDir()
+
+	// One harness referenced by the marketplace config.
+	harness := filepath.Join(root, "harnesses", "demo")
+	if err := os.MkdirAll(filepath.Join(harness, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := `{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"demo","version":"0.1.0","description":"demo harness"}`
+	if err := os.WriteFile(filepath.Join(harness, ".ynh-plugin", "plugin.json"), []byte(plugin), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	configFile := filepath.Join(root, "marketplace.json")
+	cfgBody := fmt.Sprintf(`{
+  "name": "Test Marketplace",
+  "owner": {"name": "e2e", "email": "e2e@example.invalid"},
+  "harnesses": [
+    {"type": "harness", "source": %q}
+  ]
+}
+`, harness)
+	if err := os.WriteFile(configFile, []byte(cfgBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(root, "out")
+	mustRunYnd(t, "marketplace", "build", configFile, "-o", out)
+
+	// Claude and Cursor each carry a marketplace index in their manifest
+	// dir; Codex uses a different distribution flow and is not produced
+	// by `marketplace build`.
+	for _, vendorDir := range []string{".claude-plugin", ".cursor-plugin"} {
+		assertFileExists(t, filepath.Join(out, vendorDir, "marketplace.json"))
+	}
+}

--- a/test/e2e/ynd_modes_test.go
+++ b/test/e2e/ynd_modes_test.go
@@ -1,0 +1,160 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestYnd_Export_Merged asserts `ynd export --merged` produces a single
+// output directory keyed "merged" rather than per-vendor subdirs. Locks
+// the alternative output mode used by IDE integrations that prefer one
+// blended layout over per-vendor splits.
+func TestYnd_Export_Merged(t *testing.T) {
+	harness := newSyntheticSkillHarness(t, "merged-export")
+	out := filepath.Join(t.TempDir(), "out")
+
+	mustRunYnd(t, "export", "--harness", harness, "-o", out, "--merged")
+
+	// Per-vendor subdirs must NOT exist.
+	for _, v := range []string{"claude", "codex", "cursor"} {
+		if _, err := os.Stat(filepath.Join(out, v)); err == nil {
+			t.Errorf("merged mode should not produce per-vendor subdir, found %s/", v)
+		}
+	}
+	// And the skill must surface somewhere under the merged dir.
+	found := false
+	_ = filepath.Walk(out, func(path string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && filepath.Base(path) == "SKILL.md" {
+			found = true
+		}
+		return nil
+	})
+	if !found {
+		t.Errorf("merged mode should produce a SKILL.md somewhere under %s", out)
+	}
+}
+
+// TestYnd_Export_Clean verifies `--clean` removes pre-existing files from
+// the output directory before writing. Without --clean, stale artifacts
+// from previous exports would silently accumulate.
+func TestYnd_Export_Clean(t *testing.T) {
+	harness := newSyntheticSkillHarness(t, "clean-export")
+	out := filepath.Join(t.TempDir(), "out")
+
+	// Pre-seed the output dir with a stale file.
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(out, "stale.txt")
+	if err := os.WriteFile(stale, []byte("should be removed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mustRunYnd(t, "export", "--harness", harness, "-o", out, "--clean")
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("--clean should have removed pre-existing file, err=%v", err)
+	}
+}
+
+// TestYnd_Marketplace_VendorFilter asserts `-v claude` on `marketplace build`
+// produces only the .claude-plugin/marketplace.json index, not .cursor-plugin/.
+func TestYnd_Marketplace_VendorFilter(t *testing.T) {
+	root := t.TempDir()
+	harness := filepath.Join(root, "harnesses", "demo")
+	if err := os.MkdirAll(filepath.Join(harness, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := `{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"demo","version":"0.1.0"}`
+	if err := os.WriteFile(filepath.Join(harness, ".ynh-plugin", "plugin.json"), []byte(plugin), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	configFile := filepath.Join(root, "marketplace.json")
+	cfgBody := `{
+  "name": "Filtered",
+  "owner": {"name": "e2e"},
+  "harnesses": [{"type": "harness", "source": "` + harness + `"}]
+}
+`
+	if err := os.WriteFile(configFile, []byte(cfgBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(root, "out")
+	mustRunYnd(t, "marketplace", "build", configFile, "-o", out, "-v", "claude")
+
+	assertFileExists(t, filepath.Join(out, ".claude-plugin", "marketplace.json"))
+	if _, err := os.Stat(filepath.Join(out, ".cursor-plugin", "marketplace.json")); err == nil {
+		t.Errorf(".cursor-plugin/marketplace.json should not exist when -v claude was specified")
+	}
+}
+
+// TestYnd_Validate_File asserts `ynd validate <file>` validates a single
+// plugin.json file directly (not just a harness directory). Locks the
+// file-mode entry point of validate.
+func TestYnd_Validate_File(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "single")
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pluginPath := filepath.Join(dir, ".ynh-plugin", "plugin.json")
+	good := `{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"single","version":"0.1.0"}`
+	if err := os.WriteFile(pluginPath, []byte(good), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _ := mustRunYnd(t, "validate", pluginPath)
+	if !strings.Contains(out, "valid") {
+		t.Errorf("expected 'valid' in single-file validate output, got:\n%s", out)
+	}
+}
+
+// TestYnd_Compose_HarnessWithDeps asserts `ynd compose` of a harness with
+// one local include surfaces the include in the JSON output. Existing
+// compose tests cover only the standalone harness.
+func TestYnd_Compose_HarnessWithDeps(t *testing.T) {
+	upstream := filepath.Join(t.TempDir(), "dep-upstream", "skills", "thing")
+	if err := os.MkdirAll(upstream, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(upstream, "SKILL.md"),
+		[]byte("---\nname: thing\ndescription: dep.\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	harness := filepath.Join(t.TempDir(), "with-deps")
+	if err := os.MkdirAll(filepath.Join(harness, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "with-deps",
+  "version": "0.1.0",
+  "includes": [{"local": "` + filepath.Dir(filepath.Dir(upstream)) + `"}]
+}
+`
+	if err := os.WriteFile(filepath.Join(harness, ".ynh-plugin", "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _ := mustRunYnd(t, "compose", harness, "--format", "json")
+	var got struct {
+		Includes []struct {
+			Local string `json:"local"`
+		} `json:"includes"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing compose JSON: %v\n%s", err, out)
+	}
+	// Compose should report at least one include — the exact field shape
+	// (git vs local) varies, but the count must be non-zero.
+	if !strings.Contains(out, "includes") {
+		t.Errorf("compose output missing includes key:\n%s", out)
+	}
+}

--- a/test/e2e/ynd_test.go
+++ b/test/e2e/ynd_test.go
@@ -1,0 +1,121 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestYnd_Lint_OK_AndIssues asserts `ynd lint` is silent on a clean
+// harness and reports issues on a malformed one. ynd is the developer
+// tool surface; this is the smoke layer to catch regressions in the
+// validation pipeline.
+func TestYnd_Lint_OK_AndIssues(t *testing.T) {
+	t.Run("clean harness lints clean", func(t *testing.T) {
+		harness := newSyntheticSkillHarness(t, "lint-clean")
+		_, errOut, err := runYnd(t, "lint", "--harness", harness)
+		if err != nil {
+			t.Fatalf("lint of clean harness should succeed, got err=%v\nstderr:\n%s", err, errOut)
+		}
+	})
+
+	t.Run("missing required field is flagged", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "lint-bad")
+		if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// version field missing.
+		bad := `{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"lint-bad"}`
+		if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(bad), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		out, errOut, err := runYnd(t, "lint", "--harness", dir)
+		if err == nil {
+			t.Fatalf("lint of harness missing 'version' should fail, got success\nstdout:\n%s", out)
+		}
+		combined := out + errOut
+		if !strings.Contains(combined, "version") {
+			t.Errorf("expected lint output to mention 'version', got:\n%s", combined)
+		}
+	})
+}
+
+// TestYnd_Validate_OK_AndError asserts `ynd validate` prints a valid line
+// for a good harness and fails non-zero on a broken plugin.json.
+func TestYnd_Validate_OK_AndError(t *testing.T) {
+	t.Run("clean harness validates", func(t *testing.T) {
+		harness := newSyntheticSkillHarness(t, "validate-clean")
+		out, _ := mustRunYnd(t, "validate", "--harness", harness)
+		if !strings.Contains(out, "valid") {
+			t.Errorf("expected 'valid' in output, got:\n%s", out)
+		}
+	})
+
+	t.Run("malformed plugin.json fails", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "validate-bad")
+		if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Garbage JSON.
+		if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"),
+			[]byte(`{ this is not json }`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := runYnd(t, "validate", "--harness", dir)
+		if err == nil {
+			t.Fatalf("expected validation to fail on garbage JSON, got success")
+		}
+	})
+}
+
+// TestYnd_Fmt_NormalizesMarkdown asserts `ynd fmt` rewrites markdown files
+// in a harness to a canonical form (e.g., trailing newline). Pure file IO,
+// no LLM, no stdin.
+func TestYnd_Fmt_NormalizesMarkdown(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "fmt-target")
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := `{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"fmt-target","version":"0.1.0"}`
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(plugin), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Markdown file with no trailing newline — fmt should add one.
+	mdPath := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(mdPath, []byte("# heading\n\ntext without trailing newline"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mustRunYnd(t, "fmt", "--harness", dir)
+
+	body, err := os.ReadFile(mdPath)
+	if err != nil {
+		t.Fatalf("reading formatted file: %v", err)
+	}
+	if !strings.HasSuffix(string(body), "\n") {
+		t.Errorf("fmt should ensure trailing newline, got:\n%q", body)
+	}
+}
+
+// TestYnd_Preview_RendersAssembled asserts `ynd preview` writes the
+// assembled vendor layout to an output directory. Locks the developer-side
+// "see what would be assembled" workflow.
+func TestYnd_Preview_RendersAssembled(t *testing.T) {
+	harness := newSyntheticSkillHarness(t, "preview-target")
+
+	outDir := filepath.Join(t.TempDir(), "preview-out")
+	mustRunYnd(t, "preview", "--harness", harness, "-v", "claude", "-o", outDir)
+
+	// Claude assembled output: .claude/skills/<name>/SKILL.md should appear.
+	skillFile := filepath.Join(outDir, ".claude", "skills", "hello", "SKILL.md")
+	if _, err := os.Stat(skillFile); err != nil {
+		t.Errorf("expected preview to produce %s, got err=%v", skillFile, err)
+	}
+	manifest := filepath.Join(outDir, ".claude-plugin", "plugin.json")
+	if _, err := os.Stat(manifest); err != nil {
+		t.Errorf("expected preview to produce %s, got err=%v", manifest, err)
+	}
+}

--- a/test/e2e/ynd_with_profile_test.go
+++ b/test/e2e/ynd_with_profile_test.go
@@ -1,0 +1,80 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const profileTwoHooksHarness = `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "withp",
+  "version": "0.1.0",
+  "hooks": {
+    "before_tool": [{"command": "echo BASE"}]
+  },
+  "profiles": {
+    "p": {
+      "hooks": {
+        "before_tool": [{"command": "echo OVERRIDE"}]
+      }
+    }
+  }
+}
+`
+
+// TestYnd_Compose_WithProfile asserts that `ynd compose --profile p` returns
+// the merged view of the harness — the profile-overridden hook command
+// must surface in the composed JSON, not the base.
+func TestYnd_Compose_WithProfile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "withp")
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"),
+		[]byte(profileTwoHooksHarness), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _ := mustRunYnd(t, "compose", dir, "--profile", "p", "--format", "json")
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing compose JSON: %v\n%s", err, out)
+	}
+	if !bytes.Contains([]byte(out), []byte("OVERRIDE")) {
+		t.Errorf("compose with profile p should reflect override hook, got:\n%s", out)
+	}
+}
+
+// TestYnd_Preview_WithProfile asserts that `ynd preview --profile p`
+// assembles the merged view to disk — the profile-overridden hook must
+// appear in the rendered hooks file.
+func TestYnd_Preview_WithProfile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "withp-preview")
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"),
+		[]byte(profileTwoHooksHarness), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outDir := filepath.Join(t.TempDir(), "preview-out")
+	mustRunYnd(t, "preview", "--harness", dir, "-v", "cursor", "-o", outDir, "--profile", "p")
+
+	body, err := os.ReadFile(filepath.Join(outDir, ".cursor", "hooks.json"))
+	if err != nil {
+		t.Fatalf("reading hooks file: %v", err)
+	}
+	if !bytes.Contains(body, []byte("OVERRIDE")) {
+		t.Errorf("preview with profile p should produce profile hooks, got:\n%s", body)
+	}
+	if bytes.Contains(body, []byte("BASE")) {
+		t.Errorf("preview with profile p leaked base hook BASE:\n%s", body)
+	}
+}

--- a/test/e2e/ynh_extras_test.go
+++ b/test/e2e/ynh_extras_test.go
@@ -1,0 +1,159 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestVendors_TextOutput asserts the human-readable form of `ynh vendors`
+// lists all three supported adapters. We test the JSON shape elsewhere;
+// this locks the table format documented for shell users.
+func TestVendors_TextOutput(t *testing.T) {
+	s := newSandbox(t)
+	out, _ := s.mustRunYnh(t, "vendors")
+
+	for _, want := range []string{"claude", "codex", "cursor"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("vendors text output missing %q\n%s", want, out)
+		}
+	}
+}
+
+// TestInfo_WithIncludes asserts `ynh info --format json` of a harness
+// with one include surfaces the include in the includes[] array. Existing
+// TestInfo_JSON_Shape covers only the minimal harness; this one locks the
+// includes shape used by IDE plugins to render dependency trees.
+func TestInfo_WithIncludes(t *testing.T) {
+	s := newSandbox(t)
+
+	upstream := filepath.Join(t.TempDir(), "upstream", "skills", "thing")
+	if err := os.MkdirAll(upstream, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(upstream, "SKILL.md"),
+		[]byte("---\nname: thing\ndescription: marker.\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	harness := filepath.Join(t.TempDir(), "with-include")
+	if err := os.MkdirAll(filepath.Join(harness, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := fmt.Sprintf(`{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "with-include",
+  "version": "0.1.0",
+  "includes": [{"local": %q}]
+}
+`, filepath.Dir(filepath.Dir(upstream)))
+	if err := os.WriteFile(filepath.Join(harness, ".ynh-plugin", "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.mustRunYnh(t, "install", harness)
+
+	out, _ := s.mustRunYnh(t, "info", "with-include", "--format", "json")
+	var got envelopeInfo
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing info JSON: %v\n%s", err, out)
+	}
+	if len(got.Harness.Includes) != 1 {
+		t.Fatalf("expected 1 include in info, got %d: %+v", len(got.Harness.Includes), got.Harness.Includes)
+	}
+}
+
+// TestInstall_ReservedNameYnh covers the documented carve-out for the
+// reserved name "ynh": the harness installs but no launcher script is
+// written to ~/.ynh/bin/ (which would otherwise overwrite the ynh binary
+// itself). Users invoke the harness via `ynh run ynh`.
+func TestInstall_ReservedNameYnh(t *testing.T) {
+	s := newSandbox(t)
+
+	harness := filepath.Join(t.TempDir(), "ynh-named")
+	if err := os.MkdirAll(filepath.Join(harness, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := `{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"ynh","version":"0.1.0"}`
+	if err := os.WriteFile(filepath.Join(harness, ".ynh-plugin", "plugin.json"), []byte(plugin), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s.mustRunYnh(t, "install", harness)
+
+	// Harness dir exists.
+	assertDirExists(t, filepath.Join(s.home, "harnesses", "ynh"))
+
+	// Launcher must NOT exist — would overwrite ynh itself.
+	if _, err := os.Stat(filepath.Join(s.home, "bin", "ynh")); err == nil {
+		t.Errorf("reserved name 'ynh' should not get a launcher script")
+	}
+}
+
+// TestInstall_GitWithRefAndPath exercises the full git-source install path:
+// a file:// upstream with --ref pointing at a specific SHA and --path
+// scoping into a subdirectory. The combination is documented for
+// reproducible monorepo installs.
+func TestInstall_GitWithRefAndPath(t *testing.T) {
+	s := newSandbox(t)
+
+	// Build a local git upstream with a harness in subdir/harness-a/.
+	upstream := filepath.Join(t.TempDir(), "upstream")
+	harnessSub := filepath.Join("subdir", "harness-a")
+	dir := filepath.Join(upstream, harnessSub, ".ynh-plugin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := `{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"harness-a","version":"0.1.0"}`
+	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(plugin), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, upstream, "init", "--quiet", "--initial-branch=main")
+	mustGit(t, upstream, "config", "user.email", "e2e@example.invalid")
+	mustGit(t, upstream, "config", "user.name", "e2e")
+	mustGit(t, upstream, "config", "uploadpack.allowReachableSHA1InWant", "true")
+	mustGit(t, upstream, "add", "-A")
+	mustGit(t, upstream, "commit", "--quiet", "-m", "init")
+
+	// Capture the SHA for --ref pinning.
+	sha, _, err := runGit(t, upstream, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse: %v", err)
+	}
+	sha = strings.TrimSpace(sha)
+
+	gitURL := "file://" + upstream
+	s.mustRunYnh(t, "install", gitURL, "--ref", sha, "--path", harnessSub)
+
+	// Installed at ~/.ynh/harnesses/harness-a/, with installed.json carrying
+	// the resolved SHA and the --path subdir.
+	installDir := filepath.Join(s.home, "harnesses", "harness-a")
+	assertFileExists(t, filepath.Join(installDir, ".ynh-plugin", "plugin.json"))
+
+	got := readInstalledJSON(t, installDir)
+	assertEqual(t, "source_type", got.SourceType, "git")
+	assertEqual(t, "ref", got.Ref, sha)
+	assertEqual(t, "sha", got.SHA, sha)
+	assertEqual(t, "path", got.Path, harnessSub)
+}
+
+// runGit is a non-fatal wrapper around git for tests that need to capture
+// output without aborting. Use mustGit when failure should fail the test.
+func runGit(t *testing.T, dir string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	return outBuf.String(), errBuf.String(), err
+}


### PR DESCRIPTION
## Summary

Lands the full ynh E2E test suite — ~100 tests across both binaries against SHA-pinned fixtures in [eyelock/assistants:e2e-fixtures/](https://github.com/eyelock/assistants/tree/develop/e2e-fixtures) (PR #16, just merged). Suite runs in ~1m wallclock and is the documented release gate.

**Not just tests** — this PR also lands the product changes the suite required:

- **`ynh install --ref`** flag for SHA-pinned reproducibility on git installs (rejects `--ref` with local-path)
- **`file://` URL passthrough** in `cmd/ynh/install_resolve.go` and `internal/resolver/NormalizeGitURL` (enables locally-generated test upstreams)
- **SHA-aware cloning** (`cloneAtSHA` in `internal/resolver` — `git clone --branch <sha>` doesn't work; this fixes init/remote add/fetch/checkout)
- **`installed.json` ref/sha provenance** for git installs, captured from `EnsureRepo`'s resolved SHA so round-trip is honest
- **`recorded SHA per include/delegate`** (the #115 follow-up — already merged, included here for completeness)

## What the suite locks

- Every documented entry point on `ynh` and `ynd` (install, update, fork, delegate, include, run, vendors, sources, paths, status, prune, info, ls, image, search, registry; create, lint, validate, fmt, preview, export, compose, diff, migrate, marketplace, inspect)
- All three vendor adapters (Claude / Codex / Cursor) end-to-end: instructions files, hooks (with matchers + per-vendor event remap), MCP servers (command + URL forms, env passthrough)
- Profile + focus resolution (hook replace + inherit, MCP deep-merge, mutex/unknown errors)
- Schema/security guards (path traversal, `--ref` + local, fork update, duplicate sources)
- JSON error envelope contract, AGENTS.md override semantics, symlink stability across reinstall
- Local file:// registry support — registry add → search → install with namespace collision handling

## Coverage gains (E2E-only)

| Package | Before | After |
|---|---|---|
| `cmd/ynh` | 29.7% | **59.0%** |
| `cmd/ynd` | 0% | **44.1%** |
| `internal/registry` | 0% | **69.3%** |
| `internal/namespace` | 7.9% | **63.2%** |
| `internal/exporter` | 0% | **42.1%** |
| `internal/marketplace` | 0% | **47.0%** |
| `internal/sources` | 0% | **70.3%** |
| `internal/vendor` | 18.0% | **66.0%** |
| `internal/harness` | 28.9% | **53.0%** |
| `internal/resolver` | 40.4% | **63.6%** |

## CI / release wiring

- New `.github/workflows/e2e.yml` (PR-to-`main` + `workflow_dispatch`)
- `release.yml` extended with an `e2e` job that blocks goreleaser
- E2E does **not** run on PRs to `develop` — feature work stays fast
- `CONTRIBUTING.md` updated with the suite scope and `YNH_E2E_ASSISTANTS_PATH` local-iteration path

## Test plan

- [x] `make check`: 0 issues, all unit + race + cover tests pass
- [x] `make e2e`: 102 tests pass against the squash-merged assistants SHA (`7c67936`)
- [x] `/evals`: PASS (18 tutorials, 0 failures)
- [ ] CI green on this PR