### PR TITLE
fix(harness): resolve local/ pointer IDs via schema-1 name-keyed fallback

### DIFF
--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -45,6 +45,12 @@ func ResolveEditTarget(ref string) (dir string, installed bool, err error) {
 		if ptr, _ := LoadPointerByID(ref); ptr != nil {
 			return ptr.Source, true, nil
 		}
+		// Schema-1 fallback: fork created before schema-2 pointer writer landed.
+		if name, ok := strings.CutPrefix(ref, "local/"); ok {
+			if ptr, _ := LoadPointer(name); ptr != nil {
+				return ptr.Source, true, nil
+			}
+		}
 		return "", false, fmt.Errorf("harness %q: %w", ref, ErrNotFound)
 	default:
 		return "", false, BadRefError(ref)

--- a/internal/harness/editor_test.go
+++ b/internal/harness/editor_test.go
@@ -105,6 +105,38 @@ func TestResolveEditTarget_PathNoHarness(t *testing.T) {
 	}
 }
 
+// TestResolveEditTarget_Schema1PointerFallback verifies that ResolveEditTarget
+// resolves "local/<name>" when only a schema-1 name-keyed pointer file exists
+// (no local--<name>.json). Regression test for the pointer-writer bug where
+// ynh fork wrote schema-1 files into a schema-2 home.
+func TestResolveEditTarget_Schema1PointerFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	forkDir := t.TempDir()
+	writeForkTree(t, forkDir, "my-fork")
+
+	if err := SavePointer(&Pointer{
+		Name:        "my-fork",
+		SourceType:  "local",
+		Source:      forkDir,
+		InstalledAt: "2026-05-08T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, installed, err := ResolveEditTarget("local/my-fork")
+	if err != nil {
+		t.Fatalf("ResolveEditTarget: %v", err)
+	}
+	if got != forkDir {
+		t.Errorf("dir = %q, want %q", got, forkDir)
+	}
+	if !installed {
+		t.Error("expected installed=true for pointer-backed ref")
+	}
+}
+
 // ---- AddInclude -------------------------------------------------------
 
 func TestAddInclude_New(t *testing.T) {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -401,9 +401,13 @@ func InstalledDirByID(id string) string {
 // LoadByID loads an installed harness by its canonical id. Resolution
 // precedence under schema 2:
 //  1. Pointer file at ~/.ynh/installed/<id-fsname>.json (local fork / alias)
-//  2. Tree at ~/.ynh/harnesses/<id-fsname>/
+//  2. Schema-1 fallback: for "local/<name>" ids, name-keyed pointer at
+//     ~/.ynh/installed/<name>.json — handles forks created before the
+//     schema-2 pointer writer landed (or in homes already stamped schema-2
+//     when fork wrote a schema-1 file).
+//  3. Tree at ~/.ynh/harnesses/<id-fsname>/
 //
-// Returns ErrNotFound if neither exists. Callers that received a user-typed
+// Returns ErrNotFound if none match. Callers that received a user-typed
 // ref must Classify first and only call LoadByID for RefID kinds.
 func LoadByID(id string) (*Harness, error) {
 	if id == "" {
@@ -413,6 +417,16 @@ func LoadByID(id string) (*Harness, error) {
 		return nil, err
 	} else if ptr != nil {
 		return loadFromPointer(ptr)
+	}
+	// Schema-1 fallback: a fork created by an older binary (or by a binary
+	// that wrote schema-1 into an already-schema-2 home) stores its pointer
+	// as <name>.json rather than local--<name>.json. Try it before giving up.
+	if name, ok := strings.CutPrefix(id, "local/"); ok {
+		if ptr, err := LoadPointer(name); err != nil {
+			return nil, err
+		} else if ptr != nil {
+			return loadFromPointer(ptr)
+		}
 	}
 	dir := InstalledDirByID(id)
 	if _, err := os.Stat(dir); err == nil {

--- a/internal/harness/pointer_test.go
+++ b/internal/harness/pointer_test.go
@@ -215,6 +215,43 @@ func TestRemovePointer_Idempotent(t *testing.T) {
 	}
 }
 
+// TestLoadByID_Schema1PointerFallback verifies that LoadByID("local/<name>")
+// resolves a schema-1 name-keyed pointer file (<name>.json) when no schema-2
+// id-keyed file (local--<name>.json) exists. This is the regression test for
+// the bug where ynh fork wrote schema-1 pointers into an already-schema-2 home
+// and ynh info / include update / delegate add all returned "not found".
+func TestLoadByID_Schema1PointerFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	forkDir := t.TempDir()
+	writeForkTree(t, forkDir, "ynh-dev")
+
+	// Write a schema-1 pointer: <name>.json (no id field, no local-- prefix).
+	if err := SavePointer(&Pointer{
+		Name:        "ynh-dev",
+		SourceType:  "local",
+		Source:      forkDir,
+		InstalledAt: "2026-05-08T19:26:52Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Schema-2 id-keyed file must NOT exist (confirms we're testing the fallback).
+	schema2Path := PointerPathByID("local/ynh-dev")
+	if _, err := os.Stat(schema2Path); err == nil {
+		t.Fatalf("unexpected schema-2 pointer at %s", schema2Path)
+	}
+
+	p, err := LoadByID("local/ynh-dev")
+	if err != nil {
+		t.Fatalf("LoadByID: %v", err)
+	}
+	if p.Name != "ynh-dev" {
+		t.Errorf("Name = %q, want ynh-dev", p.Name)
+	}
+}
+
 // contains is a no-stdlib substring check to avoid pulling in strings.Contains
 // for a single helper. Keeps the test file small and obvious.
 func contains(s, sub string) bool {


### PR DESCRIPTION
## Summary

`ynh fork` writes pointer files as `<name>.json` (schema-1 name-keyed layout). `LoadByID` and `ResolveEditTarget` only consulted schema-2 id-keyed files (`local--<name>.json`), so any command that resolved a harness by canonical id returned `harness "local/<name>": harness not found` for pointer-installed local forks.

After the schema-2 migration stamps the home, `autoMigrate` is a no-op on subsequent invocations — so the schema-1 pointer written by `fork` never gets upgraded and the resolver gap persists for the life of the install.

## Changes

- `internal/harness/harness.go` — `LoadByID`: after schema-2 pointer miss, fall back to `LoadPointer(name)` for `local/<name>` ids
- `internal/harness/editor.go` — `ResolveEditTarget`: same fallback for the include/delegate editor path
- `internal/harness/pointer_test.go` — regression test: `LoadByID("local/ynh-dev")` resolves when only a schema-1 `ynh-dev.json` exists
- `internal/harness/editor_test.go` — regression test: `ResolveEditTarget("local/my-fork")` resolves via schema-1 fallback

## Affected commands

`ynh info`, `ynh include update/add/remove`, `ynh delegate add/update/remove`, `ynh update` — any command that resolves a single harness by canonical id.

## Testing

- [x] `make check` passes (format, lint, all tests, build)
- [x] New regression tests cover both resolver paths
- [x] TermQ live verification: `ynh info`, `include update`, `delegate add`, `delegate remove` all pass against `local/ynh-dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)