### PR TITLE
ci(release): split Docker into separate post-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,25 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "~> v2"
+          args: release --clean --skip=docker,docker_manifests
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+  docker:
+    name: Docker
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v4
@@ -42,9 +61,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: goreleaser/goreleaser-action@v7
+      - name: Build and push amd64
+        uses: docker/build-push-action@v6
         with:
-          version: "~> v2"
-          args: release --clean --timeout 90m
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/eyelock/ynh:${{ steps.version.outputs.version }}-amd64
+          build-args: VERSION=${{ steps.version.outputs.version }}
+
+      - name: Build and push arm64
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/eyelock/ynh:${{ steps.version.outputs.version }}-arm64
+          build-args: VERSION=${{ steps.version.outputs.version }}
+
+      - name: Create multi-arch manifest
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          docker buildx imagetools create -t ghcr.io/eyelock/ynh:${VERSION} \
+            ghcr.io/eyelock/ynh:${VERSION}-amd64 \
+            ghcr.io/eyelock/ynh:${VERSION}-arm64
+          docker buildx imagetools create -t ghcr.io/eyelock/ynh:latest \
+            ghcr.io/eyelock/ynh:${VERSION}-amd64 \
+            ghcr.io/eyelock/ynh:${VERSION}-arm64


### PR DESCRIPTION
Binary release (goreleaser) now completes in ~2 min. Docker multi-arch build runs after in its own job. Unblocks v0.3.0 re-release.