### PR TITLE
fix(resolver): retry transient shallow-clone failures

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -204,12 +204,7 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 			return RepoResult{Path: repoDir, SHA: gitHead(repoDir), Cloned: true, Changed: true}, nil
 		}
 		// Branch/tag: use clone --branch for the depth-1 shortcut.
-		args := []string{"clone", "--depth", "1"}
-		if ref != "" {
-			args = append(args, "--branch", ref)
-		}
-		args = append(args, fullURL, repoDir)
-		if err := gitCmd(args...); err != nil {
+		if err := shallowCloneWithRetry(fullURL, ref, repoDir); err != nil {
 			return RepoResult{}, fmt.Errorf("git clone %s: %w", fullURL, err)
 		}
 		return RepoResult{Path: repoDir, SHA: gitHead(repoDir), ResolvedRef: effectiveRef(repoDir, ref), Cloned: true, Changed: true}, nil
@@ -247,12 +242,7 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 		if err := os.RemoveAll(repoDir); err != nil {
 			return RepoResult{}, fmt.Errorf("removing stale registry cache: %w", err)
 		}
-		args := []string{"clone", "--depth", "1"}
-		if ref != "" {
-			args = append(args, "--branch", ref)
-		}
-		args = append(args, fullURL, repoDir)
-		if err := gitCmd(args...); err != nil {
+		if err := shallowCloneWithRetry(fullURL, ref, repoDir); err != nil {
 			return RepoResult{}, fmt.Errorf("git clone %s: %w", fullURL, err)
 		}
 		return RepoResult{Path: repoDir, SHA: gitHead(repoDir), ResolvedRef: effectiveRef(repoDir, ref), Cloned: true, Changed: true}, nil
@@ -468,6 +458,41 @@ var shaLike = regexp.MustCompile(`^[0-9a-f]{40}$`)
 
 func isShaLike(ref string) bool {
 	return shaLike.MatchString(ref)
+}
+
+// isTransientShallowErr reports whether err looks like a known transient
+// git shallow-clone failure that a clean retry can resolve. Git can
+// intermittently produce these on `clone --depth 1` when its own internal
+// state races against the just-written shallow file or a stale lock from
+// an interrupted prior run.
+func isTransientShallowErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "shallow file has changed") ||
+		strings.Contains(s, "shallow.lock") ||
+		strings.Contains(s, "index.lock")
+}
+
+// shallowCloneWithRetry runs `git clone --depth 1 [--branch ref] url dir`,
+// retrying once on transient shallow-clone errors. dir is removed between
+// attempts so the retry sees a clean slate.
+func shallowCloneWithRetry(url, ref, dir string) error {
+	args := []string{"clone", "--depth", "1"}
+	if ref != "" {
+		args = append(args, "--branch", ref)
+	}
+	args = append(args, url, dir)
+
+	err := gitCmd(args...)
+	if err == nil || !isTransientShallowErr(err) {
+		return err
+	}
+	if rmErr := os.RemoveAll(dir); rmErr != nil {
+		return fmt.Errorf("removing partial clone before retry: %w", rmErr)
+	}
+	return gitCmd(args...)
 }
 
 // cloneAtSHA materialises a shallow checkout of url at sha into dir.

--- a/internal/resolver/resolver_cache_test.go
+++ b/internal/resolver/resolver_cache_test.go
@@ -462,6 +462,75 @@ func TestEnsureRepo_ShallowCorruption_RecoversViaReclone(t *testing.T) {
 	}
 }
 
+func TestEnsureRepo_FreshClone_TransientShallowError_RetryRecovers(t *testing.T) {
+	srcDir := t.TempDir()
+	runGit(t, srcDir, "init")
+	runGit(t, srcDir, "config", "user.email", "test@test.com")
+	runGit(t, srcDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(srcDir, "data.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, srcDir, "add", ".")
+	runGit(t, srcDir, "commit", "-m", "init")
+
+	t.Setenv("YNH_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	// First clone call fails with the exact transient error git emits when
+	// its shallow file changes mid-operation. Subsequent calls delegate to
+	// real git so the retry succeeds.
+	callCount := 0
+	orig := gitCmdFunc
+	t.Cleanup(func() { gitCmdFunc = orig })
+	gitCmdFunc = func(args ...string) error {
+		callCount++
+		isClone := len(args) > 0 && args[0] == "clone"
+		if callCount == 1 && isClone {
+			return errors.New("exit status 128\nfatal: shallow file has changed since we read it")
+		}
+		return orig(args...)
+	}
+
+	result, err := EnsureRepo(srcDir, "")
+	if err != nil {
+		t.Fatalf("EnsureRepo should retry on transient shallow error: %v", err)
+	}
+	if !result.Cloned {
+		t.Error("expected Cloned=true after retry")
+	}
+	data, err := os.ReadFile(filepath.Join(result.Path, "data.txt"))
+	if err != nil {
+		t.Fatalf("file not readable after retry: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("unexpected content: %q", string(data))
+	}
+	if callCount < 2 {
+		t.Errorf("expected at least 2 git calls (initial + retry), got %d", callCount)
+	}
+}
+
+func TestEnsureRepo_FreshClone_NonTransientError_DoesNotRetry(t *testing.T) {
+	t.Setenv("YNH_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	callCount := 0
+	orig := gitCmdFunc
+	t.Cleanup(func() { gitCmdFunc = orig })
+	gitCmdFunc = func(args ...string) error {
+		callCount++
+		return errors.New("exit status 128\nfatal: repository not found")
+	}
+
+	_, err := EnsureRepo("https://example.invalid/missing.git", "")
+	if err == nil {
+		t.Fatal("expected error for non-transient failure")
+	}
+	if callCount != 1 {
+		t.Errorf("expected exactly 1 git call (no retry on non-transient error), got %d", callCount)
+	}
+}
+
 func TestEnsureRepo_ExistingDirWithoutGit_ClonesClean(t *testing.T) {
 	srcDir := t.TempDir()
 	runGit(t, srcDir, "init")


### PR DESCRIPTION
## Summary

`git clone --depth 1` intermittently fails with `fatal: shallow file has changed since we read it` (and similar `.lock` races). On a fresh `ynh search` with no prior cache, this propagated to consumers as a hard error even though a single retry reliably fixed it. TermQ's Install Harness sheet was hitting this on first open.

The previous code only had recovery logic on the **fetch** path — checking for `.lock` substrings — which left the **fresh-clone** path with zero retry. The existing `TestEnsureRepo_ShallowCorruption_RecoversViaReclone` test masked the gap because it exercised an existing-cache scenario.

## Changes

- New `isTransientShallowErr` helper matches `shallow file has changed`, `shallow.lock`, `index.lock`.
- New `shallowCloneWithRetry` runs `git clone --depth 1 [--branch ref]` once, and on transient error wipes the partial dir and retries once. Non-transient errors fail fast.
- Both clone sites in `EnsureRepo` (fresh clone and post-fetch nuke-and-reclone) route through the helper.
- Two new tests: `FreshClone_TransientShallowError_RetryRecovers` (verifies retry path) and `FreshClone_NonTransientError_DoesNotRetry` (verifies we don't paper over real failures).

## Test plan

- [x] `make check` — format, lint, test (race), build all green
- [x] `/evals` — 24/24 PASS, no regressions
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)