### PR TITLE
fix(ls,search): emit namespace field in JSON output

### DIFF
--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -27,6 +27,12 @@ type listEnvelope struct {
 // Field order drives JSON key order via MarshalIndent.
 type listEntry struct {
 	Name string `json:"name"`
+	// Namespace is the URL-derived "<org>/<repo>" for namespaced installs
+	// (registry installs, or any install that landed under
+	// ~/.ynh/harnesses/<ns>/<name>/). Empty for flat/local installs.
+	// Downstream consumers compose stable IDs as "<namespace>/<name>" when
+	// present.
+	Namespace string `json:"namespace,omitempty"`
 	// Kind classifies the install: "local-fork" (pointer-shaped, forked
 	// from an upstream), "local" (local path, no upstream), "registry",
 	// "git", or "-" for pre-migration entries with no recorded source.
@@ -292,6 +298,7 @@ func buildListEntry(p *harness.Harness) listEntry {
 
 	entry := listEntry{
 		Name:             p.Name,
+		Namespace:        p.Namespace,
 		Kind:             classifyKind(p.InstalledFrom),
 		VersionInstalled: p.Version,
 		Description:      p.Description,

--- a/cmd/ynh/list_test.go
+++ b/cmd/ynh/list_test.go
@@ -352,6 +352,37 @@ func TestCmdListJSONNamespacedPath(t *testing.T) {
 	if env.Harnesses[0].Path != wantPath {
 		t.Errorf("path = %q, want %q", env.Harnesses[0].Path, wantPath)
 	}
+	if got, want := env.Harnesses[0].Namespace, "eyelock/assistants"; got != want {
+		t.Errorf("namespace = %q, want %q", got, want)
+	}
+}
+
+// TestCmdListJSONFlatInstallNoNamespace asserts that a flat (non-namespaced)
+// install emits no namespace key — `omitempty` keeps the JSON envelope clean
+// for local harnesses and matches the schema's "nil for flat installs" promise.
+func TestCmdListJSONFlatInstallNoNamespace(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	installListTestHarness(t, home, "alpha",
+		`{"name":"alpha","version":"1.0.0","default_vendor":"claude"}`)
+
+	var stdout bytes.Buffer
+	if err := cmdListTo([]string{"--format", "json"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdListTo: %v", err)
+	}
+
+	if strings.Contains(stdout.String(), `"namespace"`) {
+		t.Errorf("flat install must not emit namespace key; got: %s", stdout.String())
+	}
+
+	var env listEnvelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env.Harnesses[0].Namespace != "" {
+		t.Errorf("namespace = %q, want empty", env.Harnesses[0].Namespace)
+	}
 }
 
 func TestCmdListMultipleHarnesses(t *testing.T) {

--- a/cmd/ynh/search.go
+++ b/cmd/ynh/search.go
@@ -64,7 +64,11 @@ func cmdSearchTo(args []string, stdout, stderr io.Writer) error {
 
 // searchResultEntry is a unified result from both registries and local sources.
 type searchResultEntry struct {
-	Name        string     `json:"name"`
+	Name string `json:"name"`
+	// Namespace is the URL-derived "<org>/<repo>" for registry results.
+	// Empty for local-source results. Lets consumers preview the
+	// namespace they'll see post-install without a separate lookup.
+	Namespace   string     `json:"namespace,omitempty"`
 	Description string     `json:"description,omitempty"`
 	Keywords    []string   `json:"keywords,omitempty"`
 	Repo        string     `json:"repo,omitempty"`
@@ -91,6 +95,7 @@ func unifiedSearch(cfg *config.Config, query string) ([]searchResultEntry, error
 		for _, r := range registry.Search(regs, query) {
 			entry := searchResultEntry{
 				Name:        r.Entry.Name,
+				Namespace:   r.Entry.Namespace,
 				Description: r.Entry.Description,
 				Keywords:    r.Entry.Keywords,
 				Repo:        r.Entry.Repo,

--- a/test/e2e/json_envelope_test.go
+++ b/test/e2e/json_envelope_test.go
@@ -17,6 +17,7 @@ type envelopeLs struct {
 
 type envelopeItem struct {
 	Name             string             `json:"name"`
+	Namespace        string             `json:"namespace,omitempty"`
 	VersionInstalled string             `json:"version_installed"`
 	Description      string             `json:"description,omitempty"`
 	DefaultVendor    string             `json:"default_vendor,omitempty"`

--- a/test/e2e/registry_local_test.go
+++ b/test/e2e/registry_local_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -57,6 +58,41 @@ func TestInstall_FromRegistryName(t *testing.T) {
 	if !strings.Contains(out, "registry") {
 		t.Errorf("expected install to record source_type=registry, got:\n%s", out)
 	}
+
+	// `ls --format json` must surface the URL-derived namespace so consumers
+	// can disambiguate same-named harnesses across registries. Regression
+	// guard: the field was previously dropped from the output DTO.
+	wantNS := registryNamespace(regURL)
+	var ls envelopeLs
+	if err := json.Unmarshal([]byte(out), &ls); err != nil {
+		t.Fatalf("parsing ls JSON: %v\n%s", err, out)
+	}
+	var found *envelopeItem
+	for i := range ls.Harnesses {
+		if ls.Harnesses[i].Name == "regd" {
+			found = &ls.Harnesses[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("regd not in ls envelope:\n%s", out)
+	}
+	assertEqual(t, "harnesses[regd].namespace", found.Namespace, wantNS)
+
+	// `search --format json` must include namespace on registry entries so
+	// consumers can preview the namespace pre-install.
+	searchOut, _ := s.mustRunYnh(t, "search", "regd", "--format", "json")
+	var results []struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(searchOut), &results); err != nil {
+		t.Fatalf("parsing search JSON: %v\n%s", err, searchOut)
+	}
+	if len(results) == 0 {
+		t.Fatalf("search returned no results:\n%s", searchOut)
+	}
+	assertEqual(t, "search[0].namespace", results[0].Namespace, wantNS)
 }
 
 // TestRegistry_NamespaceCollision verifies that two registries publishing a


### PR DESCRIPTION
## Summary

- `ynh ls --format json` and `ynh search --format json` were collecting namespace internally but dropping it from the output DTOs. Registry installs derive a namespace from the URL (`eyelock/assistants`), the install path stamps it onto `installed.json`, and `ListAll`/`Harness.Load` read it back — but `listEntry` and `searchResultEntry` had no `namespace` JSON tag, so consumers (e.g. TermQ) saw `null`/missing on every entry.
- Add `namespace` (`omitempty`) to both output structs, populated from `Harness.Namespace` and registry `Entry.Namespace` respectively. Flat installs continue to emit no `namespace` key.
- Adds an E2E assertion. The existing `TestInstall_FromRegistryName` only string-contained `"regd"`/`"registry"` and never asserted the namespace JSON shape — that's the gap that let this slip through. Now parses the `ls` envelope and asserts `harnesses[].namespace`, plus the equivalent on `search --format json`.

## Test plan

- [x] `make check` (lint, format, test with race) — green
- [x] `make e2e` — green (48.7s, full suite)
- [x] `/evals` — PASS, 11 tutorials, 0 failures
- [x] CI green on PR