### PR TITLE
fix(resolver): LsRemoteFunc exact-ref match prevents suffix-match phantom SHA

### DIFF
--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -657,6 +657,7 @@ func cmdUpdate(args []string) error {
 			checked++
 			harnessSHA = result.SHA
 			harnessResolvedRef = result.ResolvedRef
+			shaAdvanced := harnessSHA != "" && p.InstalledFrom != nil && harnessSHA != p.InstalledFrom.SHA
 			if result.Changed {
 				updated++
 				fmt.Printf("  Updated.\n")
@@ -677,6 +678,13 @@ func cmdUpdate(args []string) error {
 						p = reloaded
 					}
 				}
+			} else if shaAdvanced {
+				// Cache was already current but the recorded SHA in installed.json
+				// was stale (cache was advanced by a different operation). The SHA
+				// is being written below; count it as updated so callers know
+				// ref_installed changed.
+				updated++
+				fmt.Printf("  Updated.\n")
 			} else {
 				fmt.Printf("  Already up to date.\n")
 			}
@@ -704,7 +712,7 @@ func cmdUpdate(args []string) error {
 			Path: inc.Path,
 			SHA:  result.SHA,
 		})
-		if result.Changed {
+		if result.Changed || result.SHA != inc.SHA {
 			updated++
 			fmt.Printf("  Updated.\n")
 		} else {
@@ -728,7 +736,7 @@ func cmdUpdate(args []string) error {
 			Path: del.Path,
 			SHA:  result.SHA,
 		})
-		if result.Changed {
+		if result.Changed || result.SHA != del.SHA {
 			updated++
 			fmt.Printf("  Updated.\n")
 		} else {

--- a/cmd/ynh/update_drift_test.go
+++ b/cmd/ynh/update_drift_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/config"
+	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/plugin"
+	"github.com/eyelock/ynh/internal/resolver"
+)
+
+// TestCmdUpdate_UnpinnedInclude_AdvancesRefWhenCacheAlreadyFresh reproduces the
+// drift-after-update bug: the local git cache was advanced by a different
+// operation (e.g. another harness's update), so EnsureRepo returns Changed=false,
+// but installed.json still records the old SHA. cmdUpdate must still advance
+// ref_installed to the current cache HEAD.
+func TestCmdUpdate_UnpinnedInclude_AdvancesRefWhenCacheAlreadyFresh(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("YNH_HOME", "")
+
+	// Create a local git repo to act as the unpinned include source.
+	srcDir := t.TempDir()
+	initGitRepo(t, srcDir)
+	writeTestFile(t, filepath.Join(srcDir, "SKILL.md"), "---\nname: skill\ndescription: v1\n---\n")
+	runGitInDir(t, srcDir, "add", ".")
+	runGitInDir(t, srcDir, "commit", "-m", "v1")
+	sha1 := gitRevParse(t, srcDir)
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install the harness manually: plugin.json with unpinned include + installed.json at sha1.
+	installDir := harness.InstalledDirByID("local/driftharn")
+	if err := os.MkdirAll(filepath.Join(installDir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pluginJSON := fmt.Sprintf(`{"name":"driftharn","version":"0.1.0","default_vendor":"claude","includes":[{"git":%q}]}`, srcDir)
+	writeTestFile(t, filepath.Join(installDir, ".ynh-plugin", "plugin.json"), pluginJSON)
+	installedJSON := fmt.Sprintf(`{"source_type":"local","installed_at":"2024-01-01T00:00:00Z","resolved":[{"git":%q,"sha":%q}]}`, srcDir, sha1)
+	writeTestFile(t, filepath.Join(installDir, ".ynh-plugin", "installed.json"), installedJSON)
+
+	// Advance the remote to sha2.
+	writeTestFile(t, filepath.Join(srcDir, "SKILL.md"), "---\nname: skill\ndescription: v2\n---\n")
+	runGitInDir(t, srcDir, "add", ".")
+	runGitInDir(t, srcDir, "commit", "-m", "v2")
+	sha2 := gitRevParse(t, srcDir)
+
+	if sha1 == sha2 {
+		t.Fatal("sha1 == sha2: git commit did not advance HEAD")
+	}
+
+	// Pre-warm the cache to sha2 WITHOUT updating installed.json.
+	// This simulates "a different harness's update fetched the same source first".
+	if _, err := resolver.EnsureRepo(srcDir, ""); err != nil {
+		t.Fatalf("pre-warming cache: %v", err)
+	}
+
+	// At this point: cache HEAD = sha2, installed.json.resolved[0].sha = sha1.
+	// EnsureRepo will return Changed=false (cache already current).
+	// cmdUpdate must still advance ref_installed to sha2.
+	if err := cmdUpdate([]string{"local/driftharn"}); err != nil {
+		t.Fatalf("cmdUpdate: %v", err)
+	}
+
+	ins, err := plugin.LoadInstalledJSON(installDir)
+	if err != nil {
+		t.Fatalf("loading installed.json after update: %v", err)
+	}
+
+	var foundSHA string
+	for _, r := range ins.Resolved {
+		if r.Git == srcDir {
+			foundSHA = r.SHA
+		}
+	}
+	if foundSHA == "" {
+		t.Fatalf("no resolved entry for %q in installed.json; resolved=%v", srcDir, ins.Resolved)
+	}
+	if foundSHA != sha2 {
+		t.Errorf("ref_installed after update = %q, want %q (sha2); drift not resolved", foundSHA, sha2)
+	}
+}
+
+// TestCmdUpdate_UnpinnedInclude_CountsUpdateWhenCachePreceded ensures that when
+// EnsureRepo returns Changed=false but the cache is ahead of ref_installed, the
+// update still increments the updated-source count and reports correctly.
+func TestCmdUpdate_UnpinnedInclude_CountsUpdateWhenCachePreceded(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("YNH_HOME", "")
+
+	srcDir := t.TempDir()
+	initGitRepo(t, srcDir)
+	writeTestFile(t, filepath.Join(srcDir, "file.txt"), "v1")
+	runGitInDir(t, srcDir, "add", ".")
+	runGitInDir(t, srcDir, "commit", "-m", "v1")
+	sha1 := gitRevParse(t, srcDir)
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	installDir := harness.InstalledDirByID("local/countharn")
+	if err := os.MkdirAll(filepath.Join(installDir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pluginJSON := fmt.Sprintf(`{"name":"countharn","version":"0.1.0","default_vendor":"claude","includes":[{"git":%q}]}`, srcDir)
+	writeTestFile(t, filepath.Join(installDir, ".ynh-plugin", "plugin.json"), pluginJSON)
+	installedJSON := fmt.Sprintf(`{"source_type":"local","installed_at":"2024-01-01T00:00:00Z","resolved":[{"git":%q,"sha":%q}]}`, srcDir, sha1)
+	writeTestFile(t, filepath.Join(installDir, ".ynh-plugin", "installed.json"), installedJSON)
+
+	// Advance the remote and pre-warm the cache (cache ahead of installed.json).
+	writeTestFile(t, filepath.Join(srcDir, "file.txt"), "v2")
+	runGitInDir(t, srcDir, "add", ".")
+	runGitInDir(t, srcDir, "commit", "-m", "v2")
+	sha2 := gitRevParse(t, srcDir)
+
+	if _, err := resolver.EnsureRepo(srcDir, ""); err != nil {
+		t.Fatalf("pre-warming cache: %v", err)
+	}
+
+	if err := cmdUpdate([]string{"local/countharn"}); err != nil {
+		t.Fatalf("cmdUpdate: %v", err)
+	}
+
+	ins, err := plugin.LoadInstalledJSON(installDir)
+	if err != nil {
+		t.Fatalf("loading installed.json: %v", err)
+	}
+	for _, r := range ins.Resolved {
+		if r.Git == srcDir && r.SHA != sha2 {
+			t.Errorf("ref_installed = %q, want %q", r.SHA, sha2)
+		}
+	}
+}
+
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	runGitInDir(t, dir, "init")
+	runGitInDir(t, dir, "config", "user.email", "test@test.com")
+	runGitInDir(t, dir, "config", "user.name", "Test")
+}
+
+func runGitInDir(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+}
+
+func gitRevParse(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD in %s: %v", dir, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", filepath.Base(path), err)
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -415,13 +415,35 @@ var LsRemoteFunc = func(gitURL, ref string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("git ls-remote %s: %w", fullURL, err)
 	}
-	// First whitespace-separated token of the first line is the SHA.
-	line := strings.SplitN(strings.TrimSpace(string(out)), "\n", 2)[0]
-	fields := strings.Fields(line)
-	if len(fields) == 0 {
-		return "", fmt.Errorf("git ls-remote %s: no output", fullURL)
+
+	// git ls-remote does suffix pattern matching: passing "main" also matches
+	// branches like "daisy/caffeinate/main". Parse all lines and return the
+	// SHA whose refname is an exact match on the intended canonical name.
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		sha, refName := fields[0], fields[1]
+		if ref == "" {
+			// HEAD probe: accept "HEAD" or any refs/heads/<branch>.
+			if refName == "HEAD" || strings.HasPrefix(refName, "refs/heads/") {
+				return sha, nil
+			}
+			continue
+		}
+		// Named ref: accept an already-qualified ref as-is; otherwise require
+		// an exact refs/heads/<ref> or refs/tags/<ref> match so partial-name
+		// branches (e.g. foo/main) don't shadow the intended target.
+		if strings.HasPrefix(ref, "refs/") {
+			if refName == ref {
+				return sha, nil
+			}
+		} else if refName == "refs/heads/"+ref || refName == "refs/tags/"+ref {
+			return sha, nil
+		}
 	}
-	return fields[0], nil
+	return "", fmt.Errorf("git ls-remote %s: ref %q not found in remote", fullURL, ref)
 }
 
 // PurgeCacheDirsForURL removes all cache directories associated with the given

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -624,3 +624,60 @@ func TestResolveGitSource_PathTraversalBlocked(t *testing.T) {
 		}
 	}
 }
+
+// TestLsRemoteFunc_ExactRefMatch ensures that LsRemoteFunc resolves "main" to
+// refs/heads/main only, even when the remote also contains branches whose names
+// end in "/main" (e.g. "daisy/caffeinate/main"). Without exact-match filtering
+// git ls-remote does suffix pattern matching and returns the ambiguous branch
+// first, which caused phantom ref_available drift in ynh status.
+func TestLsRemoteFunc_ExactRefMatch(t *testing.T) {
+	// Build a local bare-ish repo with two branches: "main" and "shadow/main".
+	srcDir := t.TempDir()
+	runGit(t, srcDir, "init", "-b", "main")
+	runGit(t, srcDir, "config", "user.email", "test@test.com")
+	runGit(t, srcDir, "config", "user.name", "Test")
+
+	// First commit on main.
+	f := filepath.Join(srcDir, "file.txt")
+	if err := os.WriteFile(f, []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, srcDir, "add", ".")
+	runGit(t, srcDir, "commit", "-m", "v1")
+	mainSHA := strings.TrimSpace(func() string {
+		cmd := exec.Command("git", "-C", srcDir, "rev-parse", "HEAD")
+		out, _ := cmd.Output()
+		return string(out)
+	}())
+
+	// Create shadow/main at a different commit.
+	runGit(t, srcDir, "checkout", "-b", "shadow/main")
+	if err := os.WriteFile(f, []byte("shadow"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, srcDir, "add", ".")
+	runGit(t, srcDir, "commit", "-m", "shadow")
+	shadowSHA := strings.TrimSpace(func() string {
+		cmd := exec.Command("git", "-C", srcDir, "rev-parse", "HEAD")
+		out, _ := cmd.Output()
+		return string(out)
+	}())
+
+	// Switch back to main so HEAD points there.
+	runGit(t, srcDir, "checkout", "main")
+
+	if mainSHA == shadowSHA {
+		t.Fatal("mainSHA == shadowSHA: branches are identical, test is invalid")
+	}
+
+	got, err := LsRemoteFunc(srcDir, "main")
+	if err != nil {
+		t.Fatalf("LsRemoteFunc: %v", err)
+	}
+	if got != mainSHA {
+		t.Errorf("LsRemoteFunc(main) = %q, want %q (refs/heads/main SHA); got shadow/main SHA instead", got, mainSHA)
+	}
+	if got == shadowSHA {
+		t.Errorf("LsRemoteFunc returned shadow/main SHA — suffix-match bug not fixed")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a phantom drift bug in `ynh status`: for harnesses with unpinned git includes, the amber triangle would persist even after `ynh update` completed successfully.

**Root cause:** `git ls-remote <url> main` uses suffix pattern matching — it also returns branches like `daisy/caffeinate/main` before `refs/heads/main`. `LsRemoteFunc` was taking the first output line, so any repo with ambiguous branch names returned the wrong SHA as `ref_available`, making `ynh status` report permanent drift.

## Changes

- `internal/resolver/resolver.go`: `LsRemoteFunc` now parses all `git ls-remote` output lines and returns the SHA for the exact canonical ref (`refs/heads/<ref>` or `refs/tags/<ref>`), falling through to an error if no exact match is found.
- `internal/resolver/resolver_test.go`: Regression test `TestLsRemoteFunc_ExactRefMatch` — creates a local repo with both `main` and `shadow/main` at different commits, asserts that probing `"main"` returns only `refs/heads/main`'s SHA.

Also includes the independently-correct fix from the earlier commit (`2299f67`): `cmdUpdate` now advances `installed.json` and increments the updated count when the git cache is already ahead of `ref_installed` (a separate scenario where `EnsureRepo` returns `Changed=false` but the cache was warmed by a concurrent update to a different harness sharing the same source).

## Testing

- [x] `make check` passes (all tests, lint, build)
- [x] `TestLsRemoteFunc_ExactRefMatch` reproduces and verifies the fix
- [x] `TestCmdUpdate_UnpinnedInclude_AdvancesRefWhenCacheAlreadyFresh` covers the cache-ahead scenario

## Related Issues

Fixes phantom `ref_available` drift where `ynh status` shows amber triangle but `ynh update` reports "0 updated".

🤖 Generated with [Claude Code](https://claude.com/claude-code)