### PR TITLE
fix(harness): route include/delegate edits to source dir for local installs

### DIFF
--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -43,7 +43,7 @@ func ResolveEditTarget(ref string) (dir string, installed bool, err error) {
 			// If this harness was installed from a local path, edits must go to
 			// the source tree — not the registry copy — so the change is visible
 			// to git and any other tools watching the authored location.
-			if ins, insErr := plugin.LoadInstalledJSON(dir); insErr == nil && ins != nil && ins.SourceType == "local" && ins.Source != "" {
+			if ins, insErr := plugin.LoadInstalledJSON(dir); insErr == nil && ins != nil && (ins.SourceType == "local" || ins.SourceType == "source") && ins.Source != "" {
 				return ins.Source, true, nil
 			}
 			return dir, true, nil

--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -40,6 +40,12 @@ func ResolveEditTarget(ref string) (dir string, installed bool, err error) {
 	case namespace.RefID:
 		dir := InstalledDirByID(ref)
 		if DetectFormat(dir) == "plugin" {
+			// If this harness was installed from a local path, edits must go to
+			// the source tree — not the registry copy — so the change is visible
+			// to git and any other tools watching the authored location.
+			if ins, insErr := plugin.LoadInstalledJSON(dir); insErr == nil && ins != nil && ins.SourceType == "local" && ins.Source != "" {
+				return ins.Source, true, nil
+			}
 			return dir, true, nil
 		}
 		if ptr, _ := LoadPointerByID(ref); ptr != nil {

--- a/internal/harness/editor_test.go
+++ b/internal/harness/editor_test.go
@@ -137,6 +137,42 @@ func TestResolveEditTarget_Schema1PointerFallback(t *testing.T) {
 	}
 }
 
+// TestResolveEditTarget_LocalInstall verifies that when a harness was installed
+// from a local path (source_type == "local"), ResolveEditTarget returns the
+// original source directory rather than the registry copy.
+func TestResolveEditTarget_LocalInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Source tree (the authored location outside ~/.ynh/).
+	sourceDir := t.TempDir()
+	writeTestHarness(t, sourceDir, "my-harness")
+
+	// Registry copy: a manifest + installed.json pointing back to the source.
+	id := "local/my-harness"
+	registryDir := InstalledDirByID(id)
+	writeTestHarness(t, registryDir, "my-harness")
+	ins := &plugin.InstalledJSON{
+		SourceType:  "local",
+		Source:      sourceDir,
+		InstalledAt: "2026-05-11T00:00:00Z",
+	}
+	if err := plugin.SaveInstalledJSON(registryDir, ins); err != nil {
+		t.Fatal(err)
+	}
+
+	got, installed, err := ResolveEditTarget(id)
+	if err != nil {
+		t.Fatalf("ResolveEditTarget: %v", err)
+	}
+	if got != sourceDir {
+		t.Errorf("dir = %q, want source dir %q", got, sourceDir)
+	}
+	if !installed {
+		t.Error("expected installed=true")
+	}
+}
+
 // ---- AddInclude -------------------------------------------------------
 
 func TestAddInclude_New(t *testing.T) {

--- a/internal/harness/editor_test.go
+++ b/internal/harness/editor_test.go
@@ -173,6 +173,40 @@ func TestResolveEditTarget_LocalInstall(t *testing.T) {
 	}
 }
 
+// TestResolveEditTarget_SourceInstall verifies the same redirect behaviour for
+// source_type == "source" (installed by name from a configured ynh sources
+// entry). The Source field holds a local path just like source_type == "local".
+func TestResolveEditTarget_SourceInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	sourceDir := t.TempDir()
+	writeTestHarness(t, sourceDir, "my-harness")
+
+	id := "local/my-harness"
+	registryDir := InstalledDirByID(id)
+	writeTestHarness(t, registryDir, "my-harness")
+	ins := &plugin.InstalledJSON{
+		SourceType:  "source",
+		Source:      sourceDir,
+		InstalledAt: "2026-05-11T00:00:00Z",
+	}
+	if err := plugin.SaveInstalledJSON(registryDir, ins); err != nil {
+		t.Fatal(err)
+	}
+
+	got, installed, err := ResolveEditTarget(id)
+	if err != nil {
+		t.Fatalf("ResolveEditTarget: %v", err)
+	}
+	if got != sourceDir {
+		t.Errorf("dir = %q, want source dir %q", got, sourceDir)
+	}
+	if !installed {
+		t.Error("expected installed=true")
+	}
+}
+
 // ---- AddInclude -------------------------------------------------------
 
 func TestAddInclude_New(t *testing.T) {

--- a/test/e2e/delegate_test.go
+++ b/test/e2e/delegate_test.go
@@ -143,6 +143,85 @@ func TestDelegate_Update(t *testing.T) {
 	assertEqual(t, "delegates_to[0].path", mf.DelegatesTo[0].Path, "e2e-fixtures/fork-source")
 }
 
+// TestInclude_LocalInstall_WritesToSource verifies that include add/remove
+// target the original source directory — not the registry copy — when the
+// harness was installed from a local path. This is the regression test for
+// the bug where ResolveEditTarget returned the registry copy for
+// source_type=local installs.
+func TestInclude_LocalInstall_WritesToSource(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+	registryDir := filepath.Join(s.home, "harnesses", "local--minimal")
+
+	s.mustRunYnh(t, "install", sourceDir)
+
+	includeURL := "https://github.com/eyelock/assistants"
+	s.mustRunYnh(t, "include", "add", "local/minimal", includeURL,
+		"--path", "e2e-fixtures/included-skill",
+		"--ref", AssistantsFixturesSHA,
+	)
+
+	// The source dir must have the new include.
+	srcMf := readManifest(t, sourceDir)
+	if len(srcMf.Includes) != 1 {
+		t.Fatalf("source dir: expected 1 include after add, got %d", len(srcMf.Includes))
+	}
+	assertEqual(t, "source includes[0].git", srcMf.Includes[0].Git, includeURL)
+
+	// The registry copy must NOT have been touched.
+	regMf := readManifest(t, registryDir)
+	if len(regMf.Includes) != 0 {
+		t.Errorf("registry copy: expected 0 includes (untouched), got %d: %+v", len(regMf.Includes), regMf.Includes)
+	}
+
+	// Remove also targets the source.
+	s.mustRunYnh(t, "include", "remove", "local/minimal", includeURL, "--path", "e2e-fixtures/included-skill")
+
+	srcMf = readManifest(t, sourceDir)
+	if len(srcMf.Includes) != 0 {
+		t.Errorf("source dir: expected 0 includes after remove, got %d", len(srcMf.Includes))
+	}
+}
+
+// TestDelegate_LocalInstall_WritesToSource mirrors TestInclude_LocalInstall_WritesToSource
+// for the delegate add/remove path.
+func TestDelegate_LocalInstall_WritesToSource(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+	registryDir := filepath.Join(s.home, "harnesses", "local--minimal")
+
+	s.mustRunYnh(t, "install", sourceDir)
+
+	delegateURL := "https://github.com/eyelock/assistants"
+	s.mustRunYnh(t, "delegate", "add", "local/minimal", delegateURL,
+		"--path", "e2e-fixtures/fork-source",
+		"--ref", AssistantsFixturesSHA,
+	)
+
+	// The source dir must have the new delegate.
+	srcMf := readManifest(t, sourceDir)
+	if len(srcMf.DelegatesTo) != 1 {
+		t.Fatalf("source dir: expected 1 delegate after add, got %d", len(srcMf.DelegatesTo))
+	}
+	assertEqual(t, "source delegates_to[0].git", srcMf.DelegatesTo[0].Git, delegateURL)
+
+	// The registry copy must NOT have been touched.
+	regMf := readManifest(t, registryDir)
+	if len(regMf.DelegatesTo) != 0 {
+		t.Errorf("registry copy: expected 0 delegates (untouched), got %d: %+v", len(regMf.DelegatesTo), regMf.DelegatesTo)
+	}
+
+	// Remove also targets the source.
+	s.mustRunYnh(t, "delegate", "remove", "local/minimal", delegateURL, "--path", "e2e-fixtures/fork-source")
+
+	srcMf = readManifest(t, sourceDir)
+	if len(srcMf.DelegatesTo) != 0 {
+		t.Errorf("source dir: expected 0 delegates after remove, got %d", len(srcMf.DelegatesTo))
+	}
+}
+
 func readManifest(t *testing.T, harnessDir string) pluginManifest {
 	t.Helper()
 	body, err := os.ReadFile(filepath.Join(harnessDir, ".ynh-plugin", "plugin.json"))


### PR DESCRIPTION
## Summary

- `ResolveEditTarget` was returning the registry copy (`~/.ynh/harnesses/<id>/`) for all canonical-id refs, even when `installed.json` recorded `source_type=local`
- `include add/remove/update` and `delegate add/remove/update` silently wrote to the registry copy, leaving the user's source tree (and their git history) unchanged
- Fix: after detecting a valid manifest in the registry dir, check `installed.json`; if `source_type == "local"`, redirect to `ins.Source` so edits land in the authored location

## Test plan

- [x] `TestResolveEditTarget_LocalInstall` (unit) — asserts `ResolveEditTarget` returns the source path when `installed.json` has `source_type=local`
- [x] `TestInclude_LocalInstall_WritesToSource` (E2E) — asserts include add writes to the source dir and leaves the registry copy untouched; include remove also targets the source
- [x] `TestDelegate_LocalInstall_WritesToSource` (E2E) — same for delegate add/remove
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)