### PR TITLE
fix(uninstall): resolve local/ pointer IDs and tag broken forks in ls

### DIFF
--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -71,8 +71,12 @@ type listEntry struct {
 	IsPinned      bool               `json:"is_pinned"`
 	InstalledFrom *listInstalledFrom `json:"installed_from,omitempty"`
 	Artifacts     listArtifacts      `json:"artifacts"`
-	Includes      []listInclude      `json:"includes"`
-	DelegatesTo   []listDelegate     `json:"delegates_to"`
+	// BrokenReason is non-empty when the harness registration exists but the
+	// source could not be loaded (e.g. plugin.json missing, source path gone).
+	// Kind is "local-fork-broken" in this case. Absent for healthy entries.
+	BrokenReason string         `json:"broken_reason,omitempty"`
+	Includes     []listInclude  `json:"includes"`
+	DelegatesTo  []listDelegate `json:"delegates_to"`
 }
 
 type listInstalledFrom struct {
@@ -231,19 +235,27 @@ func printListJSON(w io.Writer, checkUpdates bool) error {
 	for _, e := range all {
 		p, loadErr := harness.LoadDir(e.Dir)
 		if loadErr != nil {
-			// Surface broken pointer entries as minimal placeholders so the
-			// JSON consumer sees the registration even when the source path
-			// is missing. Text mode already shows these as "(error: ...)"
-			// rows; the JSON contract should be no less informative.
-			if ptr, _ := harness.LoadPointer(e.Name); ptr != nil {
+			// Surface broken pointer entries with kind "local-fork-broken" and
+			// a broken_reason so JSON consumers (e.g. TermQ) can route them to
+			// a QUARANTINED group rather than displaying them as empty-field
+			// healthy harnesses.
+			//
+			// Pointer lookup: try schema-1 (name-keyed) then schema-2 (id-keyed)
+			// so entries written by both fork generations are covered.
+			ptr, _ := harness.LoadPointer(e.Name)
+			if ptr == nil {
+				ptr, _ = harness.LoadPointerByID("local/" + e.Name)
+			}
+			if ptr != nil {
 				id := namespace.CanonicalID(ptr.Source, ptr.Name)
 				ns, _ := namespace.SplitID(id)
 				entries = append(entries, listEntry{
-					ID:        id,
-					Name:      ptr.Name,
-					Namespace: ns,
-					Kind:      "local-fork",
-					Path:      ptr.Source,
+					ID:           id,
+					Name:         ptr.Name,
+					Namespace:    ns,
+					Kind:         "local-fork-broken",
+					Path:         ptr.Source,
+					BrokenReason: loadErr.Error(),
 					InstalledFrom: &listInstalledFrom{
 						SourceType:  ptr.SourceType,
 						Source:      ptr.Source,

--- a/cmd/ynh/list_test.go
+++ b/cmd/ynh/list_test.go
@@ -531,6 +531,76 @@ func TestCmdListCheckUpdatesRequiresJSON(t *testing.T) {
 	}
 }
 
+// Broken-pointer entries (source missing or plugin.json absent) must be emitted
+// as kind "local-fork-broken" with a non-empty broken_reason so JSON consumers
+// (e.g. TermQ) can route them to a QUARANTINED group instead of displaying
+// them as valid but empty-field harnesses.
+func TestCmdListJSON_BrokenPointerKind(t *testing.T) {
+	t.Run("source_path_missing", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("YNH_HOME", home)
+
+		if err := harness.SavePointer(&harness.Pointer{
+			Name: "ghost", SourceType: "local",
+			Source: filepath.Join(t.TempDir(), "gone"), InstalledAt: "2026-05-01T00:00:00Z",
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		var stdout bytes.Buffer
+		if err := cmdListTo([]string{"--format", "json"}, &stdout, io.Discard); err != nil {
+			t.Fatalf("cmdListTo: %v", err)
+		}
+		var got listEnvelope
+		if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+		}
+		if len(got.Harnesses) != 1 {
+			t.Fatalf("expected 1 harness, got %d; output: %s", len(got.Harnesses), stdout.String())
+		}
+		h := got.Harnesses[0]
+		if h.Kind != "local-fork-broken" {
+			t.Errorf("kind = %q, want local-fork-broken", h.Kind)
+		}
+		if h.BrokenReason == "" {
+			t.Errorf("broken_reason is empty; expected non-empty reason")
+		}
+	})
+
+	t.Run("plugin_json_missing", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("YNH_HOME", home)
+
+		// Source dir exists but has no .ynh-plugin/plugin.json.
+		srcDir := t.TempDir()
+		if err := harness.SavePointer(&harness.Pointer{
+			Name: "hollow", SourceType: "local",
+			Source: srcDir, InstalledAt: "2026-05-01T00:00:00Z",
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		var stdout bytes.Buffer
+		if err := cmdListTo([]string{"--format", "json"}, &stdout, io.Discard); err != nil {
+			t.Fatalf("cmdListTo: %v", err)
+		}
+		var got listEnvelope
+		if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+		}
+		if len(got.Harnesses) != 1 {
+			t.Fatalf("expected 1 harness, got %d; output: %s", len(got.Harnesses), stdout.String())
+		}
+		h := got.Harnesses[0]
+		if h.Kind != "local-fork-broken" {
+			t.Errorf("kind = %q, want local-fork-broken", h.Kind)
+		}
+		if h.BrokenReason == "" {
+			t.Errorf("broken_reason is empty; expected non-empty reason")
+		}
+	})
+}
+
 // Broken-pointer placeholder rows must emit [] not null for empty
 // includes/delegates_to. JSON consumers expect the canonical empty-array shape
 // regardless of whether the source tree could be loaded.

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -540,12 +540,32 @@ func cmdUninstall(args []string) error {
 	// to load the manifest. Removing a pointer is a metadata operation; it
 	// must succeed even when the pointed-to source tree is missing — that's
 	// the exact case where users most need to uninstall.
+	//
+	// Resolution mirrors LoadByID: try schema-2 (id-keyed) first, then fall
+	// back to schema-1 (name-keyed) for "local/<name>" canonical IDs.
 	var bareName, pointerSource string
-	if ptr, err := harness.LoadPointer(ref); err == nil && ptr != nil {
+	ptr, ptrErr := harness.LoadPointerByID(ref)
+	if ptrErr != nil {
+		return fmt.Errorf("checking pointer: %w", ptrErr)
+	}
+	if ptr == nil {
+		if name, ok := strings.CutPrefix(ref, "local/"); ok {
+			var err error
+			ptr, err = harness.LoadPointer(name)
+			if err != nil {
+				return fmt.Errorf("checking pointer: %w", err)
+			}
+		}
+	}
+	if ptr != nil {
 		bareName = ptr.Name
 		pointerSource = ptr.Source
+		// Remove both schemas — RemovePointer* silently no-ops on missing files.
 		if err := harness.RemovePointer(bareName); err != nil {
 			return fmt.Errorf("removing pointer: %w", err)
+		}
+		if err := harness.RemovePointerByID(ref); err != nil {
+			return fmt.Errorf("removing id-keyed pointer: %w", err)
 		}
 	} else {
 		// Tree-shaped install: resolve the on-disk directory (may be flat or

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -1039,3 +1039,71 @@ func TestCanonicalIDResolver_RejectsLegacyAtForm(t *testing.T) {
 		t.Errorf("expected rejection hint, got: %v", err)
 	}
 }
+
+// ynh uninstall local/<name> must resolve schema-1 pointer-installed forks.
+// This is the canonical form TermQ emits; before the fix, the "local/" prefix
+// caused the pointer lookup to miss and the command returned "not installed".
+func TestCmdUninstall_PointerByCanonicalID(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Create a source directory with a valid harness manifest.
+	srcDir := t.TempDir()
+	pluginDir := filepath.Join(srcDir, ".ynh-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"),
+		[]byte(`{"name":"my-fork","version":"1.0.0","default_vendor":"claude"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a schema-1 (name-keyed) pointer — the form ynh fork currently writes.
+	if err := harness.SavePointer(&harness.Pointer{
+		Name: "my-fork", SourceType: "local",
+		Source: srcDir, InstalledAt: "2026-05-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Uninstall via canonical id — this is what TermQ passes.
+	if err := cmdUninstall([]string{"local/my-fork"}); err != nil {
+		t.Fatalf("cmdUninstall local/my-fork failed: %v", err)
+	}
+
+	if _, err := os.Stat(harness.PointerPath("my-fork")); !os.IsNotExist(err) {
+		t.Errorf("schema-1 pointer still exists after uninstall: err=%v", err)
+	}
+}
+
+// ynh uninstall with a bare name must still work for backwards compatibility
+// (users who type the name directly rather than the canonical id).
+func TestCmdUninstall_PointerByBareName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	srcDir := t.TempDir()
+	pluginDir := filepath.Join(srcDir, ".ynh-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"),
+		[]byte(`{"name":"my-fork","version":"1.0.0","default_vendor":"claude"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := harness.SavePointer(&harness.Pointer{
+		Name: "my-fork", SourceType: "local",
+		Source: srcDir, InstalledAt: "2026-05-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdUninstall([]string{"my-fork"}); err != nil {
+		t.Fatalf("cmdUninstall my-fork (bare name) failed: %v", err)
+	}
+
+	if _, err := os.Stat(harness.PointerPath("my-fork")); !os.IsNotExist(err) {
+		t.Errorf("schema-1 pointer still exists after bare-name uninstall: err=%v", err)
+	}
+}

--- a/docs/tutorial/16-structured-output.md
+++ b/docs/tutorial/16-structured-output.md
@@ -237,6 +237,8 @@ Expected (timestamps and paths will differ):
 Key points:
 - Output is wrapped in an **envelope**: `capabilities` (wire-contract version of JSON shapes ynh speaks), `schema_version` (on-disk format version of `~/.ynh`), `ynh_version` (release), and `harnesses` (the array).
 - `id` is the canonical, host-prefixed harness identifier — `<host>/<org>/<repo>/<name>` for installs sourced from a remote registry, or `local/<name>` for local-path installs. This is the single identity form to pass back to ynh at the CLI for any harness-targeting command.
+- `kind` classifies the install source: `local` (installed from a local path), `local-fork` (registered via `ynh fork`), `local-fork-broken` (fork whose source directory is missing or has no manifest — see `broken_reason`), `git` (installed from a remote git URL), `registry` (installed via a registry reference), or `-` (pre-migration entries with no recorded source).
+- `broken_reason` is present only when `kind` is `local-fork-broken`. It contains the load error string explaining what is wrong (e.g. `"no harness manifest found in <path>"` or a stat error when the source directory is gone). Consumers should surface broken entries distinctly — they are still registered in `~/.ynh` and can be removed with `ynh uninstall <id>`.
 - `version_installed` is the version recorded in the harness manifest. Pass `--check-updates` to add `version_available` (and `ref_available`) by querying the upstream.
 - `is_pinned` is `true` when the installed Git ref is a resolved SHA (matches `^[0-9a-f]{7,40}$`); `false` for tags, branches, or local-only installs.
 - `path` is the absolute path to the installed harness directory.

--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -446,6 +446,61 @@ ynd validate /tmp/ynh-bad-focus
 rm -rf /tmp/ynh-bad-focus
 ```
 
+### E23: Fork uninstall via canonical id
+
+`ynh fork` registers a pointer-shaped install. `ynh uninstall local/<name>` must resolve the schema-1 pointer and remove the registration cleanly — this is the form TermQ and other JSON consumers pass back.
+
+```bash
+# Create a minimal harness to fork from
+mkdir -p /tmp/ynh-fork-src/.ynh-plugin
+cat > /tmp/ynh-fork-src/.ynh-plugin/plugin.json << 'EOF'
+{"name":"fork-src","version":"1.0.0","default_vendor":"claude"}
+EOF
+
+# Fork it to a local directory
+ynh fork /tmp/ynh-fork-src --to /tmp/ynh-fork-copy --name fork-copy
+# Expected: Forked "fork-src" → "fork-copy"
+#           Path: /tmp/ynh-fork-copy
+
+# Verify it appears in ls
+ynh ls --format json | jq -r '.harnesses[] | select(.name=="fork-copy") | .id'
+# Expected: local/fork-copy
+
+# Uninstall via canonical id (the form machine consumers use)
+ynh uninstall local/fork-copy
+# Expected: Uninstalled harness "fork-copy"
+#             Source tree left in place: /tmp/ynh-fork-copy
+
+# Verify the pointer is gone
+ynh ls --format json | jq -r '.harnesses[] | select(.name=="fork-copy") | .id'
+# Expected: (empty — no output)
+
+rm -rf /tmp/ynh-fork-src /tmp/ynh-fork-copy
+```
+
+### E24: Broken fork appears as local-fork-broken in ls JSON
+
+When a fork's source directory exists but has no `.ynh-plugin/plugin.json`, `ynh ls --format json` must tag it as `kind: "local-fork-broken"` with a non-empty `broken_reason` rather than emitting an empty-field `local-fork` entry.
+
+```bash
+# Register a pointer to a directory with no manifest
+mkdir -p /tmp/ynh-hollow-src   # exists but no .ynh-plugin/
+export YNH_HOME=$(mktemp -d)
+cat > "$YNH_HOME/installed/hollow.json" << 'EOF'
+{"name":"hollow","source_type":"local","source":"/tmp/ynh-hollow-src","installed_at":"2026-01-01T00:00:00Z"}
+EOF
+
+ynh ls --format json | jq '.harnesses[] | select(.name=="hollow") | {kind, broken_reason}'
+# Expected:
+# {
+#   "kind": "local-fork-broken",
+#   "broken_reason": "no harness manifest found in /tmp/ynh-hollow-src"
+# }
+
+rm -rf /tmp/ynh-hollow-src "$YNH_HOME"
+unset YNH_HOME
+```
+
 ---
 
 ## Sensors
@@ -510,5 +565,5 @@ Re-run S1 with a focus-source sensor and verify `ynh sensors run` returns the re
 | Tutorial 15: Project-Local Config | 4 |
 | Tutorial 16: Structured Output | 11 |
 | Sensors | 3 |
-| Edge Cases | 22 |
-| **Total** | **150** |
+| Edge Cases | 24 |
+| **Total** | **152** |


### PR DESCRIPTION
## Summary

Two bugs surfaced via TermQ's Uninstall menu and ls sidebar:

- `ynh uninstall local/<name>` returned "not installed" for any fork created by `ynh fork`. TermQ's Uninstall menu item always passes the canonical id — with this gap, every fork uninstall from the UI silently failed.
- `ynh ls --format json` emitted `local-fork` entries with empty `version_installed`, `default_vendor` etc. when the fork's source directory had no `.ynh-plugin/plugin.json`. No signal to distinguish these from healthy empty harnesses.

## Changes

- **`cmd/ynh/main.go`**: `cmdUninstall` now mirrors the schema-1/schema-2 fallback that `LoadByID` uses — tries `LoadPointerByID` (schema-2, `local--<name>.json`) first, then `LoadPointer(name)` for `local/<name>` canonical IDs (schema-1, `<name>.json`). Cleans up both pointer forms on success.
- **`cmd/ynh/list.go`**: Broken pointer entries now emit `kind: "local-fork-broken"` and a `broken_reason` field (omitted on healthy entries) instead of an empty-field `local-fork` record. Also extends the pointer fallback to cover schema-2 pointers so broken-source schema-2 forks aren't silently dropped.
- **`docs/tutorial/16-structured-output.md`**: Documents the full `kind` value enum and `broken_reason` field.
- **`docs/tutorial/manual-test-plan.md`**: Adds E23 (fork → uninstall via canonical id) and E24 (broken fork in ls JSON) — both scenarios were untested before this branch.

## Testing

- [x] `make check` passes (lint, format, all tests)
- [x] `TestCmdUninstall_PointerByCanonicalID` — new regression test for Bug 1
- [x] `TestCmdUninstall_PointerByBareName` — backwards-compat check
- [x] `TestCmdListJSON_BrokenPointerKind` — two subtests covering source-missing and plugin.json-missing cases
- [x] Evals PASS across all 19 locally-testable tutorials
- [x] Manually verified by TermQ agent against live install

🤖 Generated with [Claude Code](https://claude.com/claude-code)