### PR TITLE
fix(list): key ListAll dedup map by canonical id, not bare name

### DIFF
--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -478,6 +478,39 @@ ynh ls --format json | jq -r '.harnesses[] | select(.name=="fork-copy") | .id'
 rm -rf /tmp/ynh-fork-src /tmp/ynh-fork-copy
 ```
 
+### E25: Fork and registry install sharing a leaf name both appear in ls
+
+A fork (`local/<name>`) and a registry install (`<host>/…/<name>`) that share the same leaf name but have distinct canonical ids must both appear in `ynh ls`. This is the central scenario the canonical-id work enabled.
+
+```bash
+export YNH_HOME=$(mktemp -d)
+
+# Simulate a registry install (schema-2 tree)
+mkdir -p "$YNH_HOME/harnesses/github.com--eyelock--assistants--shared/.ynh-plugin"
+cat > "$YNH_HOME/harnesses/github.com--eyelock--assistants--shared/.ynh-plugin/plugin.json" << 'EOF'
+{"name":"shared","version":"1.0.0","default_vendor":"claude"}
+EOF
+
+# Register a fork with the same leaf name
+mkdir -p /tmp/ynh-fork-shared/.ynh-plugin
+cat > /tmp/ynh-fork-shared/.ynh-plugin/plugin.json << 'EOF'
+{"name":"shared","version":"2.0.0","default_vendor":"claude"}
+EOF
+cat > "$YNH_HOME/installed/shared.json" << 'EOF'
+{"name":"shared","source_type":"local","source":"/tmp/ynh-fork-shared","installed_at":"2026-01-01T00:00:00Z"}
+EOF
+
+ynh ls --format json | jq '[.harnesses[] | select(.name=="shared") | .id]'
+# Expected (both ids present, order may vary):
+# [
+#   "local/shared",
+#   "github.com/eyelock/assistants/shared"
+# ]
+
+rm -rf /tmp/ynh-fork-shared "$YNH_HOME"
+unset YNH_HOME
+```
+
 ### E24: Broken fork appears as local-fork-broken in ls JSON
 
 When a fork's source directory exists but has no `.ynh-plugin/plugin.json`, `ynh ls --format json` must tag it as `kind: "local-fork-broken"` with a non-empty `broken_reason` rather than emitting an empty-field `local-fork` entry.
@@ -565,5 +598,5 @@ Re-run S1 with a focus-source sensor and verify `ynh sensors run` returns the re
 | Tutorial 15: Project-Local Config | 4 |
 | Tutorial 16: Structured Output | 11 |
 | Sensors | 3 |
-| Edge Cases | 24 |
-| **Total** | **152** |
+| Edge Cases | 25 |
+| **Total** | **153** |

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -261,17 +261,21 @@ func List() ([]string, error) {
 // ListAll returns all installed harnesses with namespace and directory
 // information. Unions pointer-shaped installs (local forks) with
 // tree-shaped installs (git/registry). Pointer entries take precedence
-// when a name appears in both — a pre-1.0 invariant: ynh fork now refuses
-// to register if a tree of the same name exists, but legacy two-tree
-// installs from before this change may still be on disk.
+// over a flat/local tree with the same canonical id — a pre-1.0 invariant
+// for the case where ynh fork co-existed with a local tree install. A
+// pointer and a remote registry install can share the same leaf name but
+// have distinct canonical ids (e.g. "local/foo" vs
+// "github.com/org/repo/foo") and must both appear.
 func ListAll() ([]ListEntry, error) {
 	pointers, err := ListPointers()
 	if err != nil {
 		return nil, err
 	}
+	// Key by canonical id, not bare name, so a fork and a registry install
+	// that share only the leaf name are not incorrectly deduplicated.
 	seen := make(map[string]bool, len(pointers))
 	for _, p := range pointers {
-		seen[p.Name] = true
+		seen["local/"+p.Name] = true
 	}
 
 	harnessesDir := config.HarnessesDir()
@@ -307,7 +311,7 @@ func ListAll() ([]ListEntry, error) {
 				if i := strings.LastIndex(id, "/"); i >= 0 {
 					name = id[i+1:]
 				}
-				if seen[name] {
+				if seen[id] {
 					continue
 				}
 				ns, _ := namespace.SplitID(id)
@@ -335,7 +339,7 @@ func ListAll() ([]ListEntry, error) {
 				if !child.IsDir() {
 					continue
 				}
-				if seen[child.Name()] {
+				if seen[ns+"/"+child.Name()] {
 					continue
 				}
 				childDir := filepath.Join(entryPath, child.Name())
@@ -349,7 +353,7 @@ func ListAll() ([]ListEntry, error) {
 			}
 		} else {
 			// Flat entry (unmigrated or local install)
-			if seen[entry.Name()] {
+			if seen["local/"+entry.Name()] {
 				continue
 			}
 			if DetectFormat(entryPath) != "" {

--- a/internal/harness/pointer_test.go
+++ b/internal/harness/pointer_test.go
@@ -252,6 +252,56 @@ func TestLoadByID_Schema1PointerFallback(t *testing.T) {
 	}
 }
 
+// A fork (local/<name>) and a remote registry install sharing the same leaf
+// name but with distinct canonical ids must both appear in ListAll. The
+// canonical-id work (#127) made this possible; deduplicating by bare name
+// was the regression.
+func TestListAll_ForkAndRegistryInstallSameLeafName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Pointer-shaped fork: local/termq-dev
+	forkDir := filepath.Join(t.TempDir(), "termq-dev")
+	writeForkTree(t, forkDir, "termq-dev")
+	if err := SavePointer(&Pointer{
+		Name: "termq-dev", SourceType: "local", Source: forkDir,
+		InstalledAt: "2026-05-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Schema-2 registry install: github.com/eyelock/assistants/termq-dev
+	// Dir name is the id-fsname: github.com--eyelock--assistants--termq-dev
+	registryDir := filepath.Join(home, "harnesses", "github.com--eyelock--assistants--termq-dev")
+	writeForkTree(t, registryDir, "termq-dev")
+
+	entries, err := ListAll()
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+
+	ids := map[string]string{} // id → dir
+	for _, e := range entries {
+		var id string
+		if e.Namespace == "" {
+			id = "local/" + e.Name
+		} else {
+			id = e.Namespace + "/" + e.Name
+		}
+		ids[id] = e.Dir
+	}
+
+	if _, ok := ids["local/termq-dev"]; !ok {
+		t.Errorf("ListAll missing local/termq-dev; got %+v", ids)
+	}
+	if _, ok := ids["github.com/eyelock/assistants/termq-dev"]; !ok {
+		t.Errorf("ListAll missing github.com/eyelock/assistants/termq-dev; got %+v", ids)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries, got %d: %+v", len(entries), entries)
+	}
+}
+
 // contains is a no-stdlib substring check to avoid pulling in strings.Contains
 // for a single helper. Keeps the test file small and obvious.
 func contains(s, sub string) bool {


### PR DESCRIPTION
## Summary

`ynh ls` was silently dropping a registry install when a same-named fork existed. A fork (`local/termq-dev`) and a registry install (`github.com/eyelock/assistants/termq-dev`) share only the leaf name — their canonical ids are distinct. `ListAll`'s dedup map was keyed by bare name, so the registry tree was skipped. The user appeared to have lost their registry install in TermQ's sidebar despite it being intact on disk; `ynh info` could resolve it but `ynh ls` couldn't surface it.

## Changes

- **`internal/harness/harness.go`**: Change `ListAll`'s `seen` map to use canonical ids — `local/<name>` for pointers and flat trees, the full id from `FSNameToID` for schema-2 dirs, `ns/name` for schema-1 namespace children. The existing pointer-wins-over-flat-tree invariant is preserved since both map to `local/<name>`.
- **`internal/harness/pointer_test.go`**: `TestListAll_ForkAndRegistryInstallSameLeafName` — regression test with a pointer + schema-2 registry dir sharing a leaf name, asserts both appear.
- **`docs/tutorial/manual-test-plan.md`**: E25 covers the full scenario end-to-end.

## Testing

- [x] `make check` passes
- [x] `TestListAll_ForkAndRegistryInstallSameLeafName` — new regression test
- [x] `TestListAll_PointerWinsOverTreeOnDuplicate` — existing dedup invariant still passes
- [x] Evals PASS across all locally-testable tutorials
- [x] Manually verified by TermQ agent against live install

🤖 Generated with [Claude Code](https://claude.com/claude-code)