### PR TITLE
fix(delegate): validate harness target on add

### DIFF
--- a/cmd/ynh/delegate.go
+++ b/cmd/ynh/delegate.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/plugin"
 	"github.com/eyelock/ynh/internal/resolver"
 )
 
@@ -68,9 +71,17 @@ func cmdDelegateAdd(args []string, stdout io.Writer) error {
 	}
 
 	if installed {
-		gs := harness.GitSource{Git: url, Ref: opts.Ref}
-		if _, _, fetchErr := resolver.ResolveGitSource(gs); fetchErr != nil {
+		gs := harness.GitSource{Git: url, Ref: opts.Ref, Path: opts.Path}
+		basePath, _, fetchErr := resolver.ResolveGitSource(gs)
+		if fetchErr != nil {
 			return fmt.Errorf("fetching delegate: %w", fetchErr)
+		}
+		autoPath, vErr := validateDelegateTarget(basePath, url, opts.Path)
+		if vErr != nil {
+			return vErr
+		}
+		if opts.Path == "" && autoPath != "" {
+			opts.Path = autoPath
 		}
 	}
 
@@ -195,4 +206,45 @@ func cmdDelegateUpdate(args []string, stdout io.Writer) error {
 
 	_, _ = fmt.Fprintf(stdout, "Updated delegate %q\n", url)
 	return nil
+}
+
+// validateDelegateTarget verifies the resolved basePath points to exactly one
+// harness. Returns an immediate-subdir name to record as the auto-resolved path
+// when basePath is a repo containing a single harness in a subdir; returns ""
+// when basePath itself is the harness root.
+//
+// givenPath is the user-supplied --path (may be empty). When non-empty,
+// basePath already includes it, so we only check basePath itself and never
+// auto-resolve.
+func validateDelegateTarget(basePath, gitURL, givenPath string) (string, error) {
+	if plugin.IsPluginDir(basePath) {
+		return "", nil
+	}
+	if givenPath != "" {
+		return "", fmt.Errorf("delegate target has no harness manifest at %s/%s", gitURL, givenPath)
+	}
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		return "", fmt.Errorf("scanning delegate target: %w", err)
+	}
+	var found []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if plugin.IsPluginDir(filepath.Join(basePath, e.Name())) {
+			found = append(found, e.Name())
+		}
+	}
+	switch len(found) {
+	case 0:
+		return "", fmt.Errorf("delegate target has no harness manifest at %s", gitURL)
+	case 1:
+		return found[0], nil
+	default:
+		sort.Strings(found)
+		return "", fmt.Errorf(
+			"delegate target ambiguous — %s contains multiple harnesses (%s); specify one with --path <subdir>",
+			gitURL, strings.Join(found, ", "))
+	}
 }

--- a/cmd/ynh/delegate_test.go
+++ b/cmd/ynh/delegate_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -236,6 +238,97 @@ func TestCmdDelegateUpdate_Path(t *testing.T) {
 	dels := loadTestDelegates(t, dir)
 	if dels[0].Path != "new" {
 		t.Errorf("expected path=new, got %q", dels[0].Path)
+	}
+}
+
+// ---- validateDelegateTarget -----------------------------------------
+
+func writePluginManifest(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, plugin.PluginDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, plugin.PluginDir, plugin.PluginFile),
+		[]byte(`{"name":"x","version":"0.1.0"}`), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateDelegateTarget_RootIsHarness(t *testing.T) {
+	dir := t.TempDir()
+	writePluginManifest(t, dir)
+
+	got, err := validateDelegateTarget(dir, "github.com/acme/r", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty auto-path, got %q", got)
+	}
+}
+
+func TestValidateDelegateTarget_SingleSubdir(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "vendor-harness")
+	writePluginManifest(t, sub)
+
+	got, err := validateDelegateTarget(dir, "github.com/acme/r", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "vendor-harness" {
+		t.Errorf("expected auto-path %q, got %q", "vendor-harness", got)
+	}
+}
+
+func TestValidateDelegateTarget_Ambiguous(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"planner", "vendor-harness", "media"} {
+		writePluginManifest(t, filepath.Join(dir, name))
+	}
+
+	_, err := validateDelegateTarget(dir, "github.com/acme/r", "")
+	if err == nil {
+		t.Fatal("expected ambiguous error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "ambiguous") || !strings.Contains(msg, "--path") {
+		t.Errorf("expected ambiguous + --path hint, got: %q", msg)
+	}
+	for _, name := range []string{"planner", "vendor-harness", "media"} {
+		if !strings.Contains(msg, name) {
+			t.Errorf("expected %q in error, got: %q", name, msg)
+		}
+	}
+}
+
+func TestValidateDelegateTarget_NoManifest(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := validateDelegateTarget(dir, "github.com/acme/r", "")
+	if err == nil {
+		t.Fatal("expected no-manifest error")
+	}
+	if !strings.Contains(err.Error(), "no harness manifest") {
+		t.Errorf("expected no-manifest error, got: %v", err)
+	}
+}
+
+func TestValidateDelegateTarget_GivenPathMissing(t *testing.T) {
+	dir := t.TempDir()
+	// basePath has no manifest; givenPath was non-empty so basePath is the
+	// already-resolved subdir → must not auto-resolve.
+	_, err := validateDelegateTarget(dir, "github.com/acme/r", "subdir")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "github.com/acme/r/subdir") {
+		t.Errorf("expected resolved path in error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `validateDelegateTarget` to verify the resolved git source contains exactly one harness manifest on `ynh delegate add`
- Returns a clear error when the target has no manifest or when multiple harnesses exist (with a `--path` hint listing them alphabetically)
- Auto-records the subdir path when a repo contains a single harness in a subdirectory

## Test plan

- [ ] `TestValidateDelegateTarget_RootIsHarness` — root dir is a harness, no auto-path returned
- [ ] `TestValidateDelegateTarget_SingleSubdir` — single subdir harness auto-resolved
- [ ] `TestValidateDelegateTarget_Ambiguous` — multiple harnesses → error with `--path` hint and all names listed
- [ ] `TestValidateDelegateTarget_NoManifest` — no manifest anywhere → clear error
- [ ] `TestValidateDelegateTarget_GivenPathMissing` — explicit `--path` pointing at non-harness → error with full path

All pass locally. `make check` green. Evals PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)