### PR TITLE
feat(run): add --instructions flag for per-invocation context injection

### DIFF
--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -156,6 +156,7 @@ Run flags:
   --focus <name>               Load a named focus (sets prompt and profile; implies non-interactive)
   --profile <name>             Apply a named profile overlay (with a prompt, implies non-interactive)
   --interactive                Override non-interactive default — stay in session after focus or prompt
+  --instructions "<text>"      Inject per-invocation context after harness instructions
   --session-name <name>        Session label (recorded by ynh, not forwarded to vendor CLI)
   --install                    Install symlinks for the vendor in current project
   --clean                      Remove symlinks for the vendor in current project
@@ -173,6 +174,8 @@ Examples:
   ynh run david --focus code-review
   ynh run david --focus code-review --interactive
   ynh run david --profile thorough -- "audit this module"
+  ynh run david --instructions "PR #22 in eyelock/assistants"
+  ynh run david --focus code-review --instructions "PR #22 in eyelock/assistants"
   ynh run david -v codex
   ynh run david --model opus -- "fix this bug"
   ynh run david -v codex -- "refactor auth"
@@ -1027,6 +1030,15 @@ func cmdRun(args []string) error {
 		}
 	}
 
+	// Inject per-invocation instructions into the vendor's pipeline.
+	if ra.Instructions != "" {
+		extraArgs, err := adapter.ApplyRuntimeInstructions(runDir, ra.Instructions)
+		if err != nil {
+			return fmt.Errorf("applying runtime instructions: %w", err)
+		}
+		vendorArgs = append(vendorArgs, extraArgs...)
+	}
+
 	// Dispatch based on action.
 	switch action {
 	case "install":
@@ -1245,16 +1257,17 @@ func resolveVendor(flag string, p *harness.Harness) (string, error) {
 // vendor flags take values.
 // runArgs holds parsed arguments for ynh run.
 type runArgs struct {
-	HarnessName string   // positional name, if given
-	HarnessFile string   // --harness-file or YNH_HARNESS_FILE
-	VendorFlag  string   // -v or YNH_VENDOR
-	ProfileFlag string   // --profile or YNH_PROFILE
-	FocusFlag   string   // --focus or YNH_FOCUS
-	SessionName string   // --session-name: consumed by ynh, not forwarded to vendor
-	Prompt      string   // trailing prompt after --
-	VendorArgs  []string // passthrough args for vendor CLI
-	Action      string   // "install", "clean", or ""
-	Interactive bool     // --interactive: stay in session after initial prompt
+	HarnessName  string   // positional name, if given
+	HarnessFile  string   // --harness-file or YNH_HARNESS_FILE
+	VendorFlag   string   // -v or YNH_VENDOR
+	ProfileFlag  string   // --profile or YNH_PROFILE
+	FocusFlag    string   // --focus or YNH_FOCUS
+	SessionName  string   // --session-name: consumed by ynh, not forwarded to vendor
+	Instructions string   // --instructions: per-invocation context injected into vendor pipeline
+	Prompt       string   // trailing prompt after --
+	VendorArgs   []string // passthrough args for vendor CLI
+	Action       string   // "install", "clean", or ""
+	Interactive  bool     // --interactive: stay in session after initial prompt
 }
 
 func parseRunArgs(args []string) runArgs {
@@ -1290,6 +1303,9 @@ func parseRunArgs(args []string) runArgs {
 			i++
 		case flagArgs[i] == "--session-name" && i+1 < len(flagArgs):
 			ra.SessionName = flagArgs[i+1]
+			i++
+		case flagArgs[i] == "--instructions" && i+1 < len(flagArgs):
+			ra.Instructions = flagArgs[i+1]
 			i++
 		case flagArgs[i] == "--install":
 			ra.Action = "install"

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -319,6 +319,60 @@ func TestParseRunArgs_Interactive(t *testing.T) {
 	}
 }
 
+func TestParseRunArgs_Instructions(t *testing.T) {
+	t.Setenv("YNH_FOCUS", "")
+	t.Setenv("YNH_HARNESS_FILE", "")
+
+	tests := []struct {
+		name             string
+		args             []string
+		wantInstructions string
+		wantVendorArgs   []string
+	}{
+		{
+			name:             "instructions flag",
+			args:             []string{"my-harness", "--instructions", "PR #22 in eyelock/assistants"},
+			wantInstructions: "PR #22 in eyelock/assistants",
+		},
+		{
+			name:             "instructions with focus",
+			args:             []string{"my-harness", "--focus", "review", "--instructions", "PR #22"},
+			wantInstructions: "PR #22",
+		},
+		{
+			name:             "instructions not forwarded to vendor",
+			args:             []string{"my-harness", "--instructions", "PR #22", "--model", "opus", "--", "fix this"},
+			wantInstructions: "PR #22",
+			wantVendorArgs:   []string{"--model", "opus"},
+		},
+		{
+			name:             "no instructions",
+			args:             []string{"my-harness"},
+			wantInstructions: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ra := parseRunArgs(tt.args)
+			if ra.Instructions != tt.wantInstructions {
+				t.Errorf("Instructions = %q, want %q", ra.Instructions, tt.wantInstructions)
+			}
+			if tt.wantVendorArgs != nil {
+				if len(ra.VendorArgs) != len(tt.wantVendorArgs) {
+					t.Errorf("VendorArgs = %v, want %v", ra.VendorArgs, tt.wantVendorArgs)
+				} else {
+					for i := range ra.VendorArgs {
+						if ra.VendorArgs[i] != tt.wantVendorArgs[i] {
+							t.Errorf("VendorArgs[%d] = %q, want %q", i, ra.VendorArgs[i], tt.wantVendorArgs[i])
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestResolveVendor(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/docs/tutorial/01-first-harness.md
+++ b/docs/tutorial/01-first-harness.md
@@ -227,6 +227,22 @@ my-harness --model opus -- "what are you? one sentence."
 
 `--model opus` passes through to Claude. The prompt comes after `--`.
 
+## T1.8b: Run with per-invocation instructions
+
+`--instructions` injects text into the vendor's instructions pipeline for this session only — after the harness `instructions.md`, before the session starts. It doesn't modify the harness.
+
+```bash
+my-harness --instructions "ticket: PROJ-42 — fix login timeout" -- "what's my current task?"
+```
+
+The agent should reference the ticket context in its response, even though it isn't in the harness `instructions.md`.
+
+Combined with `--focus`:
+
+```bash
+my-harness --focus code-review --instructions "PR #22 in eyelock/assistants"
+```
+
 ## T1.9: Inspect the assembled output
 
 > **Note:** The run directory is created by `ynh run`, which requires a vendor CLI. This step is only verifiable after running T1.6/T1.7/T1.8.

--- a/docs/tutorial/manual-test-plan.md
+++ b/docs/tutorial/manual-test-plan.md
@@ -40,6 +40,7 @@ Re-run `make install` after any code change you want to test.
 | T1.6 | Run interactive | [T1.6](tutorial/01-first-harness.md#t16-run-interactive) |
 | T1.7 | Run non-interactive | [T1.7](tutorial/01-first-harness.md#t17-run-non-interactive) |
 | T1.8 | Run with vendor flags | [T1.8](tutorial/01-first-harness.md#t18-run-with-vendor-flags) |
+| T1.8b | Run with --instructions | [T1.8b](tutorial/01-first-harness.md#t18b-run-with-per-invocation-instructions) |
 | T1.9 | Inspect assembled output | [T1.9](tutorial/01-first-harness.md#t19-inspect-the-assembled-output) |
 | T1.10 | Uninstall | [T1.10](tutorial/01-first-harness.md#t110-uninstall) |
 

--- a/internal/assembler/assembler_test.go
+++ b/internal/assembler/assembler_test.go
@@ -56,6 +56,9 @@ func (m *mockAdapter) MarketplaceManifestDir() string        { return ".mock-plu
 func (m *mockAdapter) GenerateMarketplaceIndex(cfg vendor.MarketplaceIndexConfig, plugins []vendor.MarketplacePluginInfo) ([]byte, error) {
 	return nil, nil
 }
+func (m *mockAdapter) ApplyRuntimeInstructions(runDir, text string) ([]string, error) {
+	return nil, nil
+}
 
 func TestAssembleWithPick(t *testing.T) {
 	// Create a fake repo with skills and agents

--- a/internal/vendor/adapter.go
+++ b/internal/vendor/adapter.go
@@ -80,6 +80,13 @@ type Adapter interface {
 	// their own files as needed (e.g. CLAUDE.md, .cursorrules).
 	GenerateSystemPrompt(content []byte) map[string][]byte
 
+	// ApplyRuntimeInstructions injects per-invocation context into the vendor's
+	// instructions pipeline. For CLI-flag vendors (Claude, Codex) it returns
+	// extra args to append to the launch call; for file-based vendors (Cursor)
+	// it writes directly to the run dir and returns nil args.
+	// text is guaranteed non-empty by the caller.
+	ApplyRuntimeInstructions(runDir, text string) ([]string, error)
+
 	// GenerateHookConfig translates canonical hook declarations to vendor-native
 	// hook configuration files. Returns a map of relative file paths to file contents.
 	// Returns nil if hooks is nil or empty.

--- a/internal/vendor/claude.go
+++ b/internal/vendor/claude.go
@@ -75,6 +75,10 @@ func (c *Claude) LaunchWithInitialPrompt(configPath, prompt string, extraArgs []
 
 func (c *Claude) SupportsInitialPrompt() bool { return true }
 
+func (c *Claude) ApplyRuntimeInstructions(runDir, text string) ([]string, error) {
+	return []string{"--append-system-prompt", text}, nil
+}
+
 // buildClaudeArgs constructs the argument list for the Claude Code CLI.
 // initialPrompt, when non-empty, is placed first so it precedes --add-dir;
 // --add-dir suppresses any positional arg that follows it.

--- a/internal/vendor/claude_test.go
+++ b/internal/vendor/claude_test.go
@@ -370,3 +370,20 @@ func TestClaudeGenerateHookConfig_EventTranslation(t *testing.T) {
 		}
 	}
 }
+
+func TestClaudeApplyRuntimeInstructions(t *testing.T) {
+	c := &Claude{}
+	args, err := c.ApplyRuntimeInstructions(t.TempDir(), "PR #22 in eyelock/assistants")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(args) != 2 {
+		t.Fatalf("args = %v, want 2 elements", args)
+	}
+	if args[0] != "--append-system-prompt" {
+		t.Errorf("args[0] = %q, want --append-system-prompt", args[0])
+	}
+	if args[1] != "PR #22 in eyelock/assistants" {
+		t.Errorf("args[1] = %q, want PR #22 in eyelock/assistants", args[1])
+	}
+}

--- a/internal/vendor/codex.go
+++ b/internal/vendor/codex.go
@@ -79,6 +79,10 @@ func (c *Codex) LaunchWithInitialPrompt(configPath, prompt string, extraArgs []s
 
 func (c *Codex) SupportsInitialPrompt() bool { return true }
 
+func (c *Codex) ApplyRuntimeInstructions(runDir, text string) ([]string, error) {
+	return []string{"-c", "developer_instructions=" + text}, nil
+}
+
 // codexHookEventMap maps canonical event names to Codex hook events.
 var codexHookEventMap = map[string]string{
 	"before_tool":   "PreToolUse",

--- a/internal/vendor/codex_test.go
+++ b/internal/vendor/codex_test.go
@@ -247,3 +247,20 @@ func TestCodexGenerateHookConfig_EventTranslation(t *testing.T) {
 		}
 	}
 }
+
+func TestCodexApplyRuntimeInstructions(t *testing.T) {
+	c := &Codex{}
+	args, err := c.ApplyRuntimeInstructions(t.TempDir(), "PR #22 in eyelock/assistants")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(args) != 2 {
+		t.Fatalf("args = %v, want 2 elements", args)
+	}
+	if args[0] != "-c" {
+		t.Errorf("args[0] = %q, want -c", args[0])
+	}
+	if args[1] != "developer_instructions=PR #22 in eyelock/assistants" {
+		t.Errorf("args[1] = %q, want developer_instructions=PR #22 in eyelock/assistants", args[1])
+	}
+}

--- a/internal/vendor/cursor.go
+++ b/internal/vendor/cursor.go
@@ -3,6 +3,7 @@ package vendor
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -75,6 +76,22 @@ func (c *Cursor) LaunchWithInitialPrompt(configPath, prompt string, extraArgs []
 }
 
 func (c *Cursor) SupportsInitialPrompt() bool { return true }
+
+func (c *Cursor) ApplyRuntimeInstructions(runDir, text string) ([]string, error) {
+	cursorrules := filepath.Join(runDir, ".cursorrules")
+	f, err := os.OpenFile(cursorrules, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("opening .cursorrules: %w", err)
+	}
+	if _, err := fmt.Fprintf(f, "\n\n%s\n", text); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("writing runtime instructions: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return nil, fmt.Errorf("closing .cursorrules: %w", err)
+	}
+	return nil, nil
+}
 
 // cursorHookEventMap maps canonical event names to Cursor hook events.
 // Cursor supports: beforeSubmitPrompt, beforeShellExecution, beforeMCPExecution,

--- a/internal/vendor/cursor_test.go
+++ b/internal/vendor/cursor_test.go
@@ -2,7 +2,9 @@ package vendor
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/eyelock/ynh/internal/plugin"
@@ -168,5 +170,55 @@ func TestCursorGenerateHookConfig_EventTranslation(t *testing.T) {
 		if _, ok := hooksObj[event]; !ok {
 			t.Errorf("missing event %s", event)
 		}
+	}
+}
+
+func TestCursorApplyRuntimeInstructions(t *testing.T) {
+	runDir := t.TempDir()
+	existing := "harness instructions"
+	if err := os.WriteFile(filepath.Join(runDir, ".cursorrules"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Cursor{}
+	args, err := c.ApplyRuntimeInstructions(runDir, "PR #22 in eyelock/assistants")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(args) != 0 {
+		t.Errorf("args = %v, want empty (Cursor uses file injection)", args)
+	}
+
+	data, err := os.ReadFile(filepath.Join(runDir, ".cursorrules"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.HasPrefix(content, existing) {
+		t.Errorf(".cursorrules does not start with original content")
+	}
+	if !strings.Contains(content, "PR #22 in eyelock/assistants") {
+		t.Errorf(".cursorrules missing injected instructions: %q", content)
+	}
+}
+
+func TestCursorApplyRuntimeInstructions_NoExistingFile(t *testing.T) {
+	runDir := t.TempDir()
+
+	c := &Cursor{}
+	args, err := c.ApplyRuntimeInstructions(runDir, "PR #22")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(args) != 0 {
+		t.Errorf("args = %v, want empty", args)
+	}
+
+	data, err := os.ReadFile(filepath.Join(runDir, ".cursorrules"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "PR #22") {
+		t.Errorf(".cursorrules missing injected instructions")
 	}
 }


### PR DESCRIPTION
## Summary

Adds `--instructions "<text>"` to `ynh run` so callers can inject per-invocation context into a harness session without modifying the harness definition.

Closes #151.

## Changes

- New `ApplyRuntimeInstructions(runDir, text string) ([]string, error)` method on the `Adapter` interface — keeps vendor logic encapsulated
- **Claude**: returns `["--append-system-prompt", text]` — appends after the harness instructions already in that pipeline
- **Codex**: returns `["-c", "developer_instructions=<text>"]` — uses Codex's native config override
- **Cursor**: appends to `.cursorrules` in the run dir — no CLI flag equivalent exists
- `--instructions` parsed in `parseRunArgs`, consumed by ynh (not forwarded to vendor via passthrough)
- `ApplyRuntimeInstructions` called after assembly, before launch — extra args appended to `vendorArgs`
- Help text and examples updated
- Tutorial 01 gets a T1.8b section; manual test plan index updated

## Testing

- [x] `make check` passes (lint, format, test, build all green)
- [x] Unit tests for all three adapter implementations
- [x] `parseRunArgs` tests confirm `--instructions` is consumed and not forwarded to vendor args

## Related Issues

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)