### PR TITLE
ci(release): increase goreleaser timeout to 90m

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,6 @@ jobs:
       - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
-          args: release --clean
+          args: release --clean --timeout 90m
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Docker multi-arch build takes ~60 min, hitting goreleaser's 1h default. Unblocks v0.3.0 release.