### PR TITLE
feat(run): add --interactive flag for focus-seeded sessions

### DIFF
--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -1081,6 +1081,9 @@ func cmdRun(args []string) error {
 		// Launch
 		fmt.Fprintf(os.Stderr, "Launching %s...\n", adapter.CLIName())
 		if prompt != "" {
+			if ra.Interactive {
+				return adapter.LaunchWithInitialPrompt(runDir, prompt, vendorArgs)
+			}
 			return adapter.LaunchNonInteractive(runDir, prompt, vendorArgs)
 		}
 		return adapter.LaunchInteractive(runDir, vendorArgs)
@@ -1093,11 +1096,12 @@ func cmdVendors(args []string) error {
 
 // vendorEntry is the JSON shape for a single vendor in `ynh vendors --format json`.
 type vendorEntry struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"display_name"`
-	CLI         string `json:"cli"`
-	ConfigDir   string `json:"config_dir"`
-	Available   bool   `json:"available"`
+	Name                  string `json:"name"`
+	DisplayName           string `json:"display_name"`
+	CLI                   string `json:"cli"`
+	ConfigDir             string `json:"config_dir"`
+	Available             bool   `json:"available"`
+	SupportsInitialPrompt bool   `json:"supports_initial_prompt"`
 }
 
 func cmdVendorsTo(args []string, stdout, stderr io.Writer) error {
@@ -1155,6 +1159,12 @@ func printVendorsText(w io.Writer) error {
 	return tw.Flush()
 }
 
+// initialPrompter is an optional capability interface for vendors that support
+// starting an interactive session with an initial prompt pre-loaded.
+type initialPrompter interface {
+	SupportsInitialPrompt() bool
+}
+
 func printVendorsJSON(w io.Writer) error {
 	entries := make([]vendorEntry, 0, len(vendor.Available()))
 	for _, name := range vendor.Available() {
@@ -1163,12 +1173,17 @@ func printVendorsJSON(w io.Writer) error {
 			return fmt.Errorf("loading vendor %s: %w", name, err)
 		}
 		_, lookErr := exec.LookPath(adapter.CLIName())
+		supportsIP := false
+		if ip, ok := adapter.(initialPrompter); ok {
+			supportsIP = ip.SupportsInitialPrompt()
+		}
 		entries = append(entries, vendorEntry{
-			Name:        adapter.Name(),
-			DisplayName: adapter.DisplayName(),
-			CLI:         adapter.CLIName(),
-			ConfigDir:   adapter.ConfigDir(),
-			Available:   lookErr == nil,
+			Name:                  adapter.Name(),
+			DisplayName:           adapter.DisplayName(),
+			CLI:                   adapter.CLIName(),
+			ConfigDir:             adapter.ConfigDir(),
+			Available:             lookErr == nil,
+			SupportsInitialPrompt: supportsIP,
 		})
 	}
 
@@ -1233,6 +1248,7 @@ type runArgs struct {
 	Prompt      string   // trailing prompt after --
 	VendorArgs  []string // passthrough args for vendor CLI
 	Action      string   // "install", "clean", or ""
+	Interactive bool     // --interactive: stay in session after initial prompt
 }
 
 func parseRunArgs(args []string) runArgs {
@@ -1273,6 +1289,8 @@ func parseRunArgs(args []string) runArgs {
 			ra.Action = "install"
 		case flagArgs[i] == "--clean":
 			ra.Action = "clean"
+		case flagArgs[i] == "--interactive":
+			ra.Interactive = true
 		case !strings.HasPrefix(flagArgs[i], "-"):
 			if firstPositional {
 				// First positional arg is the harness name

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -272,6 +272,53 @@ func TestParseRunArgs_HarnessFileEnvVar(t *testing.T) {
 	}
 }
 
+func TestParseRunArgs_Interactive(t *testing.T) {
+	t.Setenv("YNH_FOCUS", "")
+	t.Setenv("YNH_HARNESS_FILE", "")
+
+	tests := []struct {
+		name            string
+		args            []string
+		wantInteractive bool
+		wantPrompt      string
+	}{
+		{
+			name:            "--interactive with focus",
+			args:            []string{"my-harness", "--focus", "review", "--interactive"},
+			wantInteractive: true,
+		},
+		{
+			name:            "--interactive with prompt via separator",
+			args:            []string{"my-harness", "--interactive", "--", "fix this"},
+			wantInteractive: true,
+			wantPrompt:      "fix this",
+		},
+		{
+			name:            "--interactive without prompt is parsed",
+			args:            []string{"my-harness", "--interactive"},
+			wantInteractive: true,
+		},
+		{
+			name:            "no --interactive flag",
+			args:            []string{"my-harness", "--", "fix this"},
+			wantInteractive: false,
+			wantPrompt:      "fix this",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ra := parseRunArgs(tt.args)
+			if ra.Interactive != tt.wantInteractive {
+				t.Errorf("Interactive = %v, want %v", ra.Interactive, tt.wantInteractive)
+			}
+			if ra.Prompt != tt.wantPrompt {
+				t.Errorf("Prompt = %q, want %q", ra.Prompt, tt.wantPrompt)
+			}
+		})
+	}
+}
+
 func TestResolveVendor(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/cmd/ynh/vendors_test.go
+++ b/cmd/ynh/vendors_test.go
@@ -127,6 +127,47 @@ func TestCmdVendorsJSON_AvailableIsBool(t *testing.T) {
 	}
 }
 
+func TestCmdVendorsJSON_SupportsInitialPrompt(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := cmdVendorsTo([]string{"--format", "json"}, &stdout, &stderr); err != nil {
+		t.Fatalf("cmdVendorsTo JSON: %v", err)
+	}
+
+	var raw []map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	for _, entry := range raw {
+		val, ok := entry["supports_initial_prompt"]
+		if !ok {
+			t.Errorf("vendor %q missing supports_initial_prompt field", entry["name"])
+			continue
+		}
+		if _, isBool := val.(bool); !isBool {
+			t.Errorf("vendor %q supports_initial_prompt should be bool, got %T", entry["name"], val)
+		}
+	}
+
+	// All three current vendors support initial prompt.
+	byName := map[string]map[string]interface{}{}
+	for _, entry := range raw {
+		if name, ok := entry["name"].(string); ok {
+			byName[name] = entry
+		}
+	}
+	for _, name := range []string{"claude", "codex", "cursor"} {
+		e, ok := byName[name]
+		if !ok {
+			t.Errorf("missing vendor %q", name)
+			continue
+		}
+		if e["supports_initial_prompt"] != true {
+			t.Errorf("vendor %q supports_initial_prompt = %v, want true", name, e["supports_initial_prompt"])
+		}
+	}
+}
+
 func TestCmdVendors_InvalidFormat(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := cmdVendorsTo([]string{"--format", "yaml"}, &stdout, &stderr)

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -31,6 +31,9 @@ func (m *mockAdapter) Install(stagingDir string, projectDir string) ([]vendor.Sy
 }
 func (m *mockAdapter) Clean(entries []vendor.SymlinkEntry) error                     { return nil }
 func (m *mockAdapter) LaunchInteractive(configPath string, extraArgs []string) error { return nil }
+func (m *mockAdapter) LaunchWithInitialPrompt(configPath, prompt string, extraArgs []string) error {
+	return nil
+}
 func (m *mockAdapter) LaunchNonInteractive(configPath string, prompt string, extraArgs []string) error {
 	return nil
 }

--- a/internal/vendor/adapter.go
+++ b/internal/vendor/adapter.go
@@ -11,6 +11,11 @@ import (
 // ErrUnknownVendor is returned when a vendor name is not registered.
 var ErrUnknownVendor = errors.New("unknown vendor")
 
+// ErrInitialPromptNotSupported is returned by LaunchWithInitialPrompt on
+// vendors whose CLI has no mechanism to pass an initial message into an
+// interactive session.
+var ErrInitialPromptNotSupported = errors.New("vendor does not support interactive sessions with an initial prompt")
+
 // SymlinkEntry records a single symlink created during Install.
 type SymlinkEntry struct {
 	Target string `json:"target"` // Where the symlink points (staging dir)
@@ -62,6 +67,12 @@ type Adapter interface {
 	// LaunchNonInteractive runs a one-shot prompt.
 	// extraArgs are passed through verbatim to the vendor CLI.
 	LaunchNonInteractive(configPath string, prompt string, extraArgs []string) error
+
+	// LaunchWithInitialPrompt starts an interactive session with the prompt
+	// pre-populated as the first user message. Unlike LaunchNonInteractive,
+	// the session continues after the LLM responds. Vendors that cannot
+	// support this return ErrInitialPromptNotSupported.
+	LaunchWithInitialPrompt(configPath string, prompt string, extraArgs []string) error
 
 	// GenerateSystemPrompt produces vendor-native instruction files from the
 	// harness instructions content. Returns a map of relative file paths to

--- a/internal/vendor/claude.go
+++ b/internal/vendor/claude.go
@@ -69,6 +69,15 @@ func (c *Claude) LaunchNonInteractive(configPath string, prompt string, extraArg
 	return launchClaude(configPath, args)
 }
 
+func (c *Claude) LaunchWithInitialPrompt(configPath, prompt string, extraArgs []string) error {
+	// Positional arg without -p starts an interactive session with the prompt
+	// pre-loaded as the first user message (documented: claude "query").
+	args := append(extraArgs, prompt)
+	return launchClaude(configPath, args)
+}
+
+func (c *Claude) SupportsInitialPrompt() bool { return true }
+
 // buildClaudeArgs constructs the argument list for the Claude Code CLI.
 // It adds --plugin-dir for artifact loading and --append-system-prompt
 // for harness instructions, then appends any vendor pass-through args.

--- a/internal/vendor/claude.go
+++ b/internal/vendor/claude.go
@@ -1,6 +1,7 @@
 package vendor
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -70,13 +71,46 @@ func (c *Claude) LaunchNonInteractive(configPath string, prompt string, extraArg
 }
 
 func (c *Claude) LaunchWithInitialPrompt(configPath, prompt string, extraArgs []string) error {
-	// Positional arg without -p starts an interactive session with the prompt
-	// pre-loaded as the first user message (documented: claude "query").
-	args := append(extraArgs, prompt)
-	return launchClaude(configPath, args)
+	// Two-step approach: run the prompt non-interactively first (user sees the
+	// response), then resume that session interactively. A direct positional arg
+	// (claude [flags] "prompt") does not submit when --plugin-dir or --add-dir
+	// are present — those flags change Claude's session initialisation path.
+	claudeBin, err := exec.LookPath("claude")
+	if err != nil {
+		return err
+	}
+
+	sessionID, err := randomUUID()
+	if err != nil {
+		return fmt.Errorf("generating session ID: %w", err)
+	}
+
+	// Step 1: establish session context with the focus prompt.
+	step1 := buildClaudeArgs(configPath, append([]string{"-p", prompt, "--session-id", sessionID}, extraArgs...))
+	cmd := exec.Command(claudeBin, step1[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("focus run: %w", err)
+	}
+
+	// Step 2: resume that session interactively so the user can continue.
+	return launchClaude(configPath, append([]string{"--resume", sessionID}, extraArgs...))
 }
 
 func (c *Claude) SupportsInitialPrompt() bool { return true }
+
+func randomUUID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
 
 // buildClaudeArgs constructs the argument list for the Claude Code CLI.
 // It adds --plugin-dir for artifact loading and --append-system-prompt

--- a/internal/vendor/claude.go
+++ b/internal/vendor/claude.go
@@ -1,7 +1,6 @@
 package vendor
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -62,61 +61,31 @@ func (c *Claude) Clean(entries []SymlinkEntry) error {
 }
 
 func (c *Claude) LaunchInteractive(configPath string, extraArgs []string) error {
-	return launchClaude(configPath, extraArgs)
+	return launchClaude(configPath, "", extraArgs)
 }
 
 func (c *Claude) LaunchNonInteractive(configPath string, prompt string, extraArgs []string) error {
 	args := append([]string{"-p", prompt}, extraArgs...)
-	return launchClaude(configPath, args)
+	return launchClaude(configPath, "", args)
 }
 
 func (c *Claude) LaunchWithInitialPrompt(configPath, prompt string, extraArgs []string) error {
-	// Two-step approach: run the prompt non-interactively first (user sees the
-	// response), then resume that session interactively. A direct positional arg
-	// (claude [flags] "prompt") does not submit when --plugin-dir or --add-dir
-	// are present — those flags change Claude's session initialisation path.
-	claudeBin, err := exec.LookPath("claude")
-	if err != nil {
-		return err
-	}
-
-	sessionID, err := randomUUID()
-	if err != nil {
-		return fmt.Errorf("generating session ID: %w", err)
-	}
-
-	// Step 1: establish session context with the focus prompt.
-	step1 := buildClaudeArgs(configPath, append([]string{"-p", prompt, "--session-id", sessionID}, extraArgs...))
-	cmd := exec.Command(claudeBin, step1[1:]...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("focus run: %w", err)
-	}
-
-	// Step 2: resume that session interactively so the user can continue.
-	return launchClaude(configPath, append([]string{"--resume", sessionID}, extraArgs...))
+	return launchClaude(configPath, prompt, extraArgs)
 }
 
 func (c *Claude) SupportsInitialPrompt() bool { return true }
 
-func randomUUID() (string, error) {
-	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return "", err
-	}
-	b[6] = (b[6] & 0x0f) | 0x40 // version 4
-	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
-		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
-}
-
 // buildClaudeArgs constructs the argument list for the Claude Code CLI.
-// It adds --plugin-dir for artifact loading and --append-system-prompt
-// for harness instructions, then appends any vendor pass-through args.
-func buildClaudeArgs(configPath string, extraArgs []string) []string {
+// initialPrompt, when non-empty, is placed first so it precedes --add-dir;
+// --add-dir suppresses any positional arg that follows it.
+func buildClaudeArgs(configPath string, initialPrompt string, extraArgs []string) []string {
 	args := []string{"claude"}
+
+	// Positional prompt must come before --add-dir; --add-dir suppresses any
+	// positional arg that follows it in the args list.
+	if initialPrompt != "" {
+		args = append(args, initialPrompt)
+	}
 
 	// Load assembled artifacts (skills, agents, rules, commands) via --plugin-dir.
 	// Also --add-dir to grant read access so Claude doesn't prompt for permission
@@ -318,12 +287,12 @@ func (c *Claude) GenerateMCPConfig(servers map[string]plugin.MCPServer) (map[str
 	}, nil
 }
 
-func launchClaude(configPath string, extraArgs []string) error {
+func launchClaude(configPath string, initialPrompt string, extraArgs []string) error {
 	claudeBin, err := exec.LookPath("claude")
 	if err != nil {
 		return err
 	}
 
-	args := buildClaudeArgs(configPath, extraArgs)
+	args := buildClaudeArgs(configPath, initialPrompt, extraArgs)
 	return syscall.Exec(claudeBin, args, os.Environ())
 }

--- a/internal/vendor/claude_test.go
+++ b/internal/vendor/claude_test.go
@@ -22,7 +22,7 @@ func TestBuildClaudeArgs_WithInstructions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	args := buildClaudeArgs(configPath, []string{"--model", "opus"})
+	args := buildClaudeArgs(configPath, "", []string{"--model", "opus"})
 
 	expected := []string{
 		"claude",
@@ -50,7 +50,7 @@ func TestBuildClaudeArgs_NoInstructions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	args := buildClaudeArgs(configPath, nil)
+	args := buildClaudeArgs(configPath, "", nil)
 
 	expected := []string{
 		"claude",
@@ -79,7 +79,7 @@ func TestBuildClaudeArgs_EmptyInstructions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	args := buildClaudeArgs(configPath, nil)
+	args := buildClaudeArgs(configPath, "", nil)
 
 	for _, arg := range args {
 		if arg == "--append-system-prompt" {
@@ -95,7 +95,7 @@ func TestBuildClaudeArgs_ExtraArgsLast(t *testing.T) {
 	}
 
 	extra := []string{"--verbose", "--model", "sonnet"}
-	args := buildClaudeArgs(configPath, extra)
+	args := buildClaudeArgs(configPath, "", extra)
 
 	tail := args[len(args)-3:]
 	for i, want := range extra {
@@ -114,7 +114,7 @@ func TestBuildClaudeArgs_NonInteractive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	args := buildClaudeArgs(configPath, []string{"-p", "fix the bug"})
+	args := buildClaudeArgs(configPath, "", []string{"-p", "fix the bug"})
 
 	foundPlugin := false
 	foundAddDir := false
@@ -138,6 +138,36 @@ func TestBuildClaudeArgs_NonInteractive(t *testing.T) {
 	}
 	if !foundPrompt {
 		t.Error("missing -p prompt")
+	}
+}
+
+func TestBuildClaudeArgs_InitialPromptBeforeAddDir(t *testing.T) {
+	configPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(configPath, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	args := buildClaudeArgs(configPath, "do the thing", nil)
+
+	// Prompt must appear before --add-dir
+	promptIdx := -1
+	addDirIdx := -1
+	for i, arg := range args {
+		if arg == "do the thing" {
+			promptIdx = i
+		}
+		if arg == "--add-dir" {
+			addDirIdx = i
+		}
+	}
+	if promptIdx == -1 {
+		t.Fatal("initial prompt not found in args")
+	}
+	if addDirIdx == -1 {
+		t.Fatal("--add-dir not found in args")
+	}
+	if promptIdx > addDirIdx {
+		t.Errorf("prompt at index %d comes after --add-dir at index %d; --add-dir suppresses positional args that follow it", promptIdx, addDirIdx)
 	}
 }
 

--- a/internal/vendor/codex.go
+++ b/internal/vendor/codex.go
@@ -70,6 +70,15 @@ func (c *Codex) LaunchNonInteractive(configPath string, prompt string, extraArgs
 	return launchCodex(configPath, args)
 }
 
+func (c *Codex) LaunchWithInitialPrompt(configPath, prompt string, extraArgs []string) error {
+	// Positional arg without exec starts an interactive session with the prompt
+	// pre-loaded as the first user message (documented: codex "query").
+	args := append(extraArgs, prompt)
+	return launchCodex(configPath, args)
+}
+
+func (c *Codex) SupportsInitialPrompt() bool { return true }
+
 // codexHookEventMap maps canonical event names to Codex hook events.
 var codexHookEventMap = map[string]string{
 	"before_tool":   "PreToolUse",

--- a/internal/vendor/cursor.go
+++ b/internal/vendor/cursor.go
@@ -67,6 +67,15 @@ func (c *Cursor) LaunchNonInteractive(configPath string, prompt string, extraArg
 	return launchCursor(configPath, args)
 }
 
+func (c *Cursor) LaunchWithInitialPrompt(configPath, prompt string, extraArgs []string) error {
+	// Positional arg without -p starts an interactive session with the prompt
+	// pre-loaded as the first user message (documented: agent "query").
+	args := append(extraArgs, prompt)
+	return launchCursor(configPath, args)
+}
+
+func (c *Cursor) SupportsInitialPrompt() bool { return true }
+
 // cursorHookEventMap maps canonical event names to Cursor hook events.
 // Cursor supports: beforeSubmitPrompt, beforeShellExecution, beforeMCPExecution,
 // beforeReadFile, afterFileEdit, stop. There is no afterShellExecution event.


### PR DESCRIPTION
## Summary

Adds `ynh run --interactive` — launches the vendor CLI in interactive mode with the resolved focus prompt pre-submitted as the opening message, so the session starts with context already loaded.

## Changes

- `cmd/ynh/main.go`: `--interactive` flag on `ynh run`; when set alongside `--focus`, calls `LaunchWithInitialPrompt` instead of `LaunchNonInteractive`
- `internal/vendor/adapter.go`: `LaunchWithInitialPrompt(configPath, prompt string, extraArgs []string) error` added to `Adapter` interface; `ErrInitialPromptNotSupported` sentinel
- `internal/vendor/claude.go`: `buildClaudeArgs` now takes `initialPrompt string` and places it **first** in the arg list — before `--add-dir`, which silently suppresses any positional arg that follows it
- `internal/vendor/codex.go`, `cursor.go`: `LaunchWithInitialPrompt` implementations
- `cmd/ynh/vendors_test.go`: `supports_initial_prompt` field verified in JSON output

## Root cause fixed

Claude's `--add-dir` flag suppresses positional args that follow it. The original implementation appended the prompt after all flags, so it was dropped silently. The fix moves the prompt to position 2 (immediately after `"claude"`, before any flags).

Correct command shape:
```
claude "focus prompt text" --plugin-dir … --add-dir … --append-system-prompt "…"
```

## Testing

- [x] `make check` passes
- [x] Evals PASS (19 tutorials)
- [x] `cmd/ynh` e2e tests pass
- [x] `TestBuildClaudeArgs_InitialPromptBeforeAddDir` asserts ordering contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)