### PR TITLE
docs: document delegates as remote-only

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -499,6 +499,16 @@ Test fixtures in `testdata/` simulate real-world sources:
 
 `name` and `version` are required for installed harnesses. For project-local manifests (loaded via `--harness-file` or auto-discovered in cwd), they are optional. See the JSON schema at `docs/schema/harness.schema.json` for the full specification. See [Hooks](docs/hooks.md), [MCP Servers](docs/mcp.md), [Profiles](docs/profiles.md), and the focus tutorial (`docs/tutorial/14-focus.md`) for details.
 
+### Delegates: remote-only
+
+Unlike `includes`, `delegates_to` entries must be remote git URLs. The `local` source form is not supported and the schema rejects it. Reasons:
+
+- **Portability.** A delegate path baked into a committed `plugin.json` either breaks on another machine or — worse — silently resolves to a different harness with the same path. Delegates are part of a harness's public contract; they need a stable, shareable identity.
+- **Identity.** ynh keys delegate matching, SHA backfill, and provenance on the git URL. A local path has no global identity, no SHA, and no ref to track.
+- **Post-install resolution.** A relative path written during authoring (`./sibling-harness`) does not resolve from the installed location (`~/.ynh/harnesses/<id>/`). Working pre-install but broken post-install is a worse failure mode than not supporting it at all.
+
+To iterate on a delegate locally, install it (`ynh install <path>`), then reference it by its canonical id from the parent harness — or test the parent with `ynd preview` against an in-tree manifest.
+
 ### Focus Entries
 
 Focus entries combine a profile + prompt for repeatable, non-interactive AI execution. When `ynh run --focus review` is invoked, ynh looks up the focus entry, applies its profile (if any), and sends its prompt to the vendor CLI via `LaunchNonInteractive`.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -40,7 +40,7 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | `ynh info <harness>` | `--format <text\|json>` |
 | `ynh vendors` | `--format <text\|json>` |
 | `ynh search [query]` | `--format <text\|json>` |
-| `ynh delegate add <harness> <url>` | `--ref`, `--path` |
+| `ynh delegate add <harness> <url>` | `--ref`, `--path` — `<url>` must be a git URL; local paths are not supported (see CONTRIBUTING.md "Delegates: remote-only") |
 | `ynh delegate remove <harness> <url>` | `--path` |
 | `ynh delegate update <harness> <url>` | `--from-path`, `--path`, `--ref` |
 | `ynh include add <harness> <url>` | `--path`, `--pick`, `--ref`, `--replace` |


### PR DESCRIPTION
## Summary

- Adds a `Delegates: remote-only` section to CONTRIBUTING.md explaining why `delegates_to` does not accept the `local` source form
- Adds a one-line note on the `ynh delegate add` row in `docs/reference.md`

The schema already rejects `local` on delegate entries (via `DisallowUnknownFields` in `LoadPluginJSON`); this just makes the limitation visible to authors.

Reasons documented:
- Portability — a baked-in local path breaks on other machines, or silently resolves to a different harness
- Identity — delegate matching, SHA backfill, and provenance all key on git URL; local has no stable identity
- Post-install resolution — relative paths don't resolve from `~/.ynh/harnesses/<id>/`

## Test plan
- [x] make check
- [ ] CI green