### PR TITLE
feat(plugin): expose focuses field — rename JSON key focus → focuses

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -490,7 +490,7 @@ Test fixtures in `testdata/` simulate real-world sources:
       "mcp_servers": { "github": null }
     }
   },
-  "focus": {
+  "focuses": {
     "review": { "profile": "ci", "prompt": "Review staged changes for quality" },
     "docs": { "prompt": "Generate API documentation for all public interfaces" }
   }

--- a/.ynh-plugin/plugin.json
+++ b/.ynh-plugin/plugin.json
@@ -31,7 +31,7 @@
       ]
     }
   },
-  "focus": {
+  "focuses": {
     "learn": {
       "prompt": "Walk me through ynh as a first-time user, starting from the README.md. Introduce the core concepts — harnesses, vendors, includes, delegates — with a concrete example for each. When I'm ready, suggest I use /ynh-create-harness to build my own."
     },

--- a/cmd/ynd/compose_test.go
+++ b/cmd/ynd/compose_test.go
@@ -39,7 +39,7 @@ func createComposeHarness(t *testing.T) string {
 				},
 			},
 		},
-		"focus": map[string]any{
+		"focuses": map[string]any{
 			"quick": map[string]any{
 				"prompt": "Be concise",
 			},
@@ -626,7 +626,7 @@ func TestCompose_Sensors(t *testing.T) {
 	hj := map[string]any{
 		"name":    "sensor-h",
 		"version": "0.1.0",
-		"focus": map[string]any{
+		"focuses": map[string]any{
 			"audit": map[string]any{"prompt": "audit the diff"},
 		},
 		"sensors": map[string]any{

--- a/cmd/ynd/schema/plugin.schema.json
+++ b/cmd/ynd/schema/plugin.schema.json
@@ -50,7 +50,7 @@
         }
       }
     },
-    "focus": {
+    "focuses": {
       "description": "Named combinations of profile + prompt for repeatable AI execution.",
       "type": "object",
       "additionalProperties": {

--- a/cmd/ynd/validate.go
+++ b/cmd/ynd/validate.go
@@ -487,13 +487,13 @@ func validateProfileMCPServers(profile map[string]any) []string {
 func validateHarnessFocus(hj map[string]any) []string {
 	var issues []string
 
-	focus, ok := hj["focus"]
+	focus, ok := hj["focuses"]
 	if !ok {
 		return issues
 	}
 	focusMap, ok := focus.(map[string]any)
 	if !ok {
-		issues = append(issues, "'focus' must be an object")
+		issues = append(issues, "'focuses' must be an object")
 		return issues
 	}
 
@@ -548,7 +548,7 @@ func validateHarnessSensors(hj map[string]any) []string {
 		}
 	}
 	focusNames := map[string]bool{}
-	if focuses, ok := hj["focus"].(map[string]any); ok {
+	if focuses, ok := hj["focuses"].(map[string]any); ok {
 		for name := range focuses {
 			focusNames[name] = true
 		}

--- a/cmd/ynd/validate_test.go
+++ b/cmd/ynd/validate_test.go
@@ -807,7 +807,7 @@ func TestValidateHarness_FocusValid(t *testing.T) {
 	hr := filepath.Join(dir, "focus-valid")
 	mkdirAll(t, hr)
 	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
-		[]byte(`{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"focus-valid","version":"0.1.0","profiles":{"ci":{}},"focus":{"review":{"profile":"ci","prompt":"Review code"}}}`))
+		[]byte(`{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"focus-valid","version":"0.1.0","profiles":{"ci":{}},"focuses":{"review":{"profile":"ci","prompt":"Review code"}}}`))
 
 	if err := validateHarness(hr); err != nil {
 		t.Errorf("valid focus should pass: %v", err)
@@ -821,7 +821,7 @@ func TestValidateHarness_FocusMissingPrompt(t *testing.T) {
 	hr := filepath.Join(dir, "focus-no-prompt")
 	mkdirAll(t, hr)
 	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
-		[]byte(`{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"focus-no-prompt","version":"0.1.0","focus":{"review":{"profile":"ci"}}}`))
+		[]byte(`{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"focus-no-prompt","version":"0.1.0","focuses":{"review":{"profile":"ci"}}}`))
 
 	err := validateHarness(hr)
 	if err == nil {
@@ -836,7 +836,7 @@ func TestValidateHarness_FocusUnknownProfile(t *testing.T) {
 	hr := filepath.Join(dir, "focus-bad-profile")
 	mkdirAll(t, hr)
 	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
-		[]byte(`{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"focus-bad-profile","version":"0.1.0","focus":{"review":{"profile":"nonexistent","prompt":"Review code"}}}`))
+		[]byte(`{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"focus-bad-profile","version":"0.1.0","focuses":{"review":{"profile":"nonexistent","prompt":"Review code"}}}`))
 
 	err := validateHarness(hr)
 	if err == nil {
@@ -851,7 +851,7 @@ func TestValidateHarness_FocusNoProfile(t *testing.T) {
 	hr := filepath.Join(dir, "focus-no-profile")
 	mkdirAll(t, hr)
 	writeFile(t, filepath.Join(hr, ".ynh-plugin", "plugin.json"),
-		[]byte(`{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"focus-no-profile","version":"0.1.0","focus":{"docs":{"prompt":"Generate docs"}}}`))
+		[]byte(`{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"focus-no-profile","version":"0.1.0","focuses":{"docs":{"prompt":"Generate docs"}}}`))
 
 	if err := validateHarness(hr); err != nil {
 		t.Errorf("focus without profile ref should pass: %v", err)
@@ -1089,7 +1089,7 @@ func TestValidateDir_NoRootMarketplace(t *testing.T) {
 
 func TestValidateHarnessSensors_Valid(t *testing.T) {
 	hj := map[string]any{
-		"focus": map[string]any{
+		"focuses": map[string]any{
 			"infer-vulns": map[string]any{"prompt": "find vulns"},
 		},
 		"profiles": map[string]any{

--- a/cmd/ynh/info_test.go
+++ b/cmd/ynh/info_test.go
@@ -341,7 +341,7 @@ func TestCmdInfoTextRichHarness(t *testing.T) {
 				"mcp_servers": {"staging-db": {"command": "staging-mcp"}}
 			}
 		},
-		"focus": {
+		"focuses": {
 			"quick": {"prompt": "Be concise"},
 			"review": {"profile": "staging", "prompt": "Review mode"}
 		},

--- a/cmd/ynh/sensors_test.go
+++ b/cmd/ynh/sensors_test.go
@@ -14,7 +14,7 @@ const sensorHarnessJSON = `{
   "name": "sh",
   "version": "0.1.0",
   "default_vendor": "claude",
-  "focus": {
+  "focuses": {
     "audit": {"prompt": "audit the diff"}
   },
   "sensors": {

--- a/docs/schema/harness.schema.json
+++ b/docs/schema/harness.schema.json
@@ -46,7 +46,7 @@
         }
       }
     },
-    "focus": {
+    "focuses": {
       "description": "Named combinations of profile + prompt for repeatable AI execution.",
       "type": "object",
       "additionalProperties": {

--- a/docs/schema/plugin.schema.json
+++ b/docs/schema/plugin.schema.json
@@ -50,7 +50,7 @@
         }
       }
     },
-    "focus": {
+    "focuses": {
       "description": "Named combinations of profile + prompt for repeatable AI execution.",
       "type": "object",
       "additionalProperties": {

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -19,7 +19,7 @@ Sensors live under the top-level `sensors` key in `.ynh-plugin/plugin.json`. Eac
   "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
   "name": "my-harness",
   "version": "0.1.0",
-  "focus": {
+  "focuses": {
     "infer-vulns": { "prompt": "Identify high-severity vulnerabilities in the changed code" }
   },
   "sensors": {

--- a/docs/tutorial/14-focus.md
+++ b/docs/tutorial/14-focus.md
@@ -50,7 +50,7 @@ cat > /tmp/ynh-tutorial/focus-harness/.ynh-plugin/plugin.json << 'EOF'
       }
     }
   },
-  "focus": {
+  "focuses": {
     "review": {
       "profile": "ci",
       "prompt": "Review staged changes for quality and correctness"

--- a/docs/tutorial/15-project-local-config.md
+++ b/docs/tutorial/15-project-local-config.md
@@ -30,7 +30,7 @@ cat > /tmp/ynh-tutorial/my-project/.ynh-plugin/plugin.json << 'EOF'
       { "matcher": "Write", "command": "/usr/local/bin/lint.sh" }
     ]
   },
-  "focus": {
+  "focuses": {
     "review": {
       "prompt": "Review staged changes for quality"
     }
@@ -100,7 +100,7 @@ The project-local config pattern works well with focus entries (Tutorial 14) for
 {
   "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
   "default_vendor": "claude",
-  "focus": {
+  "focuses": {
     "review": { "prompt": "Review staged changes" },
     "security": { "profile": "ci", "prompt": "Audit for vulnerabilities" }
   }

--- a/docs/tutorial/19-sensors.md
+++ b/docs/tutorial/19-sensors.md
@@ -79,7 +79,7 @@ cat > /tmp/ynh-tutorial/sensor-harness/.ynh-plugin/plugin.json << 'EOF'
   "name": "sensor-demo",
   "version": "0.1.0",
   "default_vendor": "claude",
-  "focus": {
+  "focuses": {
     "audit-vulns": {
       "prompt": "Identify any high-severity vulnerabilities in the diff vs main."
     }
@@ -112,7 +112,7 @@ cat > /tmp/ynh-tutorial/sensor-harness/.ynh-plugin/plugin.json << 'EOF'
   "name": "sensor-demo",
   "version": "0.1.0",
   "default_vendor": "claude",
-  "focus": {
+  "focuses": {
     "audit-vulns": {
       "prompt": "Identify any high-severity vulnerabilities in the diff vs main."
     }

--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -426,7 +426,7 @@ ynd preview /tmp/some-harness -v claude --focus nonexistent
 mkdir -p /tmp/ynh-bad-focus
 mkdir -p /tmp/ynh-bad-focus/.ynh-plugin
 cat > /tmp/ynh-bad-focus/.ynh-plugin/plugin.json << 'EOF'
-{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"bad","version":"0.1.0","focus":{"review":{"profile":"ci"}}}
+{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"bad","version":"0.1.0","focuses":{"review":{"profile":"ci"}}}
 EOF
 ynd validate /tmp/ynh-bad-focus
 # Expected: INVALID with "focus.review: prompt must not be empty"
@@ -439,7 +439,7 @@ rm -rf /tmp/ynh-bad-focus
 mkdir -p /tmp/ynh-bad-focus
 mkdir -p /tmp/ynh-bad-focus/.ynh-plugin
 cat > /tmp/ynh-bad-focus/.ynh-plugin/plugin.json << 'EOF'
-{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"bad","version":"0.1.0","focus":{"review":{"profile":"nonexistent","prompt":"Review code"}}}
+{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"bad","version":"0.1.0","focuses":{"review":{"profile":"nonexistent","prompt":"Review code"}}}
 EOF
 ynd validate /tmp/ynh-bad-focus
 # Expected: INVALID with "focus.review: references unknown profile"

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -22,7 +22,7 @@ type HarnessJSON struct {
 	Hooks         map[string][]HookEntry `json:"hooks,omitempty"`
 	MCPServers    map[string]MCPServer   `json:"mcp_servers,omitempty"`
 	Profiles      map[string]Profile     `json:"profiles,omitempty"`
-	Focuses       map[string]Focus       `json:"focus,omitempty"`
+	Focuses       map[string]Focus       `json:"focuses,omitempty"`
 	Sensors       map[string]Sensor      `json:"sensors,omitempty"`
 	InstalledFrom *ProvenanceMeta        `json:"installed_from,omitempty"`
 }

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -465,7 +465,7 @@ func TestLoadHarnessJSON_WithFocus(t *testing.T) {
 	writeHarnessJSON(t, dir, `{
 		"name": "test",
 		"version": "0.1.0",
-		"focus": {
+		"focuses": {
 			"review": {"profile": "ci", "prompt": "Review staged changes"},
 			"docs": {"prompt": "Generate API docs"}
 		}

--- a/test/e2e/profile_focus_test.go
+++ b/test/e2e/profile_focus_test.go
@@ -24,7 +24,7 @@ const profileHarnessTmpl = `{
       }
     }
   },
-  "focus": {
+  "focuses": {
     "audit": {"profile": "review", "prompt": "audit the diff"}
   }
 }

--- a/test/e2e/sensors_test.go
+++ b/test/e2e/sensors_test.go
@@ -99,7 +99,7 @@ func TestSensors_Install_PreservesAllSourceVariants(t *testing.T) {
   "name": "sensor-demo",
   "version": "0.1.0",
   "default_vendor": "claude",
-  "focus": {
+  "focuses": {
     "audit-vulns": { "prompt": "Audit the diff for vulnerabilities." }
   },
   "sensors": {
@@ -169,7 +169,7 @@ func TestSensors_Show_ResolvesFocusReference(t *testing.T) {
   "name": "sensor-show",
   "version": "0.1.0",
   "default_vendor": "claude",
-  "focus": {
+  "focuses": {
     "audit-vulns": { "prompt": "Audit the diff for vulnerabilities." }
   },
   "sensors": {
@@ -333,7 +333,7 @@ func TestSensors_InlineFocus_NotInTopLevelFocus(t *testing.T) {
   "name": "sensor-inline",
   "version": "0.1.0",
   "default_vendor": "claude",
-  "focus": {
+  "focuses": {
     "audit-vulns": { "prompt": "Audit the diff." }
   },
   "sensors": {
@@ -440,7 +440,7 @@ const sensorsProfileFocusHarnessTmpl = `{
       }
     }
   },
-  "focus": {
+  "focuses": {
     "audit": {"profile": "review", "prompt": "audit the diff"}
   },
   "sensors": {

--- a/test/e2e/ynd_compose_diff_test.go
+++ b/test/e2e/ynd_compose_diff_test.go
@@ -4,6 +4,8 @@ package e2e
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -39,6 +41,55 @@ func TestYnd_Compose_JSON(t *testing.T) {
 	}
 	if got.Counts == nil {
 		t.Errorf("expected counts to be present")
+	}
+}
+
+// TestYnd_Compose_Focuses asserts that `ynd compose --format json` includes
+// the focuses map in its output when the harness declares focuses, and that
+// the shape matches what TermQ's HarnessComposition decoder expects.
+func TestYnd_Compose_Focuses(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "focus-composed",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "profiles": {"thorough": {}},
+  "focuses": {
+    "security-audit": {"profile": "thorough", "prompt": "Review this code for security vulnerabilities."},
+    "code-review":    {"prompt": "Review this code for correctness."}
+  }
+}`
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _ := mustRunYnd(t, "compose", dir, "--format", "json")
+
+	var got struct {
+		Profiles []string `json:"profiles"`
+		Focuses  map[string]struct {
+			Profile string `json:"profile"`
+			Prompt  string `json:"prompt"`
+		} `json:"focuses"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parsing compose JSON: %v\n%s", err, out)
+	}
+	if len(got.Profiles) != 1 || got.Profiles[0] != "thorough" {
+		t.Errorf("profiles = %v, want [thorough]", got.Profiles)
+	}
+	if len(got.Focuses) != 2 {
+		t.Errorf("focuses len = %d, want 2; output:\n%s", len(got.Focuses), out)
+	}
+	if sec := got.Focuses["security-audit"]; sec.Profile != "thorough" || sec.Prompt == "" {
+		t.Errorf("security-audit focus = %+v, want profile=thorough and non-empty prompt", sec)
+	}
+	if cr := got.Focuses["code-review"]; cr.Profile != "" || cr.Prompt == "" {
+		t.Errorf("code-review focus = %+v, want empty profile and non-empty prompt", cr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Renames the top-level plugin manifest JSON key from `"focus"` to `"focuses"` to match the documented format and TermQ's decoder expectations
- The `--focus <name>` and `--profile <name>` flags on `ynh run` were already implemented; this unblocks them by fixing the JSON parse rejection
- Sensor source `focus` (the one-of discriminant on `SensorSource`) is unchanged

## Changes

- `internal/plugin/plugin.go` — JSON tag `json:"focus,omitempty"` → `json:"focuses,omitempty"` on `HarnessJSON.Focuses`
- `cmd/ynd/validate.go` — raw-map lookups and error message updated to `"focuses"`
- Both JSON schemas (`docs/schema/`, `cmd/ynd/schema/`) — top-level property renamed
- `.ynh-plugin/plugin.json`, `CONTRIBUTING.md`, 4 tutorial/doc files — updated to use `"focuses"`
- All test fixtures across 8 test files updated
- New e2e test `TestYnd_Compose_Focuses` verifying `ynd compose` emits the correct focuses shape for TermQ

## Testing

- [x] `make check` passes (format, lint, all tests, build)
- [x] Evals PASS (T14-Focus, T15-Project-local, T19-Sensors all green)
- [x] E2E coverage: `TestRun_FocusResolvesProfile`, `TestRun_FocusAndProfileMutex`, `TestRun_FocusUnknown_Errors`, `TestYnd_Compose_Focuses`
- [x] Binaries installed locally for TermQ agent testing — confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)