### PR TITLE
fix(install): canonical id name segment selects sub-harness in monorepo

### DIFF
--- a/cmd/ynh/install_resolve.go
+++ b/cmd/ynh/install_resolve.go
@@ -22,6 +22,13 @@ type resolvedSource struct {
 	registryName string // non-empty for registry lookups (user-declared label)
 	namespace    string // non-empty for registry lookups (URL-derived "org/repo")
 	sourceName   string // non-empty for source lookups (config source name)
+	// nameHint is the trailing segment of a canonical id when we don't
+	// know its in-repo path yet — e.g. for "github.com/org/repo/researcher"
+	// the harness might live at the root, at "harnesses/researcher/", or
+	// anywhere else under the cloned repo. Post-clone discovery scans for
+	// a manifest with this name and sets path accordingly. Empty for refs
+	// where the path is already known (registry lookups, 5+-segment ids).
+	nameHint string
 }
 
 // resolveInstallSource applies disambiguation rules to determine the source type.
@@ -65,17 +72,22 @@ func resolveInstallSource(source, existingPath string, cfg *config.Config) (reso
 				"%q is a local canonical id; install from a filesystem path instead "+
 					"(e.g. 'ynh install ./path/to/harness')", source)
 		}
-		// Canonical ids with more than four segments encode an implicit
-		// --path for monorepos — e.g. github.com/eyelock/assistants/e2e-fixtures/minimal.
-		// For four-segment ids the trailing segment is the harness name
-		// at repo root; we don't set a path so the existing root-level
-		// harness loader handles it. The user's explicit --path takes
-		// precedence (handled by the caller).
-		var path string
+		// Canonical id segments after host/org/repo decompose into either
+		// an explicit subpath (5+ segments — e.g.
+		// github.com/eyelock/assistants/e2e-fixtures/minimal → path
+		// "e2e-fixtures/minimal") or a name hint (4 segments — e.g.
+		// github.com/eyelock/assistants/researcher → "find harness named
+		// researcher anywhere in the cloned repo"). The four-segment case
+		// can't assume the harness lives at the repo root because monorepos
+		// commonly nest harnesses under harnesses/<name>/ or similar; the
+		// caller does post-clone discovery to resolve the actual subpath.
+		var path, nameHint string
 		if strings.Contains(withinRepoPath, "/") {
 			path = withinRepoPath
+		} else {
+			nameHint = withinRepoPath
 		}
-		return resolvedSource{sourceType: "git", gitURL: cloneURL, path: path}, nil
+		return resolvedSource{sourceType: "git", gitURL: cloneURL, path: path, nameHint: nameHint}, nil
 	}
 
 	// Rule 5b: Contains / → Git URL shorthand

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/eyelock/ynh/internal/pathutil"
 	"github.com/eyelock/ynh/internal/plugin"
 	"github.com/eyelock/ynh/internal/resolver"
+	"github.com/eyelock/ynh/internal/sources"
 	"github.com/eyelock/ynh/internal/symlink"
 	"github.com/eyelock/ynh/internal/vendor"
 )
@@ -310,6 +311,48 @@ func cmdInstall(args []string) error {
 		// can record them. Empty for local installs (set in the local branch).
 		harnessSHA = result.SHA
 		harnessResolvedRef = result.ResolvedRef
+	}
+
+	// Canonical-id installs with a name-hint (e.g.
+	// github.com/eyelock/assistants/researcher) don't know where in the
+	// cloned repo the harness lives — the trailing "researcher" segment
+	// is a name to find, not a path. Discover the matching harness by name
+	// and use its directory as the source. The user's explicit --path
+	// takes precedence; we only run discovery when --path is absent.
+	if pathFlag == "" && resolved.nameHint != "" {
+		discovered, derr := sources.Discover(srcDir, 4)
+		if derr == nil {
+			for _, h := range discovered {
+				if h.Name == resolved.nameHint {
+					rel, relErr := filepath.Rel(srcDir, h.Path)
+					if relErr == nil && rel != "." {
+						pathFlag = rel
+					}
+					break
+				}
+			}
+		}
+		if pathFlag == "" {
+			// Last resort: see if there's a harness at the repo root with
+			// the right name. loadOrSynthesizeHarness below handles that
+			// implicitly, but only when the manifest's name matches the
+			// hint. If discovery didn't find anything and the root manifest
+			// (if any) doesn't match, error out with a clear hint instead
+			// of silently installing a different harness.
+			rootHarness, rerr := plugin.LoadHarnessJSON(srcDir)
+			rootMatches := rerr == nil && rootHarness != nil && rootHarness.Name == resolved.nameHint
+			if !rootMatches && plugin.IsPluginDir(srcDir) {
+				if hj, perr := plugin.LoadPluginJSON(srcDir); perr == nil && hj != nil && hj.Name == resolved.nameHint {
+					rootMatches = true
+				}
+			}
+			if !rootMatches {
+				return fmt.Errorf(
+					"no harness named %q found in %s; the canonical id ends in %q but the cloned repo has no matching manifest. "+
+						"Pass --path <subdir> if the harness lives at a non-default location",
+					resolved.nameHint, source, resolved.nameHint)
+			}
+		}
 	}
 
 	// Scope to subdirectory if --path was specified


### PR DESCRIPTION
## Summary

Fixes the second install-via-canonical-id regression TermQ flagged after PR-4. PR #127 already fixed the "git clone fails on the verbatim canonical id" case, but the four-segment form (e.g. `github.com/eyelock/assistants/researcher`) still discarded the trailing `researcher` segment — the install ended up named after the cache hash and the canonical id didn't round-trip.

## Reproduction (before fix)

```
$ ynh install github.com/eyelock/assistants/researcher
Installed harness "eyelock--assistants--ae2a6167"
  Location: ~/.ynh/harnesses/github.com--eyelock--assistants--eyelock--assistants--ae2a6167
$ ynh info github.com/eyelock/assistants/researcher
Error: harness not found
```

## What changed

`resolvedSource` gains a `nameHint` field. `canonicalIDToClone` populates it for **four-segment ids** ("the trailing segment is a harness name to find within the cloned repo"). **Five-segment-or-longer ids** continue to populate `path` directly (segments after host/org/repo are an explicit subpath).

`cmdInstall`, after clone, runs `sources.Discover` against the cloned repo when `nameHint` is set and `--path` is empty. The matching harness's relative path becomes the implicit `--path`. If no manifest in the repo carries the hinted name, install errors with a clear hint pointing at `--path` as the override.

## Verified

```
$ ynh install github.com/eyelock/assistants/researcher
Installed harness "researcher"
  Location: ~/.ynh/harnesses/github.com--eyelock--assistants--researcher

$ ynh info github.com/eyelock/assistants/researcher  # round-trips
Name: researcher
...

$ ynh ls --format json | jq '.harnesses[].id'
"github.com/eyelock/assistants/researcher"
```

## Test plan

- [x] `make check` — format, lint, test, build all pass
- [x] `make e2e` — full E2E suite passes (~44s)
- [x] Manual repro of TermQ's blocker scenario, end-to-end round-trip via `ynh install` → `ynh info` → `ynh ls`
- [x] TermQ verified the binary at `dev-fix-canonical-id-install-name-41b15ea`

This was the last known blocker on TermQ's `harness.id` cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)