### PR TITLE
fix(resolver): serialize concurrent cache access with file lock

### DIFF
--- a/internal/resolver/lock_other.go
+++ b/internal/resolver/lock_other.go
@@ -1,0 +1,12 @@
+//go:build !unix
+
+package resolver
+
+// withRepoLock is a no-op on non-unix platforms. ynh ships only darwin and
+// linux builds; this stub exists so cross-compilation to other platforms
+// (e.g. GOOS=windows go build for sanity-checking) still succeeds. There is
+// no inter-process locking on these platforms — concurrent ynh invocations
+// on the same cache entry can still race.
+func withRepoLock(_ string, fn func() error) error {
+	return fn()
+}

--- a/internal/resolver/lock_unix.go
+++ b/internal/resolver/lock_unix.go
@@ -1,0 +1,33 @@
+//go:build unix
+
+package resolver
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// withRepoLock acquires an exclusive advisory file lock at lockPath for the
+// duration of fn. The lock file is created if absent. Concurrent ynh
+// processes operating on the same cache entry block on the lock instead of
+// racing each other (and tripping over partial clones, in-flight RemoveAll,
+// or git's own .git/config writes).
+//
+// The lock file itself is left in place; flock state is per-fd and released
+// when the file is closed. Removing the file would race with peers that
+// already hold an open fd on it.
+func withRepoLock(lockPath string, fn func() error) error {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening cache lock %s: %w", lockPath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("locking cache %s: %w", lockPath, err)
+	}
+	defer func() { _ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }()
+
+	return fn()
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -189,6 +189,20 @@ func EnsureRepo(gitURL string, ref string) (RepoResult, error) {
 	repoDir := filepath.Join(cacheDir, repoDirName(gitURL, ref))
 	fullURL := NormalizeGitURL(gitURL)
 
+	// Serialize concurrent ynh processes against this same cache entry —
+	// without this, racing RemoveAll/clone calls produced "directory not
+	// empty" and "could not lock config file" errors when e.g. a TUI fired
+	// multiple ynh invocations in parallel.
+	var result RepoResult
+	lockErr := withRepoLock(repoDir+".lock", func() error {
+		r, err := ensureRepoLocked(repoDir, fullURL, ref)
+		result = r
+		return err
+	})
+	return result, lockErr
+}
+
+func ensureRepoLocked(repoDir, fullURL, ref string) (RepoResult, error) {
 	if _, err := os.Stat(filepath.Join(repoDir, ".git")); os.IsNotExist(err) {
 		// No .git dir — remove any partial/pre-existing directory before cloning.
 		if err := os.RemoveAll(repoDir); err != nil {

--- a/internal/resolver/resolver_cache_test.go
+++ b/internal/resolver/resolver_cache_test.go
@@ -654,3 +654,50 @@ func TestResolveFromCache_WithPath(t *testing.T) {
 		t.Errorf("expected Path=%q, got %q", "pkg", results[0].Path)
 	}
 }
+
+func TestEnsureRepo_ConcurrentCallers_DoNotRace(t *testing.T) {
+	srcDir := t.TempDir()
+	runGit(t, srcDir, "init")
+	runGit(t, srcDir, "config", "user.email", "test@test.com")
+	runGit(t, srcDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(srcDir, "data.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, srcDir, "add", ".")
+	runGit(t, srcDir, "commit", "-m", "init")
+
+	t.Setenv("YNH_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+
+	const N = 8
+	errs := make(chan error, N)
+	paths := make(chan string, N)
+	for i := 0; i < N; i++ {
+		go func() {
+			r, err := EnsureRepo(srcDir, "")
+			errs <- err
+			paths <- r.Path
+		}()
+	}
+	for i := 0; i < N; i++ {
+		if err := <-errs; err != nil {
+			t.Errorf("concurrent EnsureRepo failed: %v", err)
+		}
+	}
+	var first string
+	for i := 0; i < N; i++ {
+		p := <-paths
+		if i == 0 {
+			first = p
+			continue
+		}
+		if p != first {
+			t.Errorf("inconsistent repo path across concurrent callers: %q vs %q", first, p)
+		}
+	}
+	if data, err := os.ReadFile(filepath.Join(first, "data.txt")); err != nil {
+		t.Errorf("cache contents missing after concurrent callers: %v", err)
+	} else if string(data) != "hello" {
+		t.Errorf("cache contents corrupted: %q", string(data))
+	}
+}


### PR DESCRIPTION
## Summary

- Wrap `EnsureRepo` body in an exclusive `flock` on `<repoDir>.lock` so concurrent `ynh` processes serialize on the same cache entry.
- Add `lock_unix.go` (real impl via `syscall.Flock`) and `lock_other.go` (no-op stub) — keeps zero external deps; ynh ships darwin + linux only.
- Add `TestEnsureRepo_ConcurrentCallers_DoNotRace` — 8 parallel callers against a local source repo.

## Why

Concurrent `ynh` invocations on the same cache entry (e.g. a TUI firing list refresh + install dialog registry fetch in parallel) raced inside `EnsureRepo` and surfaced as:

```
removing stale registry cache: unlinkat .../cache/<key>: directory not empty
could not lock config file .../<key>/.git/config: No such file or directory
fatal: could not set 'core.repositoryformatversion' to '0'
```

The prior shallow-clone retry (#124) only covers intra-process git flakes; here a peer process is actively `RemoveAll`-ing the dir while another is mid-clone, so retry-once doesn't help. File locking is the right primitive.

## Test plan

- [x] `make check` — format, lint, race-tests, build all green
- [x] New concurrency test passes under `-race`
- [x] `/evals` — 19 tutorials + 15 error cases, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)