### PR TITLE
fix(harness): hotfix 0.3.1 — source dir routing and dead code removal

### DIFF
--- a/cmd/ynh/fork.go
+++ b/cmd/ynh/fork.go
@@ -86,9 +86,8 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 			fmt.Sprintf("invalid --format value %q (want text or json)", format))
 	}
 
-	// Load source harness. LoadQualified accepts both bare names ("researcher")
-	// and namespace-qualified refs ("researcher@org/repo") so callers can
-	// disambiguate when two registries publish the same name.
+	// Load source harness. Rejects bare names and the legacy "@" form — a
+	// canonical id (e.g. "github.com/org/repo/name" or "local/name") is required.
 	p, err := harness.LoadQualified(name)
 	if err != nil {
 		code := errCodeNotFound
@@ -129,12 +128,10 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 			fmt.Sprintf("destination already exists: %s", absDestDir))
 	}
 
-	// Clash check: refuse to register if a flat install already claims the
-	// install name — either a pointer file or a flat tree at
-	// ~/.ynh/harnesses/<installName>/. Namespaced installs of the same name
-	// are fine; they remain accessible via "name@org/repo" while the fork
-	// takes over the bare name. Same rule ynh install uses, applied at
-	// registration time.
+	// Clash check: refuse to register if an install already claims this name —
+	// either a pointer file or a flat tree at ~/.ynh/harnesses/<installName>/.
+	// Installs under a different canonical id (different namespace) are fine.
+	// Same rule ynh install uses, applied at registration time.
 	if existing, err := harness.LoadPointer(installName); err == nil && existing != nil {
 		return cliError(stderr, structured, errCodeInvalidInput,
 			fmt.Sprintf("harness %q is already installed (registered at %s)", installName, existing.Source))
@@ -195,9 +192,9 @@ func cmdForkTo(args []string, stdout, stderr io.Writer) error {
 			fmt.Sprintf("saving provenance: %v", saveErr))
 	}
 
-	// Register the fork in the YNH layer via a pointer file. Pointer wins
-	// over tree-shaped installs in Load() so subsequent ynh run / ls / info
-	// resolve to absDestDir directly — no copy under ~/.ynh/harnesses.
+	// Register the fork in the YNH layer via a pointer file so subsequent
+	// ynh run / ls / info resolve to absDestDir directly — no copy under
+	// ~/.ynh/harnesses.
 	ptr := &harness.Pointer{
 		Name:        installName,
 		SourceType:  "local",

--- a/cmd/ynh/info.go
+++ b/cmd/ynh/info.go
@@ -307,7 +307,7 @@ func printInfoJSON(stdout, stderr io.Writer, name string, checkUpdates bool) err
 		return cliError(stderr, true, code, err.Error())
 	}
 
-	// Migration chain has run (harness.Load was called above), so the manifest
+	// Migration chain has run (harness.LoadQualified was called above), so the manifest
 	// is always at the new path.
 	manifestPath := filepath.Join(p.Dir, plugin.PluginDir, plugin.PluginFile)
 	raw, err := os.ReadFile(manifestPath)

--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -472,13 +472,7 @@ func buildDelegates(delegates []harness.Delegate) []listDelegate {
 	return result
 }
 
-// formatArtifactSummary formats the ARTIFACTS column for ynh ls.
-// Shows a compact summary like "1s 2a 1r 1c" (skills, agents, rules, commands).
-func formatArtifactSummary(name string) string {
-	return formatArtifactSummaryDir(harness.InstalledDir(name))
-}
-
-// formatArtifactSummaryDir formats the ARTIFACTS column from an explicit directory.
+// formatArtifactSummaryDir formats the ARTIFACTS column for ynh ls from an explicit directory.
 func formatArtifactSummaryDir(dir string) string {
 	arts, _ := harness.ScanArtifactsDir(dir)
 	if arts.Total() == 0 {

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -402,7 +402,7 @@ func installTestHarness(t *testing.T, name string) string {
 	t.Helper()
 	id := "local/" + name
 
-	// Schema-1 flat path — for legacy Load(name) callers.
+	// Schema-1 flat path — retained for tests that exercise schema-1 compat fallbacks.
 	flatDir := harness.InstalledDir(name)
 	if err := os.MkdirAll(flatDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -709,9 +709,9 @@ func TestFormatArtifactSummary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := formatArtifactSummary("artfmt")
+	got := formatArtifactSummaryDir(harnessDir)
 	if got != "2s 1a" {
-		t.Errorf("formatArtifactSummary() = %q, want %q", got, "2s 1a")
+		t.Errorf("formatArtifactSummaryDir() = %q, want %q", got, "2s 1a")
 	}
 }
 
@@ -721,9 +721,9 @@ func TestFormatArtifactSummary_Empty(t *testing.T) {
 	t.Setenv("YNH_HOME", "")
 
 	installTestHarness(t, "neart")
-	got := formatArtifactSummary("neart")
+	got := formatArtifactSummaryDir(harness.InstalledDirByID("local/neart"))
 	if got != "0" {
-		t.Errorf("formatArtifactSummary() = %q, want %q", got, "0")
+		t.Errorf("formatArtifactSummaryDir() = %q, want %q", got, "0")
 	}
 }
 

--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -40,6 +40,12 @@ func ResolveEditTarget(ref string) (dir string, installed bool, err error) {
 	case namespace.RefID:
 		dir := InstalledDirByID(ref)
 		if DetectFormat(dir) == "plugin" {
+			// If this harness was installed from a local path, edits must go to
+			// the source tree — not the registry copy — so the change is visible
+			// to git and any other tools watching the authored location.
+			if ins, insErr := plugin.LoadInstalledJSON(dir); insErr == nil && ins != nil && (ins.SourceType == "local" || ins.SourceType == "source") && ins.Source != "" {
+				return ins.Source, true, nil
+			}
 			return dir, true, nil
 		}
 		if ptr, _ := LoadPointerByID(ref); ptr != nil {

--- a/internal/harness/editor_test.go
+++ b/internal/harness/editor_test.go
@@ -137,6 +137,76 @@ func TestResolveEditTarget_Schema1PointerFallback(t *testing.T) {
 	}
 }
 
+// TestResolveEditTarget_LocalInstall verifies that when a harness was installed
+// from a local path (source_type == "local"), ResolveEditTarget returns the
+// original source directory rather than the registry copy.
+func TestResolveEditTarget_LocalInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Source tree (the authored location outside ~/.ynh/).
+	sourceDir := t.TempDir()
+	writeTestHarness(t, sourceDir, "my-harness")
+
+	// Registry copy: a manifest + installed.json pointing back to the source.
+	id := "local/my-harness"
+	registryDir := InstalledDirByID(id)
+	writeTestHarness(t, registryDir, "my-harness")
+	ins := &plugin.InstalledJSON{
+		SourceType:  "local",
+		Source:      sourceDir,
+		InstalledAt: "2026-05-11T00:00:00Z",
+	}
+	if err := plugin.SaveInstalledJSON(registryDir, ins); err != nil {
+		t.Fatal(err)
+	}
+
+	got, installed, err := ResolveEditTarget(id)
+	if err != nil {
+		t.Fatalf("ResolveEditTarget: %v", err)
+	}
+	if got != sourceDir {
+		t.Errorf("dir = %q, want source dir %q", got, sourceDir)
+	}
+	if !installed {
+		t.Error("expected installed=true")
+	}
+}
+
+// TestResolveEditTarget_SourceInstall verifies the same redirect behaviour for
+// source_type == "source" (installed by name from a configured ynh sources
+// entry). The Source field holds a local path just like source_type == "local".
+func TestResolveEditTarget_SourceInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	sourceDir := t.TempDir()
+	writeTestHarness(t, sourceDir, "my-harness")
+
+	id := "local/my-harness"
+	registryDir := InstalledDirByID(id)
+	writeTestHarness(t, registryDir, "my-harness")
+	ins := &plugin.InstalledJSON{
+		SourceType:  "source",
+		Source:      sourceDir,
+		InstalledAt: "2026-05-11T00:00:00Z",
+	}
+	if err := plugin.SaveInstalledJSON(registryDir, ins); err != nil {
+		t.Fatal(err)
+	}
+
+	got, installed, err := ResolveEditTarget(id)
+	if err != nil {
+		t.Fatalf("ResolveEditTarget: %v", err)
+	}
+	if got != sourceDir {
+		t.Errorf("dir = %q, want source dir %q", got, sourceDir)
+	}
+	if !installed {
+		t.Error("expected installed=true")
+	}
+}
+
 // ---- AddInclude -------------------------------------------------------
 
 func TestAddInclude_New(t *testing.T) {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -156,26 +156,6 @@ func DetectFormat(dir string) string {
 // ErrNotFound is returned when a harness is not installed.
 var ErrNotFound = errors.New("harness not found")
 
-// Load finds and loads an installed harness by name. Resolution precedence:
-//  1. Pointer file at ~/.ynh/installed/<name>.json (local fork)
-//  2. Flat tree at ~/.ynh/harnesses/<name>/
-//  3. Namespaced tree at ~/.ynh/harnesses/<ns--repo>/<name>/
-//
-// The migration chain runs inside LoadDir so no legacy handling is needed
-// here.
-func Load(name string) (*Harness, error) {
-	if ptr, err := LoadPointer(name); err != nil {
-		return nil, err
-	} else if ptr != nil {
-		return loadFromPointer(ptr)
-	}
-	flatDir := InstalledDir(name)
-	if _, err := os.Stat(flatDir); err == nil {
-		return LoadDir(flatDir)
-	}
-	return findInNamespacedDirs(name)
-}
-
 // LoadQualified loads an installed harness by canonical id. Schema 2 only:
 // bare names and the legacy "name@org/repo" form are hard-rejected with a
 // hint pointing at the canonical id and the local path alternative.
@@ -218,28 +198,6 @@ func LoadNS(ns, name string) (*Harness, error) {
 		return nil, fmt.Errorf("harness %q@%q: %w", name, ns, ErrNotFound)
 	}
 	return LoadDir(dir)
-}
-
-// findInNamespacedDirs scans ~/.ynh/harnesses/<ns>/<name>/ for a matching harness.
-func findInNamespacedDirs(name string) (*Harness, error) {
-	harnessesDir := config.HarnessesDir()
-	entries, err := os.ReadDir(harnessesDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("harness %q: %w", name, ErrNotFound)
-		}
-		return nil, err
-	}
-	for _, e := range entries {
-		if !e.IsDir() || !strings.Contains(e.Name(), "--") {
-			continue
-		}
-		candidate := filepath.Join(harnessesDir, e.Name(), name)
-		if DetectFormat(candidate) != "" {
-			return LoadDir(candidate)
-		}
-	}
-	return nil, fmt.Errorf("harness %q: %w", name, ErrNotFound)
 }
 
 // List returns the names of all installed harnesses across all namespaces.
@@ -750,12 +708,6 @@ var ArtifactTypeDirs = []string{"skills"}
 // Keep this list in lock-step with the pick.items pattern in
 // docs/schema/plugin.schema.json.
 var ArtifactTypeFiles = []string{"agents", "rules", "commands"}
-
-// ScanArtifacts discovers local artifacts in a harness's installed directory.
-// Skills are directories containing SKILL.md; agents, rules, and commands are .md files.
-func ScanArtifacts(name string) (*Artifacts, error) {
-	return ScanArtifactsDir(InstalledDir(name))
-}
 
 // ScanArtifactsDir discovers artifacts in an arbitrary directory.
 func ScanArtifactsDir(dir string) (*Artifacts, error) {

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -41,65 +41,6 @@ func TestDetectFormat_None(t *testing.T) {
 	}
 }
 
-func TestLoad_HarnessFormat(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-	t.Setenv("YNH_HOME", "")
-
-	harnessDir := filepath.Join(dir, ".ynh", "harnesses", "mytest")
-	writeTestHarness(t, harnessDir, "mytest")
-
-	p, err := Load("mytest")
-	if err != nil {
-		t.Fatalf("Load failed: %v", err)
-	}
-	if p.Name != "mytest" {
-		t.Errorf("Name = %q, want %q", p.Name, "mytest")
-	}
-	if p.DefaultVendor != "claude" {
-		t.Errorf("DefaultVendor = %q, want %q", p.DefaultVendor, "claude")
-	}
-}
-
-func TestLoad_LegacyFormat(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-	t.Setenv("YNH_HOME", "")
-
-	harnessDir := filepath.Join(dir, ".ynh", "harnesses", "old")
-	pluginDir := filepath.Join(harnessDir, ".claude-plugin")
-	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(`{"name":"old"}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := Load("old")
-	if err == nil {
-		t.Fatal("expected error for legacy format")
-	}
-	if got := err.Error(); !strings.Contains(got, "legacy") {
-		t.Errorf("error = %q, want legacy format hint", got)
-	}
-}
-
-func TestLoad_NotFound(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-	t.Setenv("YNH_HOME", "")
-
-	harnessDir := filepath.Join(dir, ".ynh", "harnesses", "empty")
-	if err := os.MkdirAll(harnessDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := Load("empty")
-	if err == nil {
-		t.Fatal("expected error for directory without harness.json")
-	}
-}
-
 func TestLoadDir_FullMetadata(t *testing.T) {
 	dir := t.TempDir()
 	hj := `{
@@ -711,7 +652,7 @@ func TestScanArtifacts(t *testing.T) {
 		}
 	}
 
-	arts, err := ScanArtifacts("arttest")
+	arts, err := ScanArtifactsDir(harnessDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -744,7 +685,7 @@ func TestScanArtifacts_Empty(t *testing.T) {
 	harnessDir := filepath.Join(dir, ".ynh", "harnesses", "empty")
 	writeTestHarness(t, harnessDir, "empty")
 
-	arts, err := ScanArtifacts("empty")
+	arts, err := ScanArtifactsDir(harnessDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -770,7 +711,7 @@ func TestScanArtifacts_SkillWithoutManifest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	arts, err := ScanArtifacts("nosk")
+	arts, err := ScanArtifactsDir(harnessDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/harness/pointer.go
+++ b/internal/harness/pointer.go
@@ -16,8 +16,8 @@ import (
 // Pointer is the on-disk shape of ~/.ynh/installed/<name>.json.
 //
 // Pointer files register a user-owned source tree (a fork) into the YNH layer
-// without copying it. Load(name) prefers a pointer over the tree-shaped
-// install at ~/.ynh/harnesses/<name>/. Edits to the source tree are live to
+// without copying it. LoadByID("local/<name>") resolves via the pointer first,
+// so edits to the source tree are live to
 // ynh run with no sync step.
 //
 // Provenance (what the harness *is*) lives in the source tree at

--- a/internal/harness/pointer_test.go
+++ b/internal/harness/pointer_test.go
@@ -66,15 +66,17 @@ func TestPointer_LoadMissing(t *testing.T) {
 	}
 }
 
-func TestLoad_PointerBeatsTreePrecedence(t *testing.T) {
+func TestLoadByID_PointerBeatsTreePrecedence(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("YNH_HOME", home)
 
-	// Create a tree-shaped install at ~/.ynh/harnesses/researcher
-	treeDir := filepath.Join(home, "harnesses", "researcher")
+	// Create a tree-shaped install at the schema-2 path
+	treeDir := filepath.Join(home, "harnesses", "local--researcher")
 	writeForkTree(t, treeDir, "researcher")
 
-	// Create a fork tree elsewhere and a pointer registering it
+	// Create a fork tree elsewhere and register it via a schema-1 pointer
+	// (simulating a fork written by an older binary, exercising the fallback
+	// in LoadByID that reads name-keyed pointer files).
 	forkDir := filepath.Join(t.TempDir(), "researcher")
 	writeForkTree(t, forkDir, "researcher")
 	if err := SavePointer(&Pointer{
@@ -86,22 +88,23 @@ func TestLoad_PointerBeatsTreePrecedence(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := Load("researcher")
+	p, err := LoadByID("local/researcher")
 	if err != nil {
-		t.Fatalf("Load: %v", err)
+		t.Fatalf("LoadByID: %v", err)
 	}
-	// Pointer must win — Dir resolves to forkDir, not the flat tree.
+	// Pointer must win — Dir resolves to forkDir, not the tree.
 	absFork, _ := filepath.Abs(forkDir)
 	if p.Dir != absFork {
-		t.Errorf("Load resolved to %q, want %q (pointer should beat flat tree)", p.Dir, absFork)
+		t.Errorf("LoadByID resolved to %q, want %q (pointer should beat tree)", p.Dir, absFork)
 	}
 }
 
-func TestLoad_PointerWithMissingSource(t *testing.T) {
+func TestLoadByID_PointerWithMissingSource(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("YNH_HOME", home)
 
-	// Pointer references a path that doesn't exist
+	// Schema-1 pointer (name-keyed) pointing at a path that no longer exists,
+	// exercising the LoadByID schema-1 fallback for "local/<name>" ids.
 	if err := SavePointer(&Pointer{
 		Name:        "ghost",
 		SourceType:  "local",
@@ -111,7 +114,7 @@ func TestLoad_PointerWithMissingSource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := Load("ghost")
+	_, err := LoadByID("local/ghost")
 	if err == nil {
 		t.Fatal("expected error for missing pointer source")
 	}

--- a/test/e2e/delegate_test.go
+++ b/test/e2e/delegate_test.go
@@ -143,6 +143,85 @@ func TestDelegate_Update(t *testing.T) {
 	assertEqual(t, "delegates_to[0].path", mf.DelegatesTo[0].Path, "e2e-fixtures/fork-source")
 }
 
+// TestInclude_LocalInstall_WritesToSource verifies that include add/remove
+// target the original source directory — not the registry copy — when the
+// harness was installed from a local path. This is the regression test for
+// the bug where ResolveEditTarget returned the registry copy for
+// source_type=local installs.
+func TestInclude_LocalInstall_WritesToSource(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+	registryDir := filepath.Join(s.home, "harnesses", "local--minimal")
+
+	s.mustRunYnh(t, "install", sourceDir)
+
+	includeURL := "https://github.com/eyelock/assistants"
+	s.mustRunYnh(t, "include", "add", "local/minimal", includeURL,
+		"--path", "e2e-fixtures/included-skill",
+		"--ref", AssistantsFixturesSHA,
+	)
+
+	// The source dir must have the new include.
+	srcMf := readManifest(t, sourceDir)
+	if len(srcMf.Includes) != 1 {
+		t.Fatalf("source dir: expected 1 include after add, got %d", len(srcMf.Includes))
+	}
+	assertEqual(t, "source includes[0].git", srcMf.Includes[0].Git, includeURL)
+
+	// The registry copy must NOT have been touched.
+	regMf := readManifest(t, registryDir)
+	if len(regMf.Includes) != 0 {
+		t.Errorf("registry copy: expected 0 includes (untouched), got %d: %+v", len(regMf.Includes), regMf.Includes)
+	}
+
+	// Remove also targets the source.
+	s.mustRunYnh(t, "include", "remove", "local/minimal", includeURL, "--path", "e2e-fixtures/included-skill")
+
+	srcMf = readManifest(t, sourceDir)
+	if len(srcMf.Includes) != 0 {
+		t.Errorf("source dir: expected 0 includes after remove, got %d", len(srcMf.Includes))
+	}
+}
+
+// TestDelegate_LocalInstall_WritesToSource mirrors TestInclude_LocalInstall_WritesToSource
+// for the delegate add/remove path.
+func TestDelegate_LocalInstall_WritesToSource(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+	registryDir := filepath.Join(s.home, "harnesses", "local--minimal")
+
+	s.mustRunYnh(t, "install", sourceDir)
+
+	delegateURL := "https://github.com/eyelock/assistants"
+	s.mustRunYnh(t, "delegate", "add", "local/minimal", delegateURL,
+		"--path", "e2e-fixtures/fork-source",
+		"--ref", AssistantsFixturesSHA,
+	)
+
+	// The source dir must have the new delegate.
+	srcMf := readManifest(t, sourceDir)
+	if len(srcMf.DelegatesTo) != 1 {
+		t.Fatalf("source dir: expected 1 delegate after add, got %d", len(srcMf.DelegatesTo))
+	}
+	assertEqual(t, "source delegates_to[0].git", srcMf.DelegatesTo[0].Git, delegateURL)
+
+	// The registry copy must NOT have been touched.
+	regMf := readManifest(t, registryDir)
+	if len(regMf.DelegatesTo) != 0 {
+		t.Errorf("registry copy: expected 0 delegates (untouched), got %d: %+v", len(regMf.DelegatesTo), regMf.DelegatesTo)
+	}
+
+	// Remove also targets the source.
+	s.mustRunYnh(t, "delegate", "remove", "local/minimal", delegateURL, "--path", "e2e-fixtures/fork-source")
+
+	srcMf = readManifest(t, sourceDir)
+	if len(srcMf.DelegatesTo) != 0 {
+		t.Errorf("source dir: expected 0 delegates after remove, got %d", len(srcMf.DelegatesTo))
+	}
+}
+
 func readManifest(t *testing.T, harnessDir string) pluginManifest {
 	t.Helper()
 	body, err := os.ReadFile(filepath.Join(harnessDir, ".ynh-plugin", "plugin.json"))

--- a/test/e2e/delegate_test.go
+++ b/test/e2e/delegate_test.go
@@ -32,7 +32,8 @@ type manifestSourceJSON struct {
 func TestDelegate_AddRemove(t *testing.T) {
 	s := newSandbox(t)
 	clone := cloneAssistantsAtSHA(t)
-	s.mustRunYnh(t, "install", filepath.Join(clone, "e2e-fixtures", "minimal"))
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+	s.mustRunYnh(t, "install", sourceDir)
 
 	delegateURL := "https://github.com/eyelock/assistants"
 	s.mustRunYnh(t, "delegate", "add", "local/minimal", delegateURL,
@@ -40,7 +41,7 @@ func TestDelegate_AddRemove(t *testing.T) {
 		"--ref", AssistantsFixturesSHA,
 	)
 
-	mf := readManifest(t, filepath.Join(s.home, "harnesses", "local--minimal"))
+	mf := readManifest(t, sourceDir)
 	if len(mf.DelegatesTo) != 1 {
 		t.Fatalf("expected 1 delegate after add, got %d: %+v", len(mf.DelegatesTo), mf.DelegatesTo)
 	}
@@ -51,7 +52,7 @@ func TestDelegate_AddRemove(t *testing.T) {
 
 	s.mustRunYnh(t, "delegate", "remove", "local/minimal", delegateURL, "--path", "e2e-fixtures/fork-source")
 
-	mf = readManifest(t, filepath.Join(s.home, "harnesses", "local--minimal"))
+	mf = readManifest(t, sourceDir)
 	if len(mf.DelegatesTo) != 0 {
 		t.Errorf("expected 0 delegates after remove, got %d", len(mf.DelegatesTo))
 	}
@@ -61,7 +62,8 @@ func TestDelegate_AddRemove(t *testing.T) {
 func TestInclude_AddRemove(t *testing.T) {
 	s := newSandbox(t)
 	clone := cloneAssistantsAtSHA(t)
-	s.mustRunYnh(t, "install", filepath.Join(clone, "e2e-fixtures", "minimal"))
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+	s.mustRunYnh(t, "install", sourceDir)
 
 	includeURL := "https://github.com/eyelock/assistants"
 	s.mustRunYnh(t, "include", "add", "local/minimal", includeURL,
@@ -69,7 +71,7 @@ func TestInclude_AddRemove(t *testing.T) {
 		"--ref", AssistantsFixturesSHA,
 	)
 
-	mf := readManifest(t, filepath.Join(s.home, "harnesses", "local--minimal"))
+	mf := readManifest(t, sourceDir)
 	if len(mf.Includes) != 1 {
 		t.Fatalf("expected 1 include after add, got %d", len(mf.Includes))
 	}
@@ -80,7 +82,7 @@ func TestInclude_AddRemove(t *testing.T) {
 
 	s.mustRunYnh(t, "include", "remove", "local/minimal", includeURL, "--path", "e2e-fixtures/included-skill")
 
-	mf = readManifest(t, filepath.Join(s.home, "harnesses", "local--minimal"))
+	mf = readManifest(t, sourceDir)
 	if len(mf.Includes) != 0 {
 		t.Errorf("expected 0 includes after remove, got %d", len(mf.Includes))
 	}
@@ -96,7 +98,8 @@ func TestInclude_AddRemove(t *testing.T) {
 func TestInclude_Update(t *testing.T) {
 	s := newSandbox(t)
 	clone := cloneAssistantsAtSHA(t)
-	s.mustRunYnh(t, "install", filepath.Join(clone, "e2e-fixtures", "minimal"))
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+	s.mustRunYnh(t, "install", sourceDir)
 
 	includeURL := "https://github.com/eyelock/assistants"
 	s.mustRunYnh(t, "include", "add", "local/minimal", includeURL,
@@ -109,7 +112,7 @@ func TestInclude_Update(t *testing.T) {
 		"--path", "e2e-fixtures/included-skill",
 	)
 
-	mf := readManifest(t, filepath.Join(s.home, "harnesses", "local--minimal"))
+	mf := readManifest(t, sourceDir)
 	if len(mf.Includes) != 1 {
 		t.Fatalf("expected 1 include after update, got %d", len(mf.Includes))
 	}
@@ -122,7 +125,8 @@ func TestInclude_Update(t *testing.T) {
 func TestDelegate_Update(t *testing.T) {
 	s := newSandbox(t)
 	clone := cloneAssistantsAtSHA(t)
-	s.mustRunYnh(t, "install", filepath.Join(clone, "e2e-fixtures", "minimal"))
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+	s.mustRunYnh(t, "install", sourceDir)
 
 	delegateURL := "https://github.com/eyelock/assistants"
 	s.mustRunYnh(t, "delegate", "add", "local/minimal", delegateURL,
@@ -135,7 +139,7 @@ func TestDelegate_Update(t *testing.T) {
 		"--ref", AssistantsFixturesV1Tag,
 	)
 
-	mf := readManifest(t, filepath.Join(s.home, "harnesses", "local--minimal"))
+	mf := readManifest(t, sourceDir)
 	if len(mf.DelegatesTo) != 1 {
 		t.Fatalf("expected 1 delegate after update, got %d", len(mf.DelegatesTo))
 	}


### PR DESCRIPTION
## Summary

Hotfix release targeting `main` for v0.3.1. Cherry-picks two fixes from `develop`, excluding the untested `--instructions` feat which targets a future release.

- fix(harness): route include/delegate edits to source dir for local installs (#149)
- fix(harness): remove bare-name Load/ScanArtifacts/formatArtifactSummary dead code and fix stale comments (#150)

## Test plan

- [x] `make check` passes clean on hotfix branch
- [ ] CI passes after push
- [ ] Tag `v0.3.1` after merge to trigger goreleaser
- [ ] Forward-port to `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)