### PR TITLE
ci(release): fix goreleaser --skip=docker_manifests invalid flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
-          args: release --clean --skip=docker,docker_manifests
+          args: release --clean --skip=docker
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 


### PR DESCRIPTION
Removes invalid skip value — only `--skip=docker` is needed. Unblocks v0.3.0 re-release.