### PR TITLE
feat(agent): ynh agent run — autonomous agent loop driver

### DIFF
--- a/cmd/ynh/agent.go
+++ b/cmd/ynh/agent.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -141,6 +142,18 @@ func cmdAgentRun(args []string, stdout, stderr io.Writer, stdin io.Reader) error
 				return cliError(stderr, false, errCodeInvalidInput, "--emit-jsonl requires a value")
 			}
 			opts.EmitJSONL = args[i]
+
+		case "--sensor-overlay":
+			i++
+			if i >= len(args) {
+				return cliError(stderr, false, errCodeInvalidInput, "--sensor-overlay requires a value")
+			}
+			var overlay map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(args[i]), &overlay); err != nil {
+				return cliError(stderr, false, errCodeInvalidInput,
+					fmt.Sprintf("--sensor-overlay: invalid JSON: %v", err))
+			}
+			opts.SensorOverlay = overlay
 
 		default:
 			if strings.HasPrefix(arg, "-") {

--- a/cmd/ynh/agent.go
+++ b/cmd/ynh/agent.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/eyelock/ynh/internal/agent"
+)
+
+func cmdAgent(args []string) error {
+	return cmdAgentTo(args, os.Stdout, os.Stderr, os.Stdin)
+}
+
+func cmdAgentTo(args []string, stdout, stderr io.Writer, stdin io.Reader) error {
+	if len(args) < 1 {
+		return cliError(stderr, false, errCodeInvalidInput,
+			"usage: ynh agent <run> [args]")
+	}
+	switch args[0] {
+	case "run":
+		return cmdAgentRun(args[1:], stdout, stderr, stdin)
+	default:
+		return cliError(stderr, false, errCodeInvalidInput,
+			fmt.Sprintf("unknown agent subcommand: %s", args[0]))
+	}
+}
+
+func cmdAgentRun(args []string, stdout, stderr io.Writer, stdin io.Reader) error {
+	opts := agent.RunOptions{
+		Stdout: stdout,
+		Stderr: stderr,
+		Stdin:  stdin,
+	}
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "--harness":
+			i++
+			if i >= len(args) {
+				return cliError(stderr, false, errCodeInvalidInput, "--harness requires a value")
+			}
+			opts.HarnessName = args[i]
+
+		case "--task":
+			i++
+			if i >= len(args) {
+				return cliError(stderr, false, errCodeInvalidInput, "--task requires a value")
+			}
+			task, err := readTaskArg(args[i])
+			if err != nil {
+				return cliError(stderr, false, errCodeIOError, err.Error())
+			}
+			opts.Task = task
+
+		case "--backend":
+			i++
+			if i >= len(args) {
+				return cliError(stderr, false, errCodeInvalidInput, "--backend requires a value")
+			}
+			opts.Backend = args[i]
+
+		case "--sandbox":
+			i++
+			if i >= len(args) {
+				return cliError(stderr, false, errCodeInvalidInput, "--sandbox requires a value")
+			}
+			opts.Sandbox = args[i]
+
+		case "--model":
+			i++
+			if i >= len(args) {
+				return cliError(stderr, false, errCodeInvalidInput, "--model requires a value")
+			}
+			opts.Model = args[i]
+
+		case "--max-turns":
+			i++
+			if i >= len(args) {
+				return cliError(stderr, false, errCodeInvalidInput, "--max-turns requires a value")
+			}
+			n, err := strconv.Atoi(args[i])
+			if err != nil || n < 0 {
+				return cliError(stderr, false, errCodeInvalidInput, "--max-turns must be a non-negative integer")
+			}
+			opts.MaxTurns = n
+
+		case "--max-tokens":
+			i++
+			if i >= len(args) {
+				return cliError(stderr, false, errCodeInvalidInput, "--max-tokens requires a value")
+			}
+			n, err := strconv.ParseInt(args[i], 10, 64)
+			if err != nil || n < 0 {
+				return cliError(stderr, false, errCodeInvalidInput, "--max-tokens must be a non-negative integer")
+			}
+			opts.MaxTokens = n
+
+		case "--max-wall":
+			i++
+			if i >= len(args) {
+				return cliError(stderr, false, errCodeInvalidInput, "--max-wall requires a value")
+			}
+			d, err := time.ParseDuration(args[i])
+			if err != nil {
+				return cliError(stderr, false, errCodeInvalidInput,
+					fmt.Sprintf("--max-wall: %v", err))
+			}
+			opts.MaxWall = d
+
+		case "--convergence-sensor":
+			i++
+			if i >= len(args) {
+				return cliError(stderr, false, errCodeInvalidInput, "--convergence-sensor requires a value")
+			}
+			opts.ConvergenceSensor = args[i]
+
+		case "--auto-commit":
+			opts.AutoCommit = true
+
+		case "--interactive":
+			opts.Interactive = true
+
+		case "--no-plan":
+			opts.NoPlan = true
+
+		case "--worktree":
+			i++
+			if i >= len(args) {
+				return cliError(stderr, false, errCodeInvalidInput, "--worktree requires a value")
+			}
+			opts.WorktreeDir = args[i]
+
+		case "--emit-jsonl":
+			i++
+			if i >= len(args) {
+				return cliError(stderr, false, errCodeInvalidInput, "--emit-jsonl requires a value")
+			}
+			opts.EmitJSONL = args[i]
+
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return cliError(stderr, false, errCodeInvalidInput,
+					fmt.Sprintf("unknown flag: %s", arg))
+			}
+			return cliError(stderr, false, errCodeInvalidInput,
+				fmt.Sprintf("unexpected argument: %s", arg))
+		}
+	}
+
+	if opts.Task == "" {
+		return cliError(stderr, false, errCodeInvalidInput,
+			"--task is required")
+	}
+
+	if err := agent.RunLoop(opts); err != nil {
+		if exitErr, ok := err.(*agent.ExitError); ok {
+			_, _ = fmt.Fprintf(stderr, "Error: %v\n", exitErr)
+			os.Exit(exitErr.Code)
+		}
+		return err
+	}
+	return nil
+}
+
+// readTaskArg reads the task text from a flag value:
+//   - "-" reads from stdin
+//   - "@path" reads from the named file
+//   - anything else is used as-is (inline text)
+func readTaskArg(val string) (string, error) {
+	if val == "-" {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("reading task from stdin: %w", err)
+		}
+		return strings.TrimRight(string(data), "\n"), nil
+	}
+	if strings.HasPrefix(val, "@") {
+		data, err := os.ReadFile(val[1:])
+		if err != nil {
+			return "", fmt.Errorf("reading task file %q: %w", val[1:], err)
+		}
+		return strings.TrimRight(string(data), "\n"), nil
+	}
+	return val, nil
+}

--- a/cmd/ynh/cliformat.go
+++ b/cmd/ynh/cliformat.go
@@ -39,13 +39,11 @@ func cliError(stderr io.Writer, structured bool, code, message string) error {
 	}{}
 	env.Error.Code = code
 	env.Error.Message = message
-	data, marshalErr := json.Marshal(env)
-	if marshalErr != nil {
-		// Fallback: the envelope itself is simple enough that marshal should
-		// never fail, but be defensive so the caller still exits non-zero.
+	enc := json.NewEncoder(stderr)
+	enc.SetEscapeHTML(false)
+	if encErr := enc.Encode(env); encErr != nil {
 		return fmt.Errorf("%s", message)
 	}
-	_, _ = fmt.Fprintln(stderr, string(data))
 	// Return a sentinel-style error so main.go still exits non-zero.
 	// The message duplicates what's already on stderr; main.go's "Error: ..."
 	// line would be printed after the JSON envelope. To keep structured stderr

--- a/cmd/ynh/cliformat_test.go
+++ b/cmd/ynh/cliformat_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCliError_Unstructured(t *testing.T) {
+	var stderr bytes.Buffer
+	err := cliError(&stderr, false, errCodeNotFound, "thing not found")
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if err.Error() != "thing not found" {
+		t.Errorf("unexpected error message: %q", err.Error())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("unstructured mode should not write to stderr, got: %s", stderr.String())
+	}
+}
+
+func TestCliError_Structured_ValidJSON(t *testing.T) {
+	var stderr bytes.Buffer
+	err := cliError(&stderr, true, errCodeInvalidInput, "bad value")
+	if !errors.Is(err, errStructuredReported) {
+		t.Errorf("expected errStructuredReported sentinel, got %v", err)
+	}
+
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if parseErr := json.Unmarshal(bytes.TrimRight(stderr.Bytes(), "\n"), &env); parseErr != nil {
+		t.Fatalf("stderr is not valid JSON: %v\nraw: %s", parseErr, stderr.String())
+	}
+	if env.Error.Code != errCodeInvalidInput {
+		t.Errorf("expected code %q, got %q", errCodeInvalidInput, env.Error.Code)
+	}
+	if env.Error.Message != "bad value" {
+		t.Errorf("expected message %q, got %q", "bad value", env.Error.Message)
+	}
+}
+
+func TestCliError_Structured_NoHTMLEscape(t *testing.T) {
+	var stderr bytes.Buffer
+	_ = cliError(&stderr, true, errCodeInvalidInput,
+		"usage: ynh sensors run <harness-name> <sensor-name>")
+
+	raw := stderr.String()
+	// Go's default JSON encoder HTML-escapes < as <; SetEscapeHTML(false) disables that.
+	if strings.Contains(raw, `\u003c`) || strings.Contains(raw, `\u003e`) {
+		t.Errorf("angle brackets must not be HTML-escaped in error envelope, got: %s", raw)
+	}
+	if !strings.Contains(raw, "<harness-name>") {
+		t.Errorf("expected literal angle brackets in output, got: %s", raw)
+	}
+}
+
+func TestCliError_Structured_EndsWithNewline(t *testing.T) {
+	var stderr bytes.Buffer
+	_ = cliError(&stderr, true, errCodeNotFound, "not found")
+	if !bytes.HasSuffix(stderr.Bytes(), []byte("\n")) {
+		t.Error("structured error envelope should end with a newline")
+	}
+}

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -142,6 +142,7 @@ Commands:
   sensors ls <harness>         List declared sensors (supports --format json)
   sensors show <harness> <name>  Resolve a sensor declaration (supports --format text|json)
   sensors run <harness> <name>   Run a sensor and emit a JSON result (loop drivers consume this)
+  agent run --task <text> [flags]  Run an autonomous agent loop session
   registry add <url>           Add a harness registry
   registry list                Show configured registries (supports --format json)
   registry remove <url>        Remove a registry

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -81,6 +81,8 @@ func main() {
 		err = cmdInclude(os.Args[2:])
 	case "sensors":
 		err = cmdSensors(os.Args[2:])
+	case "agent":
+		err = cmdAgent(os.Args[2:])
 	case "image":
 		err = cmdImage(os.Args[2:])
 	case "prune":

--- a/cmd/ynh/sensors.go
+++ b/cmd/ynh/sensors.go
@@ -374,6 +374,7 @@ func cmdSensorsRun(args []string, stdout, stderr io.Writer) error {
 	cwd := ""
 	includeContent := true
 	var harnessName, sensorName string
+	var overlayJSON string
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--cwd":
@@ -393,6 +394,12 @@ func cmdSensorsRun(args []string, stdout, stderr io.Writer) error {
 				return cliError(stderr, structured, errCodeInvalidInput,
 					"ynh sensors run only supports --format json")
 			}
+		case "--sensor-overlay-json":
+			if i+1 >= len(args) {
+				return cliError(stderr, structured, errCodeInvalidInput, "--sensor-overlay-json requires a value")
+			}
+			i++
+			overlayJSON = args[i]
 		default:
 			if strings.HasPrefix(args[i], "-") {
 				return cliError(stderr, structured, errCodeInvalidInput,
@@ -422,6 +429,15 @@ func cmdSensorsRun(args []string, stdout, stderr io.Writer) error {
 	if !ok {
 		return cliError(stderr, structured, errCodeNotFound,
 			fmt.Sprintf("sensor %q not declared in harness %q", sensorName, p.Name))
+	}
+
+	if overlayJSON != "" {
+		merged, mergeErr := mergeSensorOverlay(s, []byte(overlayJSON))
+		if mergeErr != nil {
+			return cliError(stderr, structured, errCodeInvalidInput,
+				fmt.Sprintf("--sensor-overlay-json: %v", mergeErr))
+		}
+		s = merged
 	}
 
 	if cwd == "" {
@@ -522,4 +538,35 @@ func runSensor(p *harness.Harness, name string, s plugin.Sensor, cwd string, inc
 	}
 
 	return r, nil
+}
+
+// mergeSensorOverlay applies a partial sensor JSON on top of a base sensor
+// declaration. Only top-level fields present in the overlay replace fields in
+// the base (shallow merge). The overlay is typically sent by the loop driver
+// via --sensor-overlay-json.
+func mergeSensorOverlay(base plugin.Sensor, overlayJSON []byte) (plugin.Sensor, error) {
+	baseData, err := json.Marshal(base)
+	if err != nil {
+		return base, err
+	}
+	var baseMap map[string]json.RawMessage
+	if err := json.Unmarshal(baseData, &baseMap); err != nil {
+		return base, err
+	}
+	var overlayMap map[string]json.RawMessage
+	if err := json.Unmarshal(overlayJSON, &overlayMap); err != nil {
+		return base, fmt.Errorf("invalid JSON: %w", err)
+	}
+	for k, v := range overlayMap {
+		baseMap[k] = v
+	}
+	merged, err := json.Marshal(baseMap)
+	if err != nil {
+		return base, err
+	}
+	var result plugin.Sensor
+	if err := json.Unmarshal(merged, &result); err != nil {
+		return base, fmt.Errorf("applying overlay: %w", err)
+	}
+	return result, nil
 }

--- a/internal/agent/budget.go
+++ b/internal/agent/budget.go
@@ -38,20 +38,20 @@ func (b *Budget) Turns() int { return b.turns }
 func (b *Budget) Tokens() int64 { return b.tokens }
 
 // Exceeded returns a non-empty reason string if any limit has been hit,
-// or an empty string if still within budget. The exit code corresponding
-// to the exceeded limit is also returned.
-func (b *Budget) Exceeded() (reason string, exitCode int) {
+// or an empty string if still within budget. The BudgetType and exit code
+// corresponding to the exceeded limit are also returned.
+func (b *Budget) Exceeded() (reason string, budgetKind BudgetType, exitCode int) {
 	if b.MaxTurns > 0 && b.turns >= b.MaxTurns {
-		return fmt.Sprintf("turn cap reached (%d/%d)", b.turns, b.MaxTurns), ExitIterationCap
+		return fmt.Sprintf("turn cap reached (%d/%d)", b.turns, b.MaxTurns), BudgetTurns, ExitIterationCap
 	}
 	if b.MaxTokens > 0 && b.tokens >= b.MaxTokens {
-		return fmt.Sprintf("token budget exceeded (%d/%d)", b.tokens, b.MaxTokens), ExitTokenBudget
+		return fmt.Sprintf("token budget exceeded (%d/%d)", b.tokens, b.MaxTokens), BudgetTokens, ExitTokenBudget
 	}
 	if b.MaxWall > 0 && time.Since(b.startTime) >= b.MaxWall {
 		elapsed := time.Since(b.startTime).Round(time.Second)
-		return fmt.Sprintf("wall-clock limit reached (%s/%s)", elapsed, b.MaxWall), ExitWallClock
+		return fmt.Sprintf("wall-clock limit reached (%s/%s)", elapsed, b.MaxWall), BudgetWallClock, ExitWallClock
 	}
-	return "", 0
+	return "", "", 0
 }
 
 // Exit codes for loop termination.

--- a/internal/agent/budget.go
+++ b/internal/agent/budget.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"fmt"
+	"time"
+)
+
+// Budget tracks resource consumption for a loop session and enforces limits.
+type Budget struct {
+	MaxTurns  int
+	MaxTokens int64
+	MaxWall   time.Duration
+
+	startTime time.Time
+	turns     int
+	tokens    int64
+}
+
+// Start records the session start time. Must be called before the loop begins.
+func (b *Budget) Start() {
+	b.startTime = time.Now()
+}
+
+// RecordTurn increments the completed-turn counter.
+func (b *Budget) RecordTurn() {
+	b.turns++
+}
+
+// RecordTokens adds token usage from a completed turn.
+func (b *Budget) RecordTokens(u Usage) {
+	b.tokens += u.InputTokens + u.OutputTokens
+}
+
+// Turns returns the number of completed turns so far.
+func (b *Budget) Turns() int { return b.turns }
+
+// Tokens returns the total tokens consumed so far.
+func (b *Budget) Tokens() int64 { return b.tokens }
+
+// Exceeded returns a non-empty reason string if any limit has been hit,
+// or an empty string if still within budget. The exit code corresponding
+// to the exceeded limit is also returned.
+func (b *Budget) Exceeded() (reason string, exitCode int) {
+	if b.MaxTurns > 0 && b.turns >= b.MaxTurns {
+		return fmt.Sprintf("turn cap reached (%d/%d)", b.turns, b.MaxTurns), ExitIterationCap
+	}
+	if b.MaxTokens > 0 && b.tokens >= b.MaxTokens {
+		return fmt.Sprintf("token budget exceeded (%d/%d)", b.tokens, b.MaxTokens), ExitTokenBudget
+	}
+	if b.MaxWall > 0 && time.Since(b.startTime) >= b.MaxWall {
+		elapsed := time.Since(b.startTime).Round(time.Second)
+		return fmt.Sprintf("wall-clock limit reached (%s/%s)", elapsed, b.MaxWall), ExitWallClock
+	}
+	return "", 0
+}
+
+// Exit codes for loop termination.
+const (
+	ExitConverged    = 0
+	ExitIterationCap = 10
+	ExitTokenBudget  = 11
+	ExitWallClock    = 12
+	ExitStuck        = 13
+	ExitTamper       = 14
+	ExitWorkerError  = 20
+	ExitUserAborted  = 30
+)

--- a/internal/agent/budget_test.go
+++ b/internal/agent/budget_test.go
@@ -11,7 +11,7 @@ func TestBudget_NotExceeded(t *testing.T) {
 	b.RecordTurn()
 	b.RecordTokens(Usage{InputTokens: 100, OutputTokens: 50})
 
-	reason, code := b.Exceeded()
+	reason, _, code := b.Exceeded()
 	if reason != "" || code != 0 {
 		t.Errorf("expected within budget, got reason=%q code=%d", reason, code)
 	}
@@ -23,7 +23,7 @@ func TestBudget_TurnCap(t *testing.T) {
 	b.RecordTurn()
 	b.RecordTurn()
 
-	reason, code := b.Exceeded()
+	reason, _, code := b.Exceeded()
 	if reason == "" {
 		t.Error("expected turn cap exceeded")
 	}
@@ -37,7 +37,7 @@ func TestBudget_TokenBudget(t *testing.T) {
 	b.Start()
 	b.RecordTokens(Usage{InputTokens: 60, OutputTokens: 50})
 
-	reason, code := b.Exceeded()
+	reason, _, code := b.Exceeded()
 	if reason == "" {
 		t.Error("expected token budget exceeded")
 	}
@@ -51,7 +51,7 @@ func TestBudget_WallClock(t *testing.T) {
 	b.Start()
 	time.Sleep(5 * time.Millisecond)
 
-	reason, code := b.Exceeded()
+	reason, _, code := b.Exceeded()
 	if reason == "" {
 		t.Error("expected wall-clock exceeded")
 	}
@@ -83,7 +83,7 @@ func TestBudget_ZeroLimitsUnlimited(t *testing.T) {
 		b.RecordTurn()
 	}
 	b.RecordTokens(Usage{InputTokens: 1e9, OutputTokens: 1e9})
-	reason, code := b.Exceeded()
+	reason, _, code := b.Exceeded()
 	if reason != "" || code != 0 {
 		t.Errorf("zero limits should be unlimited, got reason=%q code=%d", reason, code)
 	}

--- a/internal/agent/budget_test.go
+++ b/internal/agent/budget_test.go
@@ -1,0 +1,90 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBudget_NotExceeded(t *testing.T) {
+	b := &Budget{MaxTurns: 10, MaxTokens: 1000, MaxWall: time.Hour}
+	b.Start()
+	b.RecordTurn()
+	b.RecordTokens(Usage{InputTokens: 100, OutputTokens: 50})
+
+	reason, code := b.Exceeded()
+	if reason != "" || code != 0 {
+		t.Errorf("expected within budget, got reason=%q code=%d", reason, code)
+	}
+}
+
+func TestBudget_TurnCap(t *testing.T) {
+	b := &Budget{MaxTurns: 2}
+	b.Start()
+	b.RecordTurn()
+	b.RecordTurn()
+
+	reason, code := b.Exceeded()
+	if reason == "" {
+		t.Error("expected turn cap exceeded")
+	}
+	if code != ExitIterationCap {
+		t.Errorf("expected ExitIterationCap (%d), got %d", ExitIterationCap, code)
+	}
+}
+
+func TestBudget_TokenBudget(t *testing.T) {
+	b := &Budget{MaxTokens: 100}
+	b.Start()
+	b.RecordTokens(Usage{InputTokens: 60, OutputTokens: 50})
+
+	reason, code := b.Exceeded()
+	if reason == "" {
+		t.Error("expected token budget exceeded")
+	}
+	if code != ExitTokenBudget {
+		t.Errorf("expected ExitTokenBudget (%d), got %d", ExitTokenBudget, code)
+	}
+}
+
+func TestBudget_WallClock(t *testing.T) {
+	b := &Budget{MaxWall: time.Millisecond}
+	b.Start()
+	time.Sleep(5 * time.Millisecond)
+
+	reason, code := b.Exceeded()
+	if reason == "" {
+		t.Error("expected wall-clock exceeded")
+	}
+	if code != ExitWallClock {
+		t.Errorf("expected ExitWallClock (%d), got %d", ExitWallClock, code)
+	}
+}
+
+func TestBudget_Counters(t *testing.T) {
+	b := &Budget{}
+	b.Start()
+	b.RecordTurn()
+	b.RecordTurn()
+	b.RecordTokens(Usage{InputTokens: 10, OutputTokens: 5, CacheTokens: 2})
+	b.RecordTokens(Usage{InputTokens: 20, OutputTokens: 3})
+
+	if b.Turns() != 2 {
+		t.Errorf("expected 2 turns, got %d", b.Turns())
+	}
+	if b.Tokens() != 38 { // 10+5+20+3 (cache not counted)
+		t.Errorf("expected 38 tokens, got %d", b.Tokens())
+	}
+}
+
+func TestBudget_ZeroLimitsUnlimited(t *testing.T) {
+	b := &Budget{}
+	b.Start()
+	for i := 0; i < 1000; i++ {
+		b.RecordTurn()
+	}
+	b.RecordTokens(Usage{InputTokens: 1e9, OutputTokens: 1e9})
+	reason, code := b.Exceeded()
+	if reason != "" || code != 0 {
+		t.Errorf("zero limits should be unlimited, got reason=%q code=%d", reason, code)
+	}
+}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -1,0 +1,229 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// ClaudeBackend implements WorkerBackend for Claude Code CLI.
+// All stream-json wire-format details are encapsulated here — the loop
+// driver never touches them.
+type ClaudeBackend struct{}
+
+func (b *ClaudeBackend) Name() string { return "claude" }
+
+// Start spawns a claude subprocess in stream-json mode.
+func (b *ClaudeBackend) Start(ctx context.Context, opts StartOptions) (WorkerSession, error) {
+	claudeBin, err := exec.LookPath("claude")
+	if err != nil {
+		return nil, fmt.Errorf("claude not found on PATH: %w", err)
+	}
+
+	args := buildClaudeStreamArgs(opts)
+
+	var cmd *exec.Cmd
+	if opts.Sandbox == "srt" {
+		srtBin, err := exec.LookPath("srt")
+		if err != nil {
+			return nil, fmt.Errorf("srt not found on PATH: %w", err)
+		}
+		srtArgs := append([]string{
+			"--profile", "workspace",
+			"--network-allow", ".anthropic.com,.openai.com",
+			"--", claudeBin,
+		}, args...)
+		cmd = exec.CommandContext(ctx, srtBin, srtArgs...)
+	} else {
+		cmd = exec.CommandContext(ctx, claudeBin, args...)
+	}
+
+	if opts.WorktreeDir != "" {
+		cmd.Dir = opts.WorktreeDir
+	}
+	cmd.Env = append(os.Environ(), opts.Env...)
+	if opts.Stderr != nil {
+		cmd.Stderr = opts.Stderr
+	}
+
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("creating stdin pipe: %w", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("creating stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting claude: %w", err)
+	}
+
+	scanner := bufio.NewScanner(stdoutPipe)
+	scanner.Buffer(make([]byte, 2<<20), 2<<20) // 2 MB — handles large tool outputs
+
+	return &claudeSession{
+		cmd:     cmd,
+		stdin:   stdinPipe,
+		scanner: scanner,
+	}, nil
+}
+
+// buildClaudeStreamArgs constructs arguments for stream-json mode.
+func buildClaudeStreamArgs(opts StartOptions) []string {
+	args := []string{
+		"--input-format", "stream-json",
+		"--output-format", "stream-json",
+		"--print",
+	}
+
+	if opts.ConfigPath != "" {
+		pluginDir := filepath.Join(opts.ConfigPath, ".claude")
+		args = append(args, "--plugin-dir", pluginDir, "--add-dir", opts.ConfigPath)
+
+		instructionsPath := filepath.Join(opts.ConfigPath, "CLAUDE.md")
+		if data, err := os.ReadFile(instructionsPath); err == nil && len(data) > 0 {
+			args = append(args, "--append-system-prompt", string(data))
+		}
+	}
+
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+	}
+
+	return args
+}
+
+// claudeSession is a running Claude Code subprocess in stream-json mode.
+type claudeSession struct {
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	scanner *bufio.Scanner
+}
+
+// stream-json input message shapes.
+type claudeUserMsg struct {
+	Type    string          `json:"type"`
+	Message claudeUserInner `json:"message"`
+}
+
+type claudeUserInner struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// stream-json output event shapes.
+// Unknown fields are silently ignored for graceful degradation on protocol
+// changes — we use json.Decoder's default behaviour (skip unknown keys).
+type claudeOutputEvent struct {
+	Type    string           `json:"type"`
+	Message *claudeOutputMsg `json:"message,omitempty"`
+	IsError bool             `json:"is_error,omitempty"`
+	Usage   *claudeUsage     `json:"usage,omitempty"`
+}
+
+type claudeOutputMsg struct {
+	Role    string          `json:"role"`
+	Content []claudeContent `json:"content"`
+	Usage   *claudeUsage    `json:"usage,omitempty"`
+}
+
+type claudeContent struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type claudeUsage struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+	CacheTokens  int64 `json:"cache_read_input_tokens,omitempty"`
+}
+
+// Send delivers a user-turn message to the worker via NDJSON.
+func (s *claudeSession) Send(msg string) error {
+	payload := claudeUserMsg{
+		Type: "user",
+		Message: claudeUserInner{
+			Role:    "user",
+			Content: msg,
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = s.stdin.Write(data)
+	return err
+}
+
+// Next reads output events until the worker completes the current turn.
+// Returns io.EOF when the subprocess exits cleanly.
+func (s *claudeSession) Next() (Turn, error) {
+	var turn Turn
+	var contentBuf bytes.Buffer
+
+	for s.scanner.Scan() {
+		line := s.scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var ev claudeOutputEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			// Unknown event shape — skip gracefully.
+			continue
+		}
+
+		switch ev.Type {
+		case "assistant":
+			if ev.Message != nil {
+				for _, block := range ev.Message.Content {
+					if block.Type == "text" {
+						contentBuf.WriteString(block.Text)
+					}
+				}
+				if ev.Message.Usage != nil {
+					turn.Usage.InputTokens += ev.Message.Usage.InputTokens
+					turn.Usage.OutputTokens += ev.Message.Usage.OutputTokens
+					turn.Usage.CacheTokens += ev.Message.Usage.CacheTokens
+				}
+			}
+
+		case "result":
+			// result signals end of this turn.
+			if ev.Usage != nil {
+				turn.Usage.InputTokens += ev.Usage.InputTokens
+				turn.Usage.OutputTokens += ev.Usage.OutputTokens
+				turn.Usage.CacheTokens += ev.Usage.CacheTokens
+			}
+			turn.Content = contentBuf.String()
+			return turn, nil
+
+			// All other types (system, tool_use, tool_result, stream_event, etc.)
+			// are intentionally ignored — the loop driver doesn't need them.
+		}
+	}
+
+	if err := s.scanner.Err(); err != nil {
+		return Turn{}, fmt.Errorf("reading claude output: %w", err)
+	}
+	return Turn{}, io.EOF
+}
+
+// Close terminates the claude subprocess cleanly.
+func (s *claudeSession) Close() error {
+	// Closing stdin signals the subprocess to exit.
+	if err := s.stdin.Close(); err != nil {
+		_ = s.cmd.Process.Kill()
+		_ = s.cmd.Wait()
+		return err
+	}
+	return s.cmd.Wait()
+}

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestClaudeBackend_Name(t *testing.T) {
+	b := &ClaudeBackend{}
+	if b.Name() != "claude" {
+		t.Errorf("expected 'claude', got %q", b.Name())
+	}
+}
+
+func TestBuildClaudeStreamArgs_Minimal(t *testing.T) {
+	args := buildClaudeStreamArgs(StartOptions{})
+	required := []string{"--input-format", "stream-json", "--output-format", "stream-json", "--print"}
+	for _, r := range required {
+		found := false
+		for _, a := range args {
+			if a == r {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("required arg %q not found in %v", r, args)
+		}
+	}
+}
+
+func TestBuildClaudeStreamArgs_Model(t *testing.T) {
+	args := buildClaudeStreamArgs(StartOptions{Model: "claude-opus-4-7"})
+	found := false
+	for i, a := range args {
+		if a == "--model" && i+1 < len(args) && args[i+1] == "claude-opus-4-7" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("--model flag not found in %v", args)
+	}
+}
+
+func TestBuildClaudeStreamArgs_NoModelWhenEmpty(t *testing.T) {
+	args := buildClaudeStreamArgs(StartOptions{})
+	for _, a := range args {
+		if a == "--model" {
+			t.Error("--model should not appear when Model is empty")
+		}
+	}
+}
+
+func TestBuildClaudeStreamArgs_ConfigPath(t *testing.T) {
+	// ConfigPath with no readable CLAUDE.md — should still add --plugin-dir and --add-dir.
+	args := buildClaudeStreamArgs(StartOptions{ConfigPath: "/nonexistent/path"})
+	hasPluginDir := false
+	hasAddDir := false
+	for i, a := range args {
+		if a == "--plugin-dir" && i+1 < len(args) {
+			hasPluginDir = true
+		}
+		if a == "--add-dir" && i+1 < len(args) {
+			hasAddDir = true
+		}
+	}
+	if !hasPluginDir {
+		t.Error("expected --plugin-dir with ConfigPath set")
+	}
+	if !hasAddDir {
+		t.Error("expected --add-dir with ConfigPath set")
+	}
+}

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -1,0 +1,163 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// CodexBackend implements WorkerBackend for OpenAI Codex CLI.
+// Codex runs as a long-lived subprocess; `codex exec --json` emits NDJSON
+// events on stdout and accepts NDJSON user turns on stdin.
+type CodexBackend struct{}
+
+func (b *CodexBackend) Name() string { return "codex" }
+
+// Start spawns a codex subprocess in JSON streaming mode.
+func (b *CodexBackend) Start(ctx context.Context, opts StartOptions) (WorkerSession, error) {
+	codexBin, err := exec.LookPath("codex")
+	if err != nil {
+		return nil, fmt.Errorf("codex not found on PATH: %w", err)
+	}
+
+	args := []string{"exec", "--json"}
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+	}
+
+	cmd := exec.CommandContext(ctx, codexBin, args...)
+	if opts.WorktreeDir != "" {
+		cmd.Dir = opts.WorktreeDir
+	}
+	cmd.Env = append(os.Environ(), opts.Env...)
+	if opts.Stderr != nil {
+		cmd.Stderr = opts.Stderr
+	}
+
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("creating stdin pipe: %w", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("creating stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting codex: %w", err)
+	}
+
+	scanner := bufio.NewScanner(stdoutPipe)
+	scanner.Buffer(make([]byte, 2<<20), 2<<20)
+
+	return &codexSession{
+		cmd:     cmd,
+		stdin:   stdinPipe,
+		scanner: scanner,
+	}, nil
+}
+
+// codex NDJSON input shape.
+type codexUserMsg struct {
+	Type    string `json:"type"`
+	Content string `json:"content"`
+}
+
+// codex NDJSON output event shapes.
+// Codex emits typed events; we only need "message" and "result" to drive the loop.
+type codexOutputEvent struct {
+	Type    string      `json:"type"`
+	Message *codexMsg   `json:"message,omitempty"`
+	Usage   *codexUsage `json:"usage,omitempty"`
+}
+
+type codexMsg struct {
+	Role    string         `json:"role"`
+	Content []codexContent `json:"content"`
+}
+
+type codexContent struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type codexUsage struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+}
+
+type codexSession struct {
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	scanner *bufio.Scanner
+}
+
+// Send delivers a user-turn message to the codex subprocess via NDJSON.
+func (s *codexSession) Send(msg string) error {
+	payload := codexUserMsg{Type: "user", Content: msg}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = s.stdin.Write(data)
+	return err
+}
+
+// Next reads events until the codex subprocess signals end-of-turn.
+// Returns io.EOF when the subprocess exits cleanly.
+func (s *codexSession) Next() (Turn, error) {
+	var turn Turn
+	var contentBuf bytes.Buffer
+
+	for s.scanner.Scan() {
+		line := s.scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var ev codexOutputEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+
+		switch ev.Type {
+		case "message":
+			if ev.Message != nil && ev.Message.Role == "assistant" {
+				for _, block := range ev.Message.Content {
+					if block.Type == "text" {
+						contentBuf.WriteString(block.Text)
+					}
+				}
+			}
+
+		case "result":
+			if ev.Usage != nil {
+				turn.Usage.InputTokens += ev.Usage.InputTokens
+				turn.Usage.OutputTokens += ev.Usage.OutputTokens
+			}
+			turn.Content = contentBuf.String()
+			return turn, nil
+		}
+	}
+
+	if err := s.scanner.Err(); err != nil {
+		return Turn{}, fmt.Errorf("reading codex output: %w", err)
+	}
+	return Turn{}, io.EOF
+}
+
+// Close terminates the codex subprocess cleanly.
+func (s *codexSession) Close() error {
+	if err := s.stdin.Close(); err != nil {
+		_ = s.cmd.Process.Kill()
+		_ = s.cmd.Wait()
+		return err
+	}
+	return s.cmd.Wait()
+}

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -1,0 +1,153 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestCodexBackend_Name(t *testing.T) {
+	b := &CodexBackend{}
+	if b.Name() != "codex" {
+		t.Errorf("expected 'codex', got %q", b.Name())
+	}
+}
+
+// buildCodexResult emits a sequence of NDJSON lines mimicking the codex
+// exec --json wire format: one "message" event followed by a "result" event.
+func buildCodexResult(text string) string {
+	msg := codexOutputEvent{
+		Type: "message",
+		Message: &codexMsg{
+			Role:    "assistant",
+			Content: []codexContent{{Type: "text", Text: text}},
+		},
+	}
+	result := codexOutputEvent{
+		Type:  "result",
+		Usage: &codexUsage{InputTokens: 10, OutputTokens: 5},
+	}
+	var sb strings.Builder
+	enc := json.NewEncoder(&sb)
+	_ = enc.Encode(msg)
+	_ = enc.Encode(result)
+	return sb.String()
+}
+
+func TestCodexSession_NextReturnsContent(t *testing.T) {
+	raw := buildCodexResult("hello from codex")
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+
+	sess := &codexSession{
+		scanner: scanner,
+		stdin:   &nopWriteCloser{new(bytes.Buffer)},
+	}
+	turn, err := sess.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if turn.Content != "hello from codex" {
+		t.Errorf("unexpected content: %q", turn.Content)
+	}
+	if turn.Usage.InputTokens != 10 || turn.Usage.OutputTokens != 5 {
+		t.Errorf("unexpected usage: %+v", turn.Usage)
+	}
+}
+
+func TestCodexSession_NextEOFOnEmptyStream(t *testing.T) {
+	scanner := bufio.NewScanner(strings.NewReader(""))
+	sess := &codexSession{
+		scanner: scanner,
+		stdin:   &nopWriteCloser{new(bytes.Buffer)},
+	}
+	_, err := sess.Next()
+	if err != io.EOF {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+}
+
+func TestCodexSession_NextSkipsUnknownEvents(t *testing.T) {
+	var sb strings.Builder
+	enc := json.NewEncoder(&sb)
+	_ = enc.Encode(map[string]string{"type": "thinking", "content": "pondering"})
+	_ = enc.Encode(codexOutputEvent{
+		Type: "message",
+		Message: &codexMsg{
+			Role:    "assistant",
+			Content: []codexContent{{Type: "text", Text: "answer"}},
+		},
+	})
+	_ = enc.Encode(codexOutputEvent{Type: "result"})
+
+	scanner := bufio.NewScanner(strings.NewReader(sb.String()))
+	sess := &codexSession{
+		scanner: scanner,
+		stdin:   &nopWriteCloser{new(bytes.Buffer)},
+	}
+	turn, err := sess.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if turn.Content != "answer" {
+		t.Errorf("unexpected content: %q", turn.Content)
+	}
+}
+
+func TestCodexSession_SendWritesJSON(t *testing.T) {
+	var buf bytes.Buffer
+	sess := &codexSession{
+		stdin: &nopWriteCloser{&buf},
+	}
+	if err := sess.Send("do the thing"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var msg codexUserMsg
+	if err := json.Unmarshal(bytes.TrimRight(buf.Bytes(), "\n"), &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Type != "user" {
+		t.Errorf("expected type 'user', got %q", msg.Type)
+	}
+	if msg.Content != "do the thing" {
+		t.Errorf("unexpected content: %q", msg.Content)
+	}
+}
+
+func TestCodexSession_NextAccumulatesMultipleMessageBlocks(t *testing.T) {
+	var sb strings.Builder
+	enc := json.NewEncoder(&sb)
+	_ = enc.Encode(codexOutputEvent{
+		Type: "message",
+		Message: &codexMsg{
+			Role: "assistant",
+			Content: []codexContent{
+				{Type: "text", Text: "part one "},
+				{Type: "tool_use", Text: "ignored"},
+				{Type: "text", Text: "part two"},
+			},
+		},
+	})
+	_ = enc.Encode(codexOutputEvent{Type: "result"})
+
+	scanner := bufio.NewScanner(strings.NewReader(sb.String()))
+	sess := &codexSession{
+		scanner: scanner,
+		stdin:   &nopWriteCloser{new(bytes.Buffer)},
+	}
+	turn, err := sess.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if turn.Content != "part one part two" {
+		t.Errorf("unexpected content: %q", turn.Content)
+	}
+}
+
+// nopWriteCloser wraps a bytes.Buffer so it satisfies io.WriteCloser.
+type nopWriteCloser struct{ *bytes.Buffer }
+
+func (n *nopWriteCloser) Close() error { return nil }

--- a/internal/agent/control.go
+++ b/internal/agent/control.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+)
+
+// ControlAction identifies an action sent on the control channel.
+type ControlAction string
+
+const (
+	ActionApprovePlan     ControlAction = "approve_plan"
+	ActionRejectPlan      ControlAction = "reject_plan"
+	ActionInterrupt       ControlAction = "interrupt"
+	ActionApproveTurn     ControlAction = "approve_turn"
+	ActionReplaceFeedback ControlAction = "replace_feedback"
+)
+
+// ControlMessage is a single NDJSON message from the control channel.
+type ControlMessage struct {
+	Action   ControlAction `json:"action"`
+	Feedback string        `json:"feedback,omitempty"` // used with replace_feedback
+}
+
+// ControlReader reads NDJSON control messages from a stream.
+// Unknown actions are silently ignored for forward-compatibility.
+type ControlReader struct {
+	ch chan ControlMessage
+}
+
+// NewControlReader starts a background goroutine reading NDJSON from r
+// and returns a ControlReader whose channel receives decoded messages.
+// The channel is closed when r reaches EOF or an unrecoverable read error.
+func NewControlReader(r io.Reader) *ControlReader {
+	cr := &ControlReader{ch: make(chan ControlMessage, 16)}
+	go cr.read(r)
+	return cr
+}
+
+// C returns the channel of incoming control messages.
+func (cr *ControlReader) C() <-chan ControlMessage {
+	return cr.ch
+}
+
+func (cr *ControlReader) read(r io.Reader) {
+	defer close(cr.ch)
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var msg ControlMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			continue // ignore malformed lines
+		}
+		if msg.Action == "" {
+			continue // ignore objects with no action
+		}
+		cr.ch <- msg
+	}
+}

--- a/internal/agent/control_test.go
+++ b/internal/agent/control_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestControlReader_DecodesActions(t *testing.T) {
+	input := strings.NewReader(
+		`{"action":"approve_plan"}` + "\n" +
+			`{"action":"replace_feedback","feedback":"try harder"}` + "\n" +
+			`{"action":"interrupt"}` + "\n",
+	)
+	cr := NewControlReader(input)
+
+	timeout := time.After(time.Second)
+	want := []ControlAction{ActionApprovePlan, ActionReplaceFeedback, ActionInterrupt}
+	for _, expected := range want {
+		select {
+		case msg, ok := <-cr.C():
+			if !ok {
+				t.Fatalf("channel closed before receiving %q", expected)
+			}
+			if msg.Action != expected {
+				t.Errorf("expected %q, got %q", expected, msg.Action)
+			}
+		case <-timeout:
+			t.Fatalf("timeout waiting for %q", expected)
+		}
+	}
+}
+
+func TestControlReader_SkipsMalformedLines(t *testing.T) {
+	input := strings.NewReader(
+		"not json\n" +
+			`{"action":"approve_turn"}` + "\n" +
+			"also not json\n",
+	)
+	cr := NewControlReader(input)
+
+	timeout := time.After(time.Second)
+	select {
+	case msg, ok := <-cr.C():
+		if !ok {
+			t.Fatal("channel closed unexpectedly")
+		}
+		if msg.Action != ActionApproveTurn {
+			t.Errorf("expected approve_turn, got %q", msg.Action)
+		}
+	case <-timeout:
+		t.Fatal("timeout")
+	}
+}
+
+func TestControlReader_SkipsNoActionObjects(t *testing.T) {
+	input := strings.NewReader(
+		`{}` + "\n" +
+			`{"other":"field"}` + "\n" +
+			`{"action":"reject_plan"}` + "\n",
+	)
+	cr := NewControlReader(input)
+
+	timeout := time.After(time.Second)
+	select {
+	case msg, ok := <-cr.C():
+		if !ok {
+			t.Fatal("channel closed before receiving reject_plan")
+		}
+		if msg.Action != ActionRejectPlan {
+			t.Errorf("expected reject_plan, got %q", msg.Action)
+		}
+	case <-timeout:
+		t.Fatal("timeout")
+	}
+}
+
+func TestControlReader_ChannelClosedOnEOF(t *testing.T) {
+	input := strings.NewReader(`{"action":"approve_plan"}` + "\n")
+	cr := NewControlReader(input)
+
+	// Drain first message.
+	<-cr.C()
+
+	// Channel should close after EOF.
+	timeout := time.After(time.Second)
+	select {
+	case _, ok := <-cr.C():
+		if ok {
+			t.Error("expected channel to be closed")
+		}
+	case <-timeout:
+		t.Error("timeout waiting for channel close")
+	}
+}
+
+func TestControlReader_ReplaceFeedbackPayload(t *testing.T) {
+	input := strings.NewReader(
+		`{"action":"replace_feedback","feedback":"updated feedback text"}` + "\n",
+	)
+	cr := NewControlReader(input)
+	msg := <-cr.C()
+	if msg.Feedback != "updated feedback text" {
+		t.Errorf("expected feedback payload, got %q", msg.Feedback)
+	}
+}

--- a/internal/agent/cursor.go
+++ b/internal/agent/cursor.go
@@ -1,0 +1,202 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// CursorBackend implements WorkerBackend for Cursor's headless agent CLI.
+// Cursor spawns a new subprocess per turn, resuming conversation state via
+// --resume <chatId>. The session manages the chatId across turns.
+type CursorBackend struct{}
+
+func (b *CursorBackend) Name() string { return "cursor" }
+
+// Start allocates a new session with a fresh chat ID.
+// The first subprocess is not spawned until Send+Next are called.
+func (b *CursorBackend) Start(_ context.Context, opts StartOptions) (WorkerSession, error) {
+	cursorBin, err := exec.LookPath("cursor")
+	if err != nil {
+		return nil, fmt.Errorf("cursor not found on PATH: %w", err)
+	}
+
+	// Generate a unique chat ID for this session.
+	b8 := make([]byte, 8)
+	_, _ = rand.Read(b8)
+	chatID := hex.EncodeToString(b8)
+
+	return &cursorSession{
+		cursorBin: cursorBin,
+		chatID:    chatID,
+		opts:      opts,
+		firstTurn: true,
+	}, nil
+}
+
+// cursorSession holds the resumable chat state across per-turn subprocesses.
+type cursorSession struct {
+	cursorBin string
+	chatID    string
+	opts      StartOptions
+	firstTurn bool
+	pending   string // message queued for the next Next() call
+}
+
+// Send queues the user message for the next subprocess invocation.
+func (s *cursorSession) Send(msg string) error {
+	s.pending = msg
+	return nil
+}
+
+// Next spawns a cursor subprocess for the pending message, collects its output,
+// and returns the completed assistant turn. Returns io.EOF if cursor exits with
+// no output (should not happen in normal flow).
+func (s *cursorSession) Next() (Turn, error) {
+	if s.pending == "" {
+		return Turn{}, fmt.Errorf("cursor: Next called without a prior Send")
+	}
+	msg := s.pending
+	s.pending = ""
+
+	args := []string{
+		"agent",
+		"--print",
+		"--output-format", "stream-json",
+		"--trust",
+	}
+	if s.opts.WorktreeDir != "" {
+		args = append(args, "--workspace", s.opts.WorktreeDir)
+	}
+	if s.opts.Model != "" {
+		args = append(args, "--model", s.opts.Model)
+	}
+	if !s.firstTurn {
+		args = append(args, "--resume", s.chatID)
+	}
+	// Pass the user message as the final positional argument.
+	args = append(args, msg)
+	s.firstTurn = false
+
+	cmd := exec.Command(s.cursorBin, args...)
+	if s.opts.WorktreeDir != "" {
+		cmd.Dir = s.opts.WorktreeDir
+	}
+	cmd.Env = append(os.Environ(), s.opts.Env...)
+	if s.opts.Stderr != nil {
+		cmd.Stderr = s.opts.Stderr
+	}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return Turn{}, fmt.Errorf("cursor stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return Turn{}, fmt.Errorf("starting cursor: %w", err)
+	}
+
+	turn, parseErr := parseCursorOutput(stdoutPipe)
+
+	if waitErr := cmd.Wait(); waitErr != nil {
+		if parseErr == nil {
+			// Subprocess exit error takes priority only if we have no content.
+			if turn.Content == "" {
+				return Turn{}, fmt.Errorf("cursor exited: %w", waitErr)
+			}
+		}
+	}
+
+	if parseErr != nil && parseErr != io.EOF {
+		return Turn{}, parseErr
+	}
+	if turn.Content == "" {
+		return Turn{}, io.EOF
+	}
+	return turn, nil
+}
+
+// Close is a no-op for Cursor — subprocesses are short-lived per-turn.
+func (s *cursorSession) Close() error { return nil }
+
+// cursor stream-json output shapes (same wire format as Claude Code).
+type cursorOutputEvent struct {
+	Type    string           `json:"type"`
+	Message *cursorOutputMsg `json:"message,omitempty"`
+	Usage   *cursorUsage     `json:"usage,omitempty"`
+}
+
+type cursorOutputMsg struct {
+	Role    string          `json:"role"`
+	Content []cursorContent `json:"content"`
+	Usage   *cursorUsage    `json:"usage,omitempty"`
+}
+
+type cursorContent struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type cursorUsage struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+	CacheTokens  int64 `json:"cache_read_input_tokens,omitempty"`
+}
+
+// parseCursorOutput reads stream-json events from a single Cursor subprocess run.
+func parseCursorOutput(r io.Reader) (Turn, error) {
+	var turn Turn
+	var contentBuf bytes.Buffer
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 2<<20), 2<<20)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var ev cursorOutputEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+
+		switch ev.Type {
+		case "assistant":
+			if ev.Message != nil {
+				for _, block := range ev.Message.Content {
+					if block.Type == "text" {
+						contentBuf.WriteString(block.Text)
+					}
+				}
+				if ev.Message.Usage != nil {
+					turn.Usage.InputTokens += ev.Message.Usage.InputTokens
+					turn.Usage.OutputTokens += ev.Message.Usage.OutputTokens
+					turn.Usage.CacheTokens += ev.Message.Usage.CacheTokens
+				}
+			}
+
+		case "result":
+			if ev.Usage != nil {
+				turn.Usage.InputTokens += ev.Usage.InputTokens
+				turn.Usage.OutputTokens += ev.Usage.OutputTokens
+				turn.Usage.CacheTokens += ev.Usage.CacheTokens
+			}
+			turn.Content = contentBuf.String()
+			return turn, nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return Turn{}, fmt.Errorf("reading cursor output: %w", err)
+	}
+	turn.Content = contentBuf.String()
+	return turn, io.EOF
+}

--- a/internal/agent/cursor_test.go
+++ b/internal/agent/cursor_test.go
@@ -1,0 +1,153 @@
+package agent
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestCursorBackend_Name(t *testing.T) {
+	b := &CursorBackend{}
+	if b.Name() != "cursor" {
+		t.Errorf("expected 'cursor', got %q", b.Name())
+	}
+}
+
+// buildCursorResult emits stream-json lines matching Cursor's output format
+// (same wire format as Claude Code: "assistant" then "result").
+func buildCursorResult(text string) string {
+	msg := cursorOutputEvent{
+		Type: "assistant",
+		Message: &cursorOutputMsg{
+			Role:    "assistant",
+			Content: []cursorContent{{Type: "text", Text: text}},
+			Usage:   &cursorUsage{InputTokens: 8, OutputTokens: 3},
+		},
+	}
+	result := cursorOutputEvent{
+		Type:  "result",
+		Usage: &cursorUsage{InputTokens: 2, OutputTokens: 1},
+	}
+	var sb strings.Builder
+	enc := json.NewEncoder(&sb)
+	_ = enc.Encode(msg)
+	_ = enc.Encode(result)
+	return sb.String()
+}
+
+func TestParseCursorOutput_HappyPath(t *testing.T) {
+	raw := buildCursorResult("hello from cursor")
+	turn, err := parseCursorOutput(strings.NewReader(raw))
+	if err != nil && err != io.EOF {
+		t.Fatalf("parseCursorOutput: %v", err)
+	}
+	if turn.Content != "hello from cursor" {
+		t.Errorf("unexpected content: %q", turn.Content)
+	}
+	// Usage is accumulated from both assistant and result events.
+	if turn.Usage.InputTokens != 10 {
+		t.Errorf("expected InputTokens=10, got %d", turn.Usage.InputTokens)
+	}
+	if turn.Usage.OutputTokens != 4 {
+		t.Errorf("expected OutputTokens=4, got %d", turn.Usage.OutputTokens)
+	}
+}
+
+func TestParseCursorOutput_EmptyStream(t *testing.T) {
+	turn, err := parseCursorOutput(strings.NewReader(""))
+	if err != io.EOF {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+	if turn.Content != "" {
+		t.Errorf("expected empty content, got %q", turn.Content)
+	}
+}
+
+func TestParseCursorOutput_SkipsUnknownEvents(t *testing.T) {
+	var sb strings.Builder
+	enc := json.NewEncoder(&sb)
+	_ = enc.Encode(map[string]string{"type": "system", "data": "ignored"})
+	_ = enc.Encode(cursorOutputEvent{
+		Type: "assistant",
+		Message: &cursorOutputMsg{
+			Role:    "assistant",
+			Content: []cursorContent{{Type: "text", Text: "real answer"}},
+		},
+	})
+	_ = enc.Encode(cursorOutputEvent{Type: "result"})
+
+	turn, err := parseCursorOutput(strings.NewReader(sb.String()))
+	if err != nil && err != io.EOF {
+		t.Fatalf("parseCursorOutput: %v", err)
+	}
+	if turn.Content != "real answer" {
+		t.Errorf("unexpected content: %q", turn.Content)
+	}
+}
+
+func TestParseCursorOutput_AccumulatesTextBlocks(t *testing.T) {
+	var sb strings.Builder
+	enc := json.NewEncoder(&sb)
+	_ = enc.Encode(cursorOutputEvent{
+		Type: "assistant",
+		Message: &cursorOutputMsg{
+			Role: "assistant",
+			Content: []cursorContent{
+				{Type: "text", Text: "first "},
+				{Type: "tool_use", Text: "skip"},
+				{Type: "text", Text: "second"},
+			},
+		},
+	})
+	_ = enc.Encode(cursorOutputEvent{Type: "result"})
+
+	turn, err := parseCursorOutput(strings.NewReader(sb.String()))
+	if err != nil && err != io.EOF {
+		t.Fatalf("parseCursorOutput: %v", err)
+	}
+	if turn.Content != "first second" {
+		t.Errorf("unexpected content: %q", turn.Content)
+	}
+}
+
+func TestCursorSession_SendQueuesMessage(t *testing.T) {
+	sess := &cursorSession{}
+	if err := sess.Send("hello"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if sess.pending != "hello" {
+		t.Errorf("expected pending='hello', got %q", sess.pending)
+	}
+}
+
+func TestCursorSession_NextErrorsWithoutSend(t *testing.T) {
+	sess := &cursorSession{}
+	_, err := sess.Next()
+	if err == nil {
+		t.Error("expected error when Next called without prior Send")
+	}
+}
+
+func TestCursorSession_CloseIsNoop(t *testing.T) {
+	sess := &cursorSession{}
+	if err := sess.Close(); err != nil {
+		t.Errorf("Close should be a no-op, got %v", err)
+	}
+}
+
+func TestCursorSession_FirstTurnOmitsResume(t *testing.T) {
+	// Verify the firstTurn flag is true on a fresh session and flips after Next.
+	// We can't easily test the subprocess args without spawning cursor, so we
+	// check the state transitions directly.
+	sess := &cursorSession{firstTurn: true}
+	if !sess.firstTurn {
+		t.Error("expected firstTurn=true on fresh session")
+	}
+
+	// Simulate what Next() does to firstTurn (set to false before subprocess).
+	sess.firstTurn = false
+	if sess.firstTurn {
+		t.Error("expected firstTurn=false after first turn")
+	}
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1,0 +1,614 @@
+package agent
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/eyelock/ynh/internal/assembler"
+	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/resolver"
+	"github.com/eyelock/ynh/internal/vendor"
+)
+
+// ExitError carries a specific exit code for non-zero loop termination.
+// The CLI handler checks for this type and calls os.Exit with the code.
+type ExitError struct {
+	Code    int
+	Message string
+}
+
+func (e *ExitError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return fmt.Sprintf("agent loop exited with code %d", e.Code)
+}
+
+// RunOptions configures a single agent loop session.
+type RunOptions struct {
+	// HarnessName is the qualified name of the harness to load and assemble.
+	HarnessName string
+	// Task is the task text sent as the first user message.
+	Task string
+	// Backend selects the worker backend ("claude" or "codex"). Defaults to "claude".
+	Backend string
+	// Sandbox is "srt" or "none". Defaults to "none".
+	Sandbox string
+	// Model overrides the worker's default model. Empty means backend default.
+	Model string
+
+	// Budget limits — zero means unlimited.
+	MaxTurns  int
+	MaxTokens int64
+	MaxWall   time.Duration
+
+	// ConvergenceSensor is the name of a sensor to consult as a final done-check.
+	// All regular sensors must pass first; then this sensor is consulted.
+	ConvergenceSensor string
+
+	// AutoCommit creates a git commit in WorktreeDir after each assistant turn.
+	AutoCommit bool
+	// Interactive pauses after each turn for user approval via the control channel.
+	Interactive bool
+	// NoPlan skips the plan phase and sends the task directly into the act loop.
+	NoPlan bool
+
+	// WorktreeDir is where the worker subprocess runs. Defaults to cwd.
+	WorktreeDir string
+
+	// EmitJSONL is the path for trajectory output. "-" writes to Stdout.
+	// If empty, trajectory events are discarded.
+	EmitJSONL string
+
+	// I/O streams. Defaults to os.Stdout / os.Stderr / os.Stdin.
+	Stdout io.Writer
+	Stderr io.Writer
+	Stdin  io.Reader
+
+	// YNHBinary is the path to the ynh executable for sensor invocation.
+	// Defaults to os.Executable() if empty.
+	YNHBinary string
+
+	// backendOverride is the resolved WorkerBackend; set by tests or left nil to auto-select.
+	backendOverride WorkerBackend
+
+	// testSensorNames overrides sensor collection from the harness.
+	// Set by tests that need sensor-loop behaviour without a real installed harness.
+	testSensorNames []string
+}
+
+// RunLoop executes the agent loop. It returns an *ExitError on non-zero
+// termination so the CLI handler can map it to os.Exit.
+func RunLoop(opts RunOptions) error {
+	// ── I/O defaults ─────────────────────────────────────────────────────────
+	if opts.Stdout == nil {
+		opts.Stdout = os.Stdout
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = os.Stderr
+	}
+	if opts.Stdin == nil {
+		opts.Stdin = os.Stdin
+	}
+	if opts.Backend == "" {
+		opts.Backend = "claude"
+	}
+	if opts.WorktreeDir == "" {
+		var err error
+		opts.WorktreeDir, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("resolving working directory: %w", err)
+		}
+	}
+
+	ynh, err := resolveYNHBinary(opts.YNHBinary)
+	if err != nil {
+		return err
+	}
+
+	// ── Trajectory writer ─────────────────────────────────────────────────────
+	traj := newNullTrajectory()
+	if opts.EmitJSONL != "" {
+		tw, cleanup, err := openTrajectory(opts.EmitJSONL, opts.Stdout)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		traj = tw
+	}
+
+	sessionID := newSessionID()
+
+	// ── Load and assemble harness ─────────────────────────────────────────────
+	var configPath string
+	var harnessObj *harness.Harness
+
+	if opts.HarnessName != "" {
+		harnessObj, err = harness.LoadQualified(opts.HarnessName)
+		if err != nil {
+			return fmt.Errorf("loading harness %q: %w", opts.HarnessName, err)
+		}
+		configPath, err = assembleHarness(harnessObj, opts.Backend)
+		if err != nil {
+			return fmt.Errorf("assembling harness: %w", err)
+		}
+		defer func() { _ = os.RemoveAll(configPath) }()
+	}
+
+	// ── Select backend ────────────────────────────────────────────────────────
+	wb := opts.backendOverride
+	if wb == nil {
+		wb, err = selectBackend(opts.Backend)
+		if err != nil {
+			return err
+		}
+	}
+
+	// ── Session start ─────────────────────────────────────────────────────────
+	ctx := context.Background()
+
+	harnessName := opts.HarnessName
+	if harnessName == "" {
+		harnessName = "(none)"
+	}
+	if emitErr := traj.Emit(KindSessionStart, 0, SessionStartData{
+		SessionID: sessionID,
+		Harness:   harnessName,
+		Backend:   wb.Name(),
+		Task:      opts.Task,
+	}); emitErr != nil {
+		return fmt.Errorf("writing trajectory: %w", emitErr)
+	}
+
+	sess, err := wb.Start(ctx, StartOptions{
+		WorktreeDir: opts.WorktreeDir,
+		ConfigPath:  configPath,
+		Sandbox:     opts.Sandbox,
+		Model:       opts.Model,
+		Stderr:      opts.Stderr,
+	})
+	if err != nil {
+		_ = traj.Emit(KindSessionEnd, 0, SessionEndData{ExitCode: ExitWorkerError, Reason: err.Error()})
+		return &ExitError{Code: ExitWorkerError, Message: fmt.Sprintf("starting worker: %v", err)}
+	}
+	defer func() { _ = sess.Close() }()
+
+	// ── Budget + watchdog ─────────────────────────────────────────────────────
+	budget := &Budget{
+		MaxTurns:  opts.MaxTurns,
+		MaxTokens: opts.MaxTokens,
+		MaxWall:   opts.MaxWall,
+	}
+	budget.Start()
+	watchdog := NewWatchdog()
+
+	// ── Control channel ───────────────────────────────────────────────────────
+	ctrl := NewControlReader(opts.Stdin)
+
+	// ── Collect sensors ───────────────────────────────────────────────────────
+	var sensorNames []string
+	var convergenceSensor string
+
+	if opts.testSensorNames != nil {
+		// Test injection: use the provided names, skip harness-based collection.
+		sensorNames = opts.testSensorNames
+	} else if harnessObj != nil {
+		for name, s := range harnessObj.Sensors {
+			if s.Role == "convergence-verifier" || name == opts.ConvergenceSensor {
+				if convergenceSensor == "" {
+					convergenceSensor = name
+				}
+				continue
+			}
+			if s.Role != "stuck-recovery" {
+				sensorNames = append(sensorNames, name)
+			}
+		}
+		// Sort by tier (build → lint → test → other), then alphabetically within tier.
+		sort.Slice(sensorNames, func(i, j int) bool {
+			ti := sensorTier(harnessObj.Sensors[sensorNames[i]].Category)
+			tj := sensorTier(harnessObj.Sensors[sensorNames[j]].Category)
+			if ti != tj {
+				return ti < tj
+			}
+			return sensorNames[i] < sensorNames[j]
+		})
+	} // end else if harnessObj != nil
+
+	// ── Plan phase ────────────────────────────────────────────────────────────
+	if !opts.NoPlan {
+		planMsg := fmt.Sprintf(
+			"Write a plan for the following task. Document it clearly in plan.md in the current directory.\n\nTask: %s",
+			opts.Task,
+		)
+		if emitErr := traj.Emit(KindPlan, 0, nil); emitErr != nil {
+			return fmt.Errorf("writing trajectory: %w", emitErr)
+		}
+		if err := sess.Send(planMsg); err != nil {
+			_ = traj.Emit(KindSessionEnd, 0, SessionEndData{ExitCode: ExitWorkerError, Reason: err.Error()})
+			return &ExitError{Code: ExitWorkerError, Message: fmt.Sprintf("sending plan request: %v", err)}
+		}
+		planTurn, err := sess.Next()
+		if err == io.EOF {
+			_ = traj.Emit(KindSessionEnd, 0, SessionEndData{ExitCode: ExitWorkerError, Reason: "worker exited during plan phase"})
+			return &ExitError{Code: ExitWorkerError, Message: "worker exited during plan phase"}
+		}
+		if err != nil {
+			_ = traj.Emit(KindSessionEnd, 0, SessionEndData{ExitCode: ExitWorkerError, Reason: err.Error()})
+			return &ExitError{Code: ExitWorkerError, Message: fmt.Sprintf("plan turn: %v", err)}
+		}
+		_ = traj.Emit(KindAssistantMessage, 0, planTurn.Content)
+
+		if opts.Interactive {
+			feedback := planTurn.Content
+			if emitErr := traj.Emit(KindTurnApprovalRequired, 0, TurnApprovalData{Feedback: feedback}); emitErr != nil {
+				return fmt.Errorf("writing trajectory: %w", emitErr)
+			}
+			action, replacement, aborted := waitForApproval(ctrl, ActionApprovePlan, ActionRejectPlan)
+			if aborted {
+				_ = traj.Emit(KindSessionEnd, 0, SessionEndData{ExitCode: ExitUserAborted, Reason: "user aborted"})
+				return &ExitError{Code: ExitUserAborted, Message: "plan rejected by user"}
+			}
+			if action == ActionRejectPlan {
+				_ = traj.Emit(KindSessionEnd, 0, SessionEndData{ExitCode: ExitUserAborted, Reason: "plan rejected"})
+				return &ExitError{Code: ExitUserAborted, Message: "plan rejected by user"}
+			}
+			if replacement != "" {
+				feedback = replacement
+			}
+			_ = feedback // plan approval carries no feedback to the worker
+		}
+	}
+
+	// ── Act loop ──────────────────────────────────────────────────────────────
+	// First message: task (or plan-approved continuation).
+	firstMsg := opts.Task
+	if !opts.NoPlan {
+		firstMsg = "Plan approved. Proceed with implementation: " + opts.Task
+	}
+	if err := sess.Send(firstMsg); err != nil {
+		_ = traj.Emit(KindSessionEnd, 0, SessionEndData{ExitCode: ExitWorkerError, Reason: err.Error()})
+		return &ExitError{Code: ExitWorkerError, Message: fmt.Sprintf("sending first message: %v", err)}
+	}
+
+	for {
+		// ── Budget check ──────────────────────────────────────────────────────
+		if reason, code := budget.Exceeded(); reason != "" {
+			_ = traj.Emit(KindBudgetExceeded, budget.Turns(), BudgetExceededData{Reason: reason})
+			_ = traj.Emit(KindSessionEnd, budget.Turns(), SessionEndData{ExitCode: code, Reason: reason})
+			return &ExitError{Code: code, Message: reason}
+		}
+
+		turnN := budget.Turns() + 1
+		_ = traj.Emit(KindTurnStart, turnN, nil)
+
+		// ── Wait for assistant turn ───────────────────────────────────────────
+		turn, err := sess.Next()
+		if err == io.EOF {
+			_ = traj.Emit(KindSessionEnd, turnN, SessionEndData{ExitCode: ExitWorkerError, Reason: "worker exited unexpectedly"})
+			return &ExitError{Code: ExitWorkerError, Message: "worker exited before convergence"}
+		}
+		if err != nil {
+			_ = traj.Emit(KindSessionEnd, turnN, SessionEndData{ExitCode: ExitWorkerError, Reason: err.Error()})
+			return &ExitError{Code: ExitWorkerError, Message: fmt.Sprintf("worker turn %d: %v", turnN, err)}
+		}
+		_ = traj.Emit(KindAssistantMessage, turnN, turn.Content)
+
+		budget.RecordTurn()
+		budget.RecordTokens(turn.Usage)
+
+		// ── Auto-commit ───────────────────────────────────────────────────────
+		if opts.AutoCommit {
+			if err := gitAutoCommit(opts.WorktreeDir, turnN); err != nil {
+				_, _ = fmt.Fprintf(opts.Stderr, "auto-commit turn %d: %v\n", turnN, err)
+			}
+		}
+
+		// ── Run sensors ───────────────────────────────────────────────────────
+		var sensorResults []*SensorResult
+		for _, name := range sensorNames {
+			_ = traj.Emit(KindSensorRun, turnN, name)
+			result, err := RunSensor(ynh, opts.HarnessName, name, opts.WorktreeDir)
+			if err != nil {
+				_, _ = fmt.Fprintf(opts.Stderr, "sensor %q error: %v\n", name, err)
+				result = &SensorResult{Name: name, ExitCode: -1}
+			}
+			sensorResults = append(sensorResults, result)
+			_ = traj.Emit(KindSensorResult, turnN, SensorResultData{
+				Name:       result.Name,
+				Kind:       result.Kind,
+				Role:       result.Role,
+				ExitCode:   result.ExitCode,
+				DurationMS: result.DurationMS,
+				Passed:     result.Passed(),
+				Summary:    result.Summary(),
+			})
+		}
+
+		// ── Check convergence ─────────────────────────────────────────────────
+		if converged, feedback := checkConvergence(sensorResults, convergenceSensor, ynh, opts.HarnessName, opts.WorktreeDir, traj, turnN); converged {
+			_ = traj.Emit(KindConverged, turnN, nil)
+			_ = traj.Emit(KindSessionEnd, turnN, SessionEndData{ExitCode: ExitConverged})
+			return nil
+		} else if feedback == "" {
+			// All sensors passed but no convergence sensor; treat as converged.
+			_ = traj.Emit(KindConverged, turnN, nil)
+			_ = traj.Emit(KindSessionEnd, turnN, SessionEndData{ExitCode: ExitConverged})
+			return nil
+		} else {
+			// ── Stuckness watchdog ─────────────────────────────────────────────
+			sensorHash := SensorHash(sensorResults)
+			if reason := watchdog.RecordTurn(turn.Content, sensorHash); reason != "" {
+				_ = traj.Emit(KindStuckDetected, turnN, StuckDetectedData{Reason: reason, TurnCount: budget.Turns()})
+				_ = traj.Emit(KindSessionEnd, turnN, SessionEndData{ExitCode: ExitStuck, Reason: reason})
+				return &ExitError{Code: ExitStuck, Message: "stuck: " + reason}
+			}
+
+			// ── Interactive approval ───────────────────────────────────────────
+			if opts.Interactive {
+				if emitErr := traj.Emit(KindTurnApprovalRequired, turnN, TurnApprovalData{Feedback: feedback}); emitErr != nil {
+					return fmt.Errorf("writing trajectory: %w", emitErr)
+				}
+				_, replacement, aborted := waitForApproval(ctrl, ActionApproveTurn, ActionRejectPlan)
+				if aborted {
+					_ = traj.Emit(KindSessionEnd, turnN, SessionEndData{ExitCode: ExitUserAborted, Reason: "user interrupted"})
+					return &ExitError{Code: ExitUserAborted, Message: "session interrupted by user"}
+				}
+				if replacement != "" {
+					feedback = replacement
+				}
+			}
+
+			_ = traj.Emit(KindFeedbackSent, turnN, feedback)
+			if err := sess.Send(feedback); err != nil {
+				_ = traj.Emit(KindSessionEnd, turnN, SessionEndData{ExitCode: ExitWorkerError, Reason: err.Error()})
+				return &ExitError{Code: ExitWorkerError, Message: fmt.Sprintf("sending feedback turn %d: %v", turnN, err)}
+			}
+		}
+	}
+}
+
+// checkConvergence returns (converged=true, feedback="") when all sensors
+// pass and the convergence sensor (if any) confirms done.
+// Returns (converged=false, feedback=<synthesized feedback>) when work remains.
+func checkConvergence(
+	results []*SensorResult,
+	convergenceSensor, ynh, harnessName, cwd string,
+	traj *TrajectoryWriter,
+	turnN int,
+) (bool, string) {
+	// Check all regular sensors.
+	allPassed := true
+	for _, r := range results {
+		if !r.Passed() {
+			allPassed = false
+		}
+	}
+
+	if !allPassed {
+		return false, synthesizeFeedback(results)
+	}
+
+	// All regular sensors green — consult convergence-verifier if declared.
+	if convergenceSensor != "" && ynh != "" && harnessName != "" {
+		_ = traj.Emit(KindSensorRun, turnN, convergenceSensor)
+		cvResult, err := RunSensor(ynh, harnessName, convergenceSensor, cwd)
+		if err != nil || !cvResult.Passed() {
+			var summary string
+			if err != nil {
+				summary = err.Error()
+			} else {
+				summary = cvResult.Summary()
+			}
+			_ = traj.Emit(KindSensorResult, turnN, SensorResultData{
+				Name:    convergenceSensor,
+				Kind:    "focus",
+				Role:    "convergence-verifier",
+				Passed:  false,
+				Summary: summary,
+			})
+			return false, "All sensors passed but convergence verifier says: " + summary
+		}
+		_ = traj.Emit(KindSensorResult, turnN, SensorResultData{
+			Name:   convergenceSensor,
+			Kind:   "focus",
+			Role:   "convergence-verifier",
+			Passed: true,
+		})
+	}
+
+	return true, ""
+}
+
+// synthesizeFeedback produces the user-turn message injected after a
+// non-converged turn. Format mirrors the plan §7.3 sensor-results block.
+func synthesizeFeedback(results []*SensorResult) string {
+	var sb strings.Builder
+	sb.WriteString("<sensor-results>\n")
+	for _, r := range results {
+		status := "passed"
+		if !r.Passed() {
+			status = "failed"
+		}
+		durationSec := float64(r.DurationMS) / 1000
+		_, _ = fmt.Fprintf(&sb, "  <%s status=%q duration=%.1fs", r.Name, status, durationSec)
+		if summary := r.Summary(); !r.Passed() && summary != "" && summary != "passed" && summary != "failed" {
+			_, _ = fmt.Fprintf(&sb, ">\n%s\n  </%s>", summary, r.Name)
+		} else {
+			sb.WriteString("/>")
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString("</sensor-results>\n\nContinue work. Address the failing sensors first.")
+	return sb.String()
+}
+
+// waitForApproval blocks until the control channel delivers one of the
+// expected approval or abort actions. Returns (action, replacementFeedback, aborted).
+// aborted is true if an interrupt was received.
+func waitForApproval(ctrl *ControlReader, approveAction, rejectAction ControlAction) (ControlAction, string, bool) {
+	for msg := range ctrl.C() {
+		switch msg.Action {
+		case approveAction:
+			return approveAction, "", false
+		case ActionReplaceFeedback:
+			return approveAction, msg.Feedback, false
+		case rejectAction, ActionRejectPlan:
+			return rejectAction, "", false
+		case ActionInterrupt:
+			return ActionInterrupt, "", true
+		}
+	}
+	// Control channel closed (stdin EOF) — treat as interrupt.
+	return ActionInterrupt, "", true
+}
+
+// assembleHarness assembles the harness for the named vendor backend into
+// a temporary directory. The caller is responsible for os.RemoveAll on the
+// returned path.
+func assembleHarness(h *harness.Harness, backendName string) (string, error) {
+	adapter, err := vendor.Get(backendName)
+	if err != nil {
+		return "", fmt.Errorf("vendor %q: %w", backendName, err)
+	}
+
+	dir, err := os.MkdirTemp("", "ynh-agent-")
+	if err != nil {
+		return "", fmt.Errorf("creating temp dir: %w", err)
+	}
+
+	content := []resolver.ResolvedContent{{BasePath: h.Dir}}
+
+	if err := assembler.AssembleTo(dir, adapter, content); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", fmt.Errorf("assembling harness: %w", err)
+	}
+
+	// Generate vendor-native hook config.
+	if len(h.Hooks) > 0 {
+		hookFiles, err := adapter.GenerateHookConfig(h.Hooks)
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			return "", fmt.Errorf("generating hook config: %w", err)
+		}
+		for relPath, data := range hookFiles {
+			absPath := fmt.Sprintf("%s/%s", dir, relPath)
+			if mkdirErr := os.MkdirAll(dirOf(absPath), 0o755); mkdirErr != nil {
+				_ = os.RemoveAll(dir)
+				return "", mkdirErr
+			}
+			if writeErr := os.WriteFile(absPath, data, 0o644); writeErr != nil {
+				_ = os.RemoveAll(dir)
+				return "", writeErr
+			}
+		}
+	}
+
+	// Generate vendor-native MCP config.
+	if len(h.MCPServers) > 0 {
+		mcpFiles, err := adapter.GenerateMCPConfig(h.MCPServers)
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			return "", fmt.Errorf("generating MCP config: %w", err)
+		}
+		for relPath, data := range mcpFiles {
+			absPath := fmt.Sprintf("%s/%s", dir, relPath)
+			if mkdirErr := os.MkdirAll(dirOf(absPath), 0o755); mkdirErr != nil {
+				_ = os.RemoveAll(dir)
+				return "", mkdirErr
+			}
+			if writeErr := os.WriteFile(absPath, data, 0o644); writeErr != nil {
+				_ = os.RemoveAll(dir)
+				return "", writeErr
+			}
+		}
+	}
+
+	return dir, nil
+}
+
+// gitAutoCommit runs `git add -A && git commit` in the given directory.
+// A git commit with nothing to commit is silently ignored.
+func gitAutoCommit(dir string, turnN int) error {
+	addCmd := exec.Command("git", "-C", dir, "add", "-A")
+	if err := addCmd.Run(); err != nil {
+		return fmt.Errorf("git add: %w", err)
+	}
+	commitCmd := exec.Command("git", "-C", dir, "commit", "-m",
+		fmt.Sprintf("agent: turn %d", turnN))
+	out, err := commitCmd.CombinedOutput()
+	if err != nil {
+		// Exit 1 from git commit means "nothing to commit" — not an error.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return nil
+		}
+		return fmt.Errorf("git commit: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// selectBackend returns the WorkerBackend for the given name.
+func selectBackend(name string) (WorkerBackend, error) {
+	switch name {
+	case "claude", "":
+		return &ClaudeBackend{}, nil
+	default:
+		return nil, fmt.Errorf("unknown backend %q (supported: claude)", name)
+	}
+}
+
+// resolveYNHBinary returns the path to the ynh binary to use for sensor execution.
+func resolveYNHBinary(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolving ynh binary: %w", err)
+	}
+	return exe, nil
+}
+
+// openTrajectory opens a trajectory output destination.
+// If path is "-", it returns the provided stdout writer.
+// Returns the writer and a cleanup function.
+func openTrajectory(path string, stdout io.Writer) (*TrajectoryWriter, func(), error) {
+	if path == "-" {
+		return NewTrajectoryWriter(stdout), func() {}, nil
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening trajectory file %q: %w", path, err)
+	}
+	return NewTrajectoryWriter(f), func() { _ = f.Close() }, nil
+}
+
+// newNullTrajectory returns a TrajectoryWriter that discards all events.
+func newNullTrajectory() *TrajectoryWriter {
+	return NewTrajectoryWriter(io.Discard)
+}
+
+// newSessionID returns a random hex session identifier.
+func newSessionID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// dirOf returns the directory component of a path.
+func dirOf(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' || path[i] == '\\' {
+			return path[:i]
+		}
+	}
+	return "."
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -76,6 +77,12 @@ type RunOptions struct {
 	// YNHBinary is the path to the ynh executable for sensor invocation.
 	// Defaults to os.Executable() if empty.
 	YNHBinary string
+
+	// SensorOverlay is an optional per-sensor JSON patch applied before each
+	// sensor run. Keys are sensor names; values are partial plugin.Sensor JSON
+	// (e.g. `{"source":{"command":"make fast"}}`). Passed to ynh sensors run
+	// via --sensor-overlay-json so the merge happens inside ynh.
+	SensorOverlay map[string]json.RawMessage
 
 	// backendOverride is the resolved WorkerBackend; set by tests or left nil to auto-select.
 	backendOverride WorkerBackend
@@ -316,7 +323,11 @@ func RunLoop(opts RunOptions) error {
 		var sensorResults []*SensorResult
 		for _, name := range sensorNames {
 			_ = traj.Emit(KindSensorRun, turnN, name)
-			result, err := RunSensor(ynh, opts.HarnessName, name, opts.WorktreeDir)
+			var overlayJSON string
+			if raw, ok := opts.SensorOverlay[name]; ok {
+				overlayJSON = string(raw)
+			}
+			result, err := RunSensor(ynh, opts.HarnessName, name, opts.WorktreeDir, overlayJSON)
 			if err != nil {
 				_, _ = fmt.Fprintf(opts.Stderr, "sensor %q error: %v\n", name, err)
 				result = &SensorResult{Name: name, ExitCode: -1}
@@ -400,7 +411,7 @@ func checkConvergence(
 	// All regular sensors green — consult convergence-verifier if declared.
 	if convergenceSensor != "" && ynh != "" && harnessName != "" {
 		_ = traj.Emit(KindSensorRun, turnN, convergenceSensor)
-		cvResult, err := RunSensor(ynh, harnessName, convergenceSensor, cwd)
+		cvResult, err := RunSensor(ynh, harnessName, convergenceSensor, cwd, "")
 		if err != nil || !cvResult.Passed() {
 			var summary string
 			if err != nil {

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -249,7 +249,7 @@ func RunLoop(opts RunOptions) error {
 
 		if opts.Interactive {
 			feedback := planTurn.Content
-			if emitErr := traj.Emit(KindTurnApprovalRequired, 0, TurnApprovalData{Feedback: feedback}); emitErr != nil {
+			if emitErr := traj.Emit(KindTurnApprovalRequired, 0, TurnApprovalData{SynthesizedFeedback: feedback}); emitErr != nil {
 				return fmt.Errorf("writing trajectory: %w", emitErr)
 			}
 			action, replacement, aborted := waitForApproval(ctrl, ActionApprovePlan, ActionRejectPlan)
@@ -281,9 +281,9 @@ func RunLoop(opts RunOptions) error {
 
 	for {
 		// ── Budget check ──────────────────────────────────────────────────────
-		if reason, code := budget.Exceeded(); reason != "" {
-			_ = traj.Emit(KindBudgetExceeded, budget.Turns(), BudgetExceededData{Reason: reason})
-			_ = traj.Emit(KindSessionEnd, budget.Turns(), SessionEndData{ExitCode: code, Reason: reason})
+		if reason, budgetKind, code := budget.Exceeded(); reason != "" {
+			_ = traj.Emit(KindBudgetExceeded, budget.Turns(), BudgetExceededData{Budget: budgetKind, Reason: reason})
+			_ = traj.Emit(KindSessionEnd, budget.Turns(), SessionEndData{ExitCode: code, Reason: reason, TotalTurns: budget.Turns(), TotalTokens: budget.Tokens()})
 			return &ExitError{Code: code, Message: reason}
 		}
 
@@ -336,12 +336,12 @@ func RunLoop(opts RunOptions) error {
 		// ── Check convergence ─────────────────────────────────────────────────
 		if converged, feedback := checkConvergence(sensorResults, convergenceSensor, ynh, opts.HarnessName, opts.WorktreeDir, traj, turnN); converged {
 			_ = traj.Emit(KindConverged, turnN, nil)
-			_ = traj.Emit(KindSessionEnd, turnN, SessionEndData{ExitCode: ExitConverged})
+			_ = traj.Emit(KindSessionEnd, turnN, SessionEndData{ExitCode: ExitConverged, TotalTurns: budget.Turns(), TotalTokens: budget.Tokens()})
 			return nil
 		} else if feedback == "" {
 			// All sensors passed but no convergence sensor; treat as converged.
 			_ = traj.Emit(KindConverged, turnN, nil)
-			_ = traj.Emit(KindSessionEnd, turnN, SessionEndData{ExitCode: ExitConverged})
+			_ = traj.Emit(KindSessionEnd, turnN, SessionEndData{ExitCode: ExitConverged, TotalTurns: budget.Turns(), TotalTokens: budget.Tokens()})
 			return nil
 		} else {
 			// ── Stuckness watchdog ─────────────────────────────────────────────
@@ -354,7 +354,7 @@ func RunLoop(opts RunOptions) error {
 
 			// ── Interactive approval ───────────────────────────────────────────
 			if opts.Interactive {
-				if emitErr := traj.Emit(KindTurnApprovalRequired, turnN, TurnApprovalData{Feedback: feedback}); emitErr != nil {
+				if emitErr := traj.Emit(KindTurnApprovalRequired, turnN, TurnApprovalData{SynthesizedFeedback: feedback}); emitErr != nil {
 					return fmt.Errorf("writing trajectory: %w", emitErr)
 				}
 				_, replacement, aborted := waitForApproval(ctrl, ActionApproveTurn, ActionRejectPlan)
@@ -560,8 +560,12 @@ func selectBackend(name string) (WorkerBackend, error) {
 	switch name {
 	case "claude", "":
 		return &ClaudeBackend{}, nil
+	case "codex":
+		return &CodexBackend{}, nil
+	case "cursor":
+		return &CursorBackend{}, nil
 	default:
-		return nil, fmt.Errorf("unknown backend %q (supported: claude)", name)
+		return nil, fmt.Errorf("unknown backend %q (supported: claude, codex, cursor)", name)
 	}
 }
 

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -79,7 +79,7 @@ func TestRunLoop_TurnCapExceeded(t *testing.T) {
 	// MaxTurns=1 should stop after the first act turn is recorded.
 	original := runSensorFn
 	defer func() { runSensorFn = original }()
-	runSensorFn = func(ynh, harnessName, sensorName, cwd string) (*SensorResult, error) {
+	runSensorFn = func(ynh, harnessName, sensorName, cwd, overlayJSON string) (*SensorResult, error) {
 		return &SensorResult{Name: sensorName, Kind: "command", ExitCode: 1}, nil
 	}
 
@@ -131,7 +131,7 @@ func TestRunLoop_SensorFailureSendsFeedback(t *testing.T) {
 	defer func() { runSensorFn = original }()
 
 	callCount := 0
-	runSensorFn = func(ynh, harnessName, sensorName, cwd string) (*SensorResult, error) {
+	runSensorFn = func(ynh, harnessName, sensorName, cwd, overlayJSON string) (*SensorResult, error) {
 		callCount++
 		exitCode := 1
 		if callCount > 1 {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1,0 +1,288 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+// mockBackend is a test WorkerBackend that returns scripted turns.
+type mockBackend struct {
+	name  string
+	turns []Turn
+	pos   int
+	sends []string
+}
+
+func (m *mockBackend) Name() string { return m.name }
+
+func (m *mockBackend) Start(_ context.Context, _ StartOptions) (WorkerSession, error) {
+	return &mockSession{backend: m}, nil
+}
+
+type mockSession struct {
+	backend *mockBackend
+}
+
+func (s *mockSession) Send(msg string) error {
+	s.backend.sends = append(s.backend.sends, msg)
+	return nil
+}
+
+func (s *mockSession) Next() (Turn, error) {
+	if s.backend.pos >= len(s.backend.turns) {
+		return Turn{}, io.EOF
+	}
+	t := s.backend.turns[s.backend.pos]
+	s.backend.pos++
+	return t, nil
+}
+
+func (s *mockSession) Close() error { return nil }
+
+// baseOpts returns a minimal RunOptions for testing the loop without harness or sensors.
+func baseOpts(backend WorkerBackend, stdout, stderr io.Writer, stdin io.Reader) RunOptions {
+	return RunOptions{
+		HarnessName:     "", // no harness — sensors are skipped
+		Task:            "test task",
+		NoPlan:          true, // skip plan phase
+		MaxTurns:        5,
+		Stdout:          stdout,
+		Stderr:          stderr,
+		Stdin:           stdin,
+		YNHBinary:       "ynh",
+		backendOverride: backend,
+	}
+}
+
+func TestRunLoop_ConvergesWhenNoSensors(t *testing.T) {
+	// With no sensors declared and a single response from the worker,
+	// the loop should immediately converge (all zero sensors = all passed).
+	mb := &mockBackend{
+		name:  "mock",
+		turns: []Turn{{Content: "done"}},
+	}
+	var stdout, stderr bytes.Buffer
+	opts := baseOpts(mb, &stdout, &stderr, strings.NewReader(""))
+
+	err := RunLoop(opts)
+	if err != nil {
+		t.Fatalf("expected convergence, got: %v", err)
+	}
+}
+
+func TestRunLoop_TurnCapExceeded(t *testing.T) {
+	// Worker keeps responding, sensors always fail → no convergence.
+	// MaxTurns=1 should stop after the first act turn is recorded.
+	original := runSensorFn
+	defer func() { runSensorFn = original }()
+	runSensorFn = func(ynh, harnessName, sensorName, cwd string) (*SensorResult, error) {
+		return &SensorResult{Name: sensorName, Kind: "command", ExitCode: 1}, nil
+	}
+
+	mb := &mockBackend{
+		name: "mock",
+		turns: []Turn{
+			{Content: "response 1"},
+			{Content: "response 2"},
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	opts := baseOpts(mb, &stdout, &stderr, strings.NewReader(""))
+	opts.MaxTurns = 1
+	opts.testSensorNames = []string{"build"}
+
+	err := RunLoop(opts)
+	var exitErr *ExitError
+	if err == nil {
+		t.Fatal("expected ExitError, got nil")
+	}
+	if !asExitError(err, &exitErr) || exitErr.Code != ExitIterationCap {
+		t.Errorf("expected ExitIterationCap (%d), got: %v", ExitIterationCap, err)
+	}
+}
+
+func TestRunLoop_WorkerEOFBeforeConvergence(t *testing.T) {
+	// Worker exits after one turn but sensors (if any) didn't all pass.
+	// With sensors mocked to fail, worker EOF is a worker error.
+	original := runSensorFn
+	defer func() { runSensorFn = original }()
+
+	mb := &mockBackend{
+		name:  "mock",
+		turns: []Turn{{Content: "partial work"}},
+	}
+	var stdout, stderr bytes.Buffer
+	opts := baseOpts(mb, &stdout, &stderr, strings.NewReader(""))
+
+	// Worker returns EOF after 1 turn; since there are no sensors, loop converges.
+	err := RunLoop(opts)
+	if err != nil {
+		t.Fatalf("no sensors → should converge on first turn, got: %v", err)
+	}
+}
+
+func TestRunLoop_SensorFailureSendsFeedback(t *testing.T) {
+	// Sensor fails on turn 1, passes on turn 2. Loop should converge on turn 2.
+	original := runSensorFn
+	defer func() { runSensorFn = original }()
+
+	callCount := 0
+	runSensorFn = func(ynh, harnessName, sensorName, cwd string) (*SensorResult, error) {
+		callCount++
+		exitCode := 1
+		if callCount > 1 {
+			exitCode = 0 // pass on second sensor run
+		}
+		return &SensorResult{Name: sensorName, Kind: "command", ExitCode: exitCode}, nil
+	}
+
+	mb := &mockBackend{
+		name: "mock",
+		turns: []Turn{
+			{Content: "first attempt"},
+			{Content: "second attempt (fixed)"},
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	opts := baseOpts(mb, &stdout, &stderr, strings.NewReader(""))
+	opts.testSensorNames = []string{"build"} // inject sensor without real harness
+
+	err := RunLoop(opts)
+	if err != nil {
+		t.Fatalf("expected convergence after retry, got: %v", err)
+	}
+	// Worker should have received the initial task + sensor feedback.
+	if len(mb.sends) < 2 {
+		t.Errorf("expected at least 2 sends (task + feedback), got %d", len(mb.sends))
+	}
+}
+
+func TestRunLoop_TrajectoryContainsSessionStart(t *testing.T) {
+	mb := &mockBackend{
+		name:  "mock",
+		turns: []Turn{{Content: "done"}},
+	}
+	var traj, stderr bytes.Buffer
+	opts := baseOpts(mb, &bytes.Buffer{}, &stderr, strings.NewReader(""))
+	opts.EmitJSONL = "-"
+	opts.Stdout = &traj
+
+	if err := RunLoop(opts); err != nil {
+		t.Fatalf("RunLoop: %v", err)
+	}
+
+	lines := bytes.Split(bytes.TrimRight(traj.Bytes(), "\n"), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("no trajectory events emitted")
+	}
+
+	var firstEvent Event
+	if err := json.Unmarshal(lines[0], &firstEvent); err != nil {
+		t.Fatalf("parsing first event: %v", err)
+	}
+	if firstEvent.Kind != KindSessionStart {
+		t.Errorf("expected first event to be session_start, got %q", firstEvent.Kind)
+	}
+}
+
+func TestRunLoop_TrajectoryEndsWithSessionEnd(t *testing.T) {
+	mb := &mockBackend{
+		name:  "mock",
+		turns: []Turn{{Content: "done"}},
+	}
+	var traj, stderr bytes.Buffer
+	opts := baseOpts(mb, &bytes.Buffer{}, &stderr, strings.NewReader(""))
+	opts.EmitJSONL = "-"
+	opts.Stdout = &traj
+
+	if err := RunLoop(opts); err != nil {
+		t.Fatalf("RunLoop: %v", err)
+	}
+
+	lines := bytes.Split(bytes.TrimRight(traj.Bytes(), "\n"), []byte("\n"))
+	last := lines[len(lines)-1]
+
+	var lastEvent Event
+	if err := json.Unmarshal(last, &lastEvent); err != nil {
+		t.Fatalf("parsing last event: %v", err)
+	}
+	if lastEvent.Kind != KindSessionEnd {
+		t.Errorf("expected last event to be session_end, got %q", lastEvent.Kind)
+	}
+}
+
+func TestRunLoop_TaskRequired(t *testing.T) {
+	mb := &mockBackend{name: "mock"}
+	var stdout, stderr bytes.Buffer
+	opts := baseOpts(mb, &stdout, &stderr, strings.NewReader(""))
+	opts.Task = "" // missing
+
+	// Should not crash — missing task is detected by the CLI layer.
+	// But if somehow called with empty task, the loop will send "" as first message.
+	// This test verifies no panic occurs.
+	err := RunLoop(opts)
+	// With no turns and empty task, worker returns EOF immediately.
+	// That's a worker error since convergence wasn't reached.
+	if err == nil {
+		// No sensors → convergence (valid outcome with 0 turns + 0 sensors).
+		return
+	}
+}
+
+func TestSelectBackend(t *testing.T) {
+	wb, err := selectBackend("claude")
+	if err != nil {
+		t.Fatalf("selectBackend claude: %v", err)
+	}
+	if wb.Name() != "claude" {
+		t.Errorf("expected claude, got %q", wb.Name())
+	}
+
+	_, err = selectBackend("unknown")
+	if err == nil {
+		t.Error("expected error for unknown backend")
+	}
+}
+
+func TestSynthesizeFeedback(t *testing.T) {
+	results := []*SensorResult{
+		{Name: "build", Kind: "command", ExitCode: 0, DurationMS: 800},
+		{Name: "test", Kind: "command", ExitCode: 1, DurationMS: 2100,
+			Output: SensorRunOutput{Stdout: "FAIL: TestFoo"}},
+	}
+	fb := synthesizeFeedback(results)
+	if !strings.Contains(fb, "<sensor-results>") {
+		t.Error("feedback should contain <sensor-results>")
+	}
+	if !strings.Contains(fb, `status="failed"`) {
+		t.Error("feedback should mark test as failed")
+	}
+	if !strings.Contains(fb, `status="passed"`) {
+		t.Error("feedback should mark build as passed")
+	}
+}
+
+func TestExitError(t *testing.T) {
+	e := &ExitError{Code: ExitStuck, Message: "stuck in a loop"}
+	if e.Error() != "stuck in a loop" {
+		t.Errorf("unexpected Error() string: %q", e.Error())
+	}
+
+	e2 := &ExitError{Code: ExitWorkerError}
+	if e2.Error() == "" {
+		t.Error("ExitError with no message should still return non-empty string")
+	}
+}
+
+// asExitError type-asserts err to *ExitError and stores it in out.
+func asExitError(err error, out **ExitError) bool {
+	if exitErr, ok := err.(*ExitError); ok {
+		*out = exitErr
+		return true
+	}
+	return false
+}

--- a/internal/agent/sensor.go
+++ b/internal/agent/sensor.go
@@ -1,0 +1,150 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// SensorResult is the parsed output of `ynh sensors run`.
+// Wire shape mirrors cmd/ynh sensors.go sensorRunResult exactly.
+type SensorResult struct {
+	Name       string          `json:"name"`
+	Kind       string          `json:"kind"` // files | command | focus
+	Role       string          `json:"role,omitempty"`
+	Category   string          `json:"category,omitempty"`
+	ExitCode   int             `json:"exit_code"`
+	DurationMS int64           `json:"duration_ms"`
+	Output     SensorRunOutput `json:"output"`
+}
+
+// Passed applies loop-driver policy:
+//   - command sensors: exit_code == 0
+//   - files sensors: at least one file matched
+//   - focus sensors: always informational (true); driver handles agent invocation
+func (r *SensorResult) Passed() bool {
+	switch r.Kind {
+	case "command":
+		return r.ExitCode == 0
+	case "files":
+		return len(r.Output.Files) > 0
+	case "focus":
+		return true
+	default:
+		return r.ExitCode == 0
+	}
+}
+
+// Summary returns a short human-readable description of the sensor result.
+func (r *SensorResult) Summary() string {
+	switch r.Kind {
+	case "command":
+		if r.ExitCode == 0 {
+			return "passed"
+		}
+		if r.Output.Stdout != "" {
+			lines := strings.SplitN(strings.TrimSpace(r.Output.Stdout), "\n", 4)
+			if len(lines) > 3 {
+				lines = append(lines[:3], "…")
+			}
+			return strings.Join(lines, "\n")
+		}
+		if r.Output.Stderr != "" {
+			lines := strings.SplitN(strings.TrimSpace(r.Output.Stderr), "\n", 4)
+			if len(lines) > 3 {
+				lines = append(lines[:3], "…")
+			}
+			return strings.Join(lines, "\n")
+		}
+		return fmt.Sprintf("failed (exit %d)", r.ExitCode)
+	case "files":
+		if len(r.Output.Files) == 0 {
+			return "no files matched"
+		}
+		return fmt.Sprintf("%d file(s)", len(r.Output.Files))
+	case "focus":
+		return "focus sensor (loop driver invokes agent runtime)"
+	default:
+		return ""
+	}
+}
+
+// SensorRunOutput mirrors the wire shape from ynh sensors run.
+type SensorRunOutput struct {
+	Format  string       `json:"format"`
+	Channel string       `json:"channel,omitempty"`
+	Stdout  string       `json:"stdout,omitempty"`
+	Stderr  string       `json:"stderr,omitempty"`
+	Files   []SensorFile `json:"files,omitempty"`
+	Note    string       `json:"note,omitempty"`
+}
+
+// SensorFile is a file artifact returned by a files-sourced sensor.
+type SensorFile struct {
+	Path    string `json:"path"`
+	Size    int64  `json:"size"`
+	Content string `json:"content,omitempty"`
+}
+
+// runSensorFn is the function used to execute sensors.
+// Replaceable in tests without touching the real ynh binary.
+var runSensorFn = defaultRunSensor
+
+// RunSensor executes `ynh sensors run <harness> <name>` and returns the
+// parsed result. The ynh binary at ynhPath is used; cwd is passed as
+// --cwd if non-empty.
+func RunSensor(ynhPath, harnessName, sensorName, cwd string) (*SensorResult, error) {
+	return runSensorFn(ynhPath, harnessName, sensorName, cwd)
+}
+
+func defaultRunSensor(ynhPath, harnessName, sensorName, cwd string) (*SensorResult, error) {
+	args := []string{"sensors", "run", harnessName, sensorName, "--format", "json"}
+	if cwd != "" {
+		args = append(args, "--cwd", cwd)
+	}
+
+	cmd := exec.Command(ynhPath, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() > 0 {
+			return nil, fmt.Errorf("ynh sensors run: %s", strings.TrimSpace(stderr.String()))
+		}
+		return nil, fmt.Errorf("ynh sensors run: %w", err)
+	}
+
+	var r SensorResult
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		return nil, fmt.Errorf("parsing sensor result: %w", err)
+	}
+	return &r, nil
+}
+
+// SensorHash produces a stable short hash over a set of sensor results.
+// Used by the watchdog to detect when sensors stop changing between turns.
+func SensorHash(results []*SensorResult) string {
+	var sb strings.Builder
+	for _, r := range results {
+		fmt.Fprintf(&sb, "%s:%d|", r.Name, r.ExitCode)
+	}
+	return contentHash(sb.String())
+}
+
+// sensorTier returns a sort priority for sensor execution order.
+// Build sensors run before lint, lint before test, everything else last.
+func sensorTier(category string) int {
+	switch strings.ToLower(category) {
+	case "build":
+		return 1
+	case "lint":
+		return 2
+	case "test":
+		return 3
+	default:
+		return 4
+	}
+}

--- a/internal/agent/sensor.go
+++ b/internal/agent/sensor.go
@@ -93,16 +93,20 @@ type SensorFile struct {
 var runSensorFn = defaultRunSensor
 
 // RunSensor executes `ynh sensors run <harness> <name>` and returns the
-// parsed result. The ynh binary at ynhPath is used; cwd is passed as
-// --cwd if non-empty.
-func RunSensor(ynhPath, harnessName, sensorName, cwd string) (*SensorResult, error) {
-	return runSensorFn(ynhPath, harnessName, sensorName, cwd)
+// parsed result. overlayJSON is an optional partial sensor JSON (e.g.
+// `{"source":{"command":"make fast"}}`) merged over the base declaration
+// by the ynh binary before execution. Pass "" for no overlay.
+func RunSensor(ynhPath, harnessName, sensorName, cwd, overlayJSON string) (*SensorResult, error) {
+	return runSensorFn(ynhPath, harnessName, sensorName, cwd, overlayJSON)
 }
 
-func defaultRunSensor(ynhPath, harnessName, sensorName, cwd string) (*SensorResult, error) {
+func defaultRunSensor(ynhPath, harnessName, sensorName, cwd, overlayJSON string) (*SensorResult, error) {
 	args := []string{"sensors", "run", harnessName, sensorName, "--format", "json"}
 	if cwd != "" {
 		args = append(args, "--cwd", cwd)
+	}
+	if overlayJSON != "" {
+		args = append(args, "--sensor-overlay-json", overlayJSON)
 	}
 
 	cmd := exec.Command(ynhPath, args...)

--- a/internal/agent/sensor_test.go
+++ b/internal/agent/sensor_test.go
@@ -1,0 +1,125 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestSensorResult_Passed_Command(t *testing.T) {
+	cases := []struct {
+		exit   int
+		passed bool
+	}{
+		{0, true},
+		{1, false},
+		{127, false},
+	}
+	for _, c := range cases {
+		r := &SensorResult{Kind: "command", ExitCode: c.exit}
+		if r.Passed() != c.passed {
+			t.Errorf("exit=%d: expected Passed()=%v", c.exit, c.passed)
+		}
+	}
+}
+
+func TestSensorResult_Passed_Files(t *testing.T) {
+	empty := &SensorResult{Kind: "files"}
+	if empty.Passed() {
+		t.Error("files sensor with no files should not pass")
+	}
+
+	withFiles := &SensorResult{Kind: "files", Output: SensorRunOutput{
+		Files: []SensorFile{{Path: "foo.txt"}},
+	}}
+	if !withFiles.Passed() {
+		t.Error("files sensor with files should pass")
+	}
+}
+
+func TestSensorResult_Passed_Focus(t *testing.T) {
+	r := &SensorResult{Kind: "focus"}
+	if !r.Passed() {
+		t.Error("focus sensor should always pass (informational)")
+	}
+}
+
+func TestSensorResult_Summary_Command(t *testing.T) {
+	passing := &SensorResult{Kind: "command", ExitCode: 0}
+	if passing.Summary() != "passed" {
+		t.Errorf("expected 'passed', got %q", passing.Summary())
+	}
+
+	failing := &SensorResult{
+		Kind:     "command",
+		ExitCode: 1,
+		Output:   SensorRunOutput{Stdout: "line1\nline2\nline3\nline4\nline5"},
+	}
+	summary := failing.Summary()
+	// Should truncate to 3 lines with ellipsis.
+	if summary == "" {
+		t.Error("failing sensor should have non-empty summary")
+	}
+}
+
+func TestSensorHash_Deterministic(t *testing.T) {
+	results := []*SensorResult{
+		{Name: "build", ExitCode: 0},
+		{Name: "test", ExitCode: 1},
+	}
+	h1 := SensorHash(results)
+	h2 := SensorHash(results)
+	if h1 != h2 {
+		t.Error("SensorHash should be deterministic")
+	}
+}
+
+func TestSensorHash_DifferentOnChange(t *testing.T) {
+	before := []*SensorResult{{Name: "build", ExitCode: 0}}
+	after := []*SensorResult{{Name: "build", ExitCode: 1}}
+	if SensorHash(before) == SensorHash(after) {
+		t.Error("different exit codes should produce different hashes")
+	}
+}
+
+func TestSensorHash_EmptySlice(t *testing.T) {
+	h := SensorHash(nil)
+	if h == "" {
+		t.Error("SensorHash of empty slice should still return a string")
+	}
+}
+
+func TestSensorTier(t *testing.T) {
+	cases := []struct {
+		category string
+		tier     int
+	}{
+		{"build", 1},
+		{"Build", 1},
+		{"lint", 2},
+		{"test", 3},
+		{"quality", 4},
+		{"behaviour", 4},
+		{"", 4},
+	}
+	for _, c := range cases {
+		if got := sensorTier(c.category); got != c.tier {
+			t.Errorf("sensorTier(%q): expected %d, got %d", c.category, c.tier, got)
+		}
+	}
+}
+
+func TestRunSensor_MockReplacement(t *testing.T) {
+	original := runSensorFn
+	defer func() { runSensorFn = original }()
+
+	runSensorFn = func(ynh, harnessName, sensorName, cwd string) (*SensorResult, error) {
+		return &SensorResult{Name: sensorName, Kind: "command", ExitCode: 0}, nil
+	}
+
+	result, err := RunSensor("ynh", "myharness", "build", "/tmp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Name != "build" || result.ExitCode != 0 {
+		t.Errorf("unexpected result: %+v", result)
+	}
+}

--- a/internal/agent/sensor_test.go
+++ b/internal/agent/sensor_test.go
@@ -111,11 +111,11 @@ func TestRunSensor_MockReplacement(t *testing.T) {
 	original := runSensorFn
 	defer func() { runSensorFn = original }()
 
-	runSensorFn = func(ynh, harnessName, sensorName, cwd string) (*SensorResult, error) {
+	runSensorFn = func(ynh, harnessName, sensorName, cwd, overlayJSON string) (*SensorResult, error) {
 		return &SensorResult{Name: sensorName, Kind: "command", ExitCode: 0}, nil
 	}
 
-	result, err := RunSensor("ynh", "myharness", "build", "/tmp")
+	result, err := RunSensor("ynh", "myharness", "build", "/tmp", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/agent/trajectory.go
+++ b/internal/agent/trajectory.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+)
+
+// EventKind identifies the type of a trajectory event.
+type EventKind string
+
+const (
+	KindSessionStart         EventKind = "session_start"
+	KindPlan                 EventKind = "plan"
+	KindTurnStart            EventKind = "turn_start"
+	KindAssistantMessage     EventKind = "assistant_message"
+	KindSensorRun            EventKind = "sensor_run"
+	KindSensorResult         EventKind = "sensor_result"
+	KindFeedbackSent         EventKind = "feedback_sent"
+	KindTurnApprovalRequired EventKind = "turn_approval_required"
+	KindStuckDetected        EventKind = "stuck_detected"
+	KindBudgetExceeded       EventKind = "budget_exceeded"
+	KindConverged            EventKind = "converged"
+	KindSessionEnd           EventKind = "session_end"
+)
+
+// Event is a single trajectory event emitted by the loop driver.
+type Event struct {
+	Time time.Time `json:"time"`
+	Kind EventKind `json:"kind"`
+	Turn int       `json:"turn,omitempty"`
+	Data any       `json:"data,omitempty"`
+}
+
+// TrajectoryWriter writes trajectory events as NDJSON.
+type TrajectoryWriter struct {
+	enc *json.Encoder
+}
+
+// NewTrajectoryWriter returns a writer that emits one JSON object per line.
+func NewTrajectoryWriter(w io.Writer) *TrajectoryWriter {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return &TrajectoryWriter{enc: enc}
+}
+
+// Emit writes a single event to the trajectory stream.
+func (t *TrajectoryWriter) Emit(kind EventKind, turn int, data any) error {
+	return t.enc.Encode(Event{
+		Time: time.Now().UTC(),
+		Kind: kind,
+		Turn: turn,
+		Data: data,
+	})
+}
+
+// Typed data payloads for specific event kinds.
+
+// SessionStartData is the payload for KindSessionStart events.
+type SessionStartData struct {
+	SessionID string `json:"session_id"`
+	Harness   string `json:"harness"`
+	Backend   string `json:"backend"`
+	Task      string `json:"task"`
+}
+
+// SensorResultData is the payload for KindSensorResult events.
+type SensorResultData struct {
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	Role       string `json:"role,omitempty"`
+	ExitCode   int    `json:"exit_code,omitempty"`
+	DurationMS int64  `json:"duration_ms"`
+	Passed     bool   `json:"passed"`
+	Summary    string `json:"summary,omitempty"`
+}
+
+// BudgetExceededData is the payload for KindBudgetExceeded events.
+type BudgetExceededData struct {
+	Reason string `json:"reason"`
+}
+
+// StuckDetectedData is the payload for KindStuckDetected events.
+type StuckDetectedData struct {
+	Reason    string `json:"reason"`
+	TurnCount int    `json:"turn_count"`
+}
+
+// SessionEndData is the payload for KindSessionEnd events.
+type SessionEndData struct {
+	ExitCode int    `json:"exit_code"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// TurnApprovalData is the payload for KindTurnApprovalRequired events.
+type TurnApprovalData struct {
+	Feedback string `json:"feedback"`
+}

--- a/internal/agent/trajectory.go
+++ b/internal/agent/trajectory.go
@@ -25,11 +25,14 @@ const (
 )
 
 // Event is a single trajectory event emitted by the loop driver.
+// Wire field names match what TermQ and other consumers expect:
+//   - "type" (not "kind") for the event discriminator
+//   - "timestamp" (not "time") for the wall-clock time
 type Event struct {
-	Time time.Time `json:"time"`
-	Kind EventKind `json:"kind"`
-	Turn int       `json:"turn,omitempty"`
-	Data any       `json:"data,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+	Kind      EventKind `json:"type"`
+	Turn      int       `json:"turn,omitempty"`
+	Data      any       `json:"data,omitempty"`
 }
 
 // TrajectoryWriter writes trajectory events as NDJSON.
@@ -47,10 +50,10 @@ func NewTrajectoryWriter(w io.Writer) *TrajectoryWriter {
 // Emit writes a single event to the trajectory stream.
 func (t *TrajectoryWriter) Emit(kind EventKind, turn int, data any) error {
 	return t.enc.Encode(Event{
-		Time: time.Now().UTC(),
-		Kind: kind,
-		Turn: turn,
-		Data: data,
+		Timestamp: time.Now().UTC(),
+		Kind:      kind,
+		Turn:      turn,
+		Data:      data,
 	})
 }
 
@@ -75,9 +78,21 @@ type SensorResultData struct {
 	Summary    string `json:"summary,omitempty"`
 }
 
+// BudgetType identifies which budget limit was hit.
+type BudgetType string
+
+const (
+	BudgetTurns     BudgetType = "turns"
+	BudgetTokens    BudgetType = "tokens"
+	BudgetWallClock BudgetType = "wall_clock"
+)
+
 // BudgetExceededData is the payload for KindBudgetExceeded events.
+// Budget holds the machine-readable limit type; Reason holds a human
+// string for logs and UIs that don't switch on Budget.
 type BudgetExceededData struct {
-	Reason string `json:"reason"`
+	Budget BudgetType `json:"budget"`
+	Reason string     `json:"reason"`
 }
 
 // StuckDetectedData is the payload for KindStuckDetected events.
@@ -88,11 +103,14 @@ type StuckDetectedData struct {
 
 // SessionEndData is the payload for KindSessionEnd events.
 type SessionEndData struct {
-	ExitCode int    `json:"exit_code"`
-	Reason   string `json:"reason,omitempty"`
+	ExitCode    int    `json:"exit_code"`
+	Reason      string `json:"reason,omitempty"`
+	TotalTurns  int    `json:"total_turns,omitempty"`
+	TotalTokens int64  `json:"total_tokens,omitempty"`
 }
 
 // TurnApprovalData is the payload for KindTurnApprovalRequired events.
+// SynthesizedFeedback matches the TermQ wire name.
 type TurnApprovalData struct {
-	Feedback string `json:"feedback"`
+	SynthesizedFeedback string `json:"synthesized_feedback"`
 }

--- a/internal/agent/trajectory_test.go
+++ b/internal/agent/trajectory_test.go
@@ -33,8 +33,8 @@ func TestTrajectoryWriter_EmitsValidNDJSON(t *testing.T) {
 		if err := json.Unmarshal(line, &ev); err != nil {
 			t.Errorf("line %d: invalid JSON: %v", i, err)
 		}
-		if ev.Time.IsZero() {
-			t.Errorf("line %d: time is zero", i)
+		if ev.Timestamp.IsZero() {
+			t.Errorf("line %d: timestamp is zero", i)
 		}
 	}
 }

--- a/internal/agent/trajectory_test.go
+++ b/internal/agent/trajectory_test.go
@@ -1,0 +1,89 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestTrajectoryWriter_EmitsValidNDJSON(t *testing.T) {
+	var buf bytes.Buffer
+	tw := NewTrajectoryWriter(&buf)
+
+	if err := tw.Emit(KindSessionStart, 0, SessionStartData{
+		SessionID: "abc123",
+		Harness:   "myharness",
+		Backend:   "claude",
+		Task:      "fix the bug",
+	}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	if err := tw.Emit(KindTurnStart, 1, nil); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	lines := bytes.Split(bytes.TrimRight(buf.Bytes(), "\n"), []byte("\n"))
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+
+	for i, line := range lines {
+		var ev Event
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Errorf("line %d: invalid JSON: %v", i, err)
+		}
+		if ev.Time.IsZero() {
+			t.Errorf("line %d: time is zero", i)
+		}
+	}
+}
+
+func TestTrajectoryWriter_TurnField(t *testing.T) {
+	var buf bytes.Buffer
+	tw := NewTrajectoryWriter(&buf)
+	_ = tw.Emit(KindTurnStart, 7, nil)
+
+	var ev Event
+	if err := json.Unmarshal(buf.Bytes(), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev.Turn != 7 {
+		t.Errorf("expected turn=7, got %d", ev.Turn)
+	}
+}
+
+func TestTrajectoryWriter_NoHTMLEscape(t *testing.T) {
+	var buf bytes.Buffer
+	tw := NewTrajectoryWriter(&buf)
+	_ = tw.Emit(KindFeedbackSent, 1, "<sensor-results>&</sensor-results>")
+
+	// json.Encoder with SetEscapeHTML(true) encodes < as < (6 bytes).
+	// With escaping disabled it should appear as the literal < byte.
+	jsonEscaped := []byte("\\u003c") // the 6-char sequence: \, u, 0, 0, 3, c
+	if bytes.Contains(buf.Bytes(), jsonEscaped) {
+		t.Error("HTML escaping should be disabled: found \\u003c in output")
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("<")) {
+		t.Error("expected literal < in output when HTML escaping is disabled")
+	}
+}
+
+func TestEventKindConstants(t *testing.T) {
+	kinds := []EventKind{
+		KindSessionStart, KindPlan, KindTurnStart, KindAssistantMessage,
+		KindSensorRun, KindSensorResult, KindFeedbackSent,
+		KindTurnApprovalRequired, KindStuckDetected, KindBudgetExceeded,
+		KindConverged, KindSessionEnd,
+	}
+	seen := make(map[EventKind]bool)
+	for _, k := range kinds {
+		if k == "" {
+			t.Error("empty EventKind constant")
+		}
+		if seen[k] {
+			t.Errorf("duplicate EventKind: %q", k)
+		}
+		seen[k] = true
+	}
+}

--- a/internal/agent/watchdog.go
+++ b/internal/agent/watchdog.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// Watchdog detects stuckness signals in the agent loop.
+// Phase 1 implements two signals: edit-loop (same content hash N times in a
+// row) and no-progress window (no sensor delta for K consecutive turns).
+type Watchdog struct {
+	// EditLoopThreshold triggers when the same response appears this many times
+	// consecutively. Zero disables this check.
+	EditLoopThreshold int
+	// NoProgressThreshold triggers when sensor state is unchanged for this
+	// many consecutive turns. Zero disables this check.
+	NoProgressThreshold int
+
+	contentHashes   []string
+	lastSensorHash  string
+	noProgressTurns int
+}
+
+// NewWatchdog returns a Watchdog with production defaults.
+func NewWatchdog() *Watchdog {
+	return &Watchdog{
+		EditLoopThreshold:   3,
+		NoProgressThreshold: 5,
+	}
+}
+
+// RecordTurn updates the watchdog with content from the latest assistant turn
+// and the current sensor hash. Returns a non-empty reason string if stuckness
+// is detected, or empty string if the session appears to be making progress.
+func (w *Watchdog) RecordTurn(content, sensorHash string) string {
+	h := contentHash(content)
+	w.contentHashes = append(w.contentHashes, h)
+
+	if w.EditLoopThreshold > 0 && len(w.contentHashes) >= w.EditLoopThreshold {
+		tail := w.contentHashes[len(w.contentHashes)-w.EditLoopThreshold:]
+		if allEqual(tail) {
+			return fmt.Sprintf("edit-loop: same response for %d consecutive turns", w.EditLoopThreshold)
+		}
+	}
+
+	if sensorHash != "" {
+		if sensorHash == w.lastSensorHash {
+			w.noProgressTurns++
+		} else {
+			w.noProgressTurns = 0
+			w.lastSensorHash = sensorHash
+		}
+		if w.NoProgressThreshold > 0 && w.noProgressTurns >= w.NoProgressThreshold {
+			return fmt.Sprintf("no sensor progress for %d consecutive turns", w.noProgressTurns)
+		}
+	}
+
+	return ""
+}
+
+func contentHash(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return fmt.Sprintf("%x", h[:8])
+}
+
+func allEqual(ss []string) bool {
+	for i := 1; i < len(ss); i++ {
+		if ss[i] != ss[0] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agent/watchdog_test.go
+++ b/internal/agent/watchdog_test.go
@@ -1,0 +1,83 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestWatchdog_NoStuck(t *testing.T) {
+	w := NewWatchdog()
+	for i := 0; i < 4; i++ {
+		reason := w.RecordTurn("different content "+string(rune('A'+i)), "hash"+string(rune('A'+i)))
+		if reason != "" {
+			t.Errorf("turn %d: unexpected stuck signal: %s", i, reason)
+		}
+	}
+}
+
+func TestWatchdog_EditLoop(t *testing.T) {
+	w := &Watchdog{EditLoopThreshold: 3, NoProgressThreshold: 0}
+	w.RecordTurn("same content", "h1")
+	w.RecordTurn("same content", "h2")
+	reason := w.RecordTurn("same content", "h3")
+	if reason == "" {
+		t.Error("expected edit-loop detection on 3rd identical turn")
+	}
+}
+
+func TestWatchdog_EditLoopBreaks(t *testing.T) {
+	w := &Watchdog{EditLoopThreshold: 3, NoProgressThreshold: 0}
+	w.RecordTurn("same", "h1")
+	w.RecordTurn("same", "h2")
+	w.RecordTurn("different", "h3") // breaks the streak
+	reason := w.RecordTurn("same", "h4")
+	if reason != "" {
+		t.Errorf("streak broken by different content; should not trigger: %s", reason)
+	}
+}
+
+func TestWatchdog_NoProgress(t *testing.T) {
+	// First call with a new hash resets the counter (hash was "").
+	// Subsequent calls with the same hash increment it.
+	// Threshold=3 triggers when noProgressTurns reaches 3.
+	w := &Watchdog{EditLoopThreshold: 0, NoProgressThreshold: 3}
+	sensorHash := "unchangedHash"
+	w.RecordTurn("a", sensorHash)           // first: resets counter (hash changed from ""), count=0
+	w.RecordTurn("b", sensorHash)           // count=1
+	w.RecordTurn("c", sensorHash)           // count=2
+	reason := w.RecordTurn("d", sensorHash) // count=3 → trigger
+	if reason == "" {
+		t.Error("expected no-progress detection after 4 turns with same sensor hash")
+	}
+}
+
+func TestWatchdog_NoProgressResets(t *testing.T) {
+	w := &Watchdog{EditLoopThreshold: 0, NoProgressThreshold: 3}
+	w.RecordTurn("a", "hash1")
+	w.RecordTurn("b", "hash1")
+	w.RecordTurn("c", "hash2") // sensor changed — reset counter
+	reason := w.RecordTurn("d", "hash2")
+	if reason != "" {
+		t.Errorf("sensor changed at turn 3; counter should have reset: %s", reason)
+	}
+}
+
+func TestWatchdog_DisabledChecks(t *testing.T) {
+	w := &Watchdog{EditLoopThreshold: 0, NoProgressThreshold: 0}
+	for i := 0; i < 20; i++ {
+		reason := w.RecordTurn("same", "same")
+		if reason != "" {
+			t.Errorf("disabled watchdog should never trigger, got: %s", reason)
+		}
+	}
+}
+
+func TestWatchdog_EmptySensorHash(t *testing.T) {
+	// If no sensors are declared, sensorHash is ""; no-progress check must skip.
+	w := &Watchdog{EditLoopThreshold: 0, NoProgressThreshold: 3}
+	for i := 0; i < 10; i++ {
+		reason := w.RecordTurn("content", "")
+		if reason != "" {
+			t.Errorf("empty sensor hash should skip no-progress check: %s", reason)
+		}
+	}
+}

--- a/internal/agent/worker.go
+++ b/internal/agent/worker.go
@@ -1,0 +1,58 @@
+package agent
+
+import (
+	"context"
+	"io"
+)
+
+// WorkerBackend abstracts over different vendor agent CLIs.
+// All wire-format details (NDJSON protocol, message shapes) live inside
+// each implementation — the loop driver never sees them.
+type WorkerBackend interface {
+	// Name returns the backend identifier ("claude", "codex", etc.).
+	Name() string
+	// Start spawns the worker subprocess and returns a live session.
+	Start(ctx context.Context, opts StartOptions) (WorkerSession, error)
+}
+
+// WorkerSession is a running agent subprocess.
+type WorkerSession interface {
+	// Send delivers a user-turn message to the worker.
+	Send(msg string) error
+	// Next blocks until the worker completes the current assistant turn.
+	// Returns io.EOF when the worker has exited cleanly.
+	Next() (Turn, error)
+	// Close terminates the worker process.
+	Close() error
+}
+
+// StartOptions carries per-session configuration for the worker subprocess.
+type StartOptions struct {
+	// WorktreeDir is the git worktree for this session; the worker runs here.
+	WorktreeDir string
+	// ConfigPath is the assembled harness directory (contains .claude/, CLAUDE.md, etc.).
+	ConfigPath string
+	// Sandbox is "srt" or "none".
+	Sandbox string
+	// Model overrides the default model. Empty means backend default.
+	Model string
+	// Env holds additional environment variables to pass to the subprocess.
+	Env []string
+	// Stderr captures subprocess stderr if non-nil.
+	Stderr io.Writer
+}
+
+// Turn represents a completed assistant response.
+type Turn struct {
+	// Content is the assistant's response text.
+	Content string
+	// Usage tracks token consumption for budget enforcement.
+	Usage Usage
+}
+
+// Usage tracks token consumption for a turn.
+type Usage struct {
+	InputTokens  int64
+	OutputTokens int64
+	CacheTokens  int64
+}


### PR DESCRIPTION
## Summary

Adds `ynh agent run` — an autonomous agent loop driver embedded in the ynh binary. The loop spawns a vendor agent subprocess, runs sensors after each turn, synthesises feedback, and enforces budgets until convergence or a halt condition.

Companion PR: eyelock/TermQ#248

## Changes

**Core loop (`internal/agent/`)**
- `loop.go` — `RunLoop`: plan phase, act loop, sensor execution, convergence check, stuckness watchdog, interactive approval, budget enforcement, NDJSON trajectory emission
- `worker.go` — `WorkerBackend` / `WorkerSession` interfaces; wire-format details stay inside each implementation
- `budget.go` — `Budget`: turn/token/wall-clock limits with typed exit codes and `BudgetType` enum
- `watchdog.go` — `Watchdog`: edit-loop detection + no-progress detection (sensor hash unchanged K turns)
- `sensor.go` — `RunSensor` wrapping `ynh sensors run`; `SensorHash` for watchdog; `--sensor-overlay-json` pass-through
- `control.go` — `ControlReader`: JSON control messages for interactive approval/interrupt via stdin
- `trajectory.go` — `TrajectoryWriter`: typed NDJSON event stream (`type`, `timestamp`, `synthesized_feedback`, `budget` enum, `total_turns`/`total_tokens`)

**Backends**
- `claude.go` — `ClaudeBackend`: long-lived subprocess, stream-json mode
- `codex.go` — `CodexBackend`: long-lived subprocess, `codex exec --json`
- `cursor.go` — `CursorBackend`: per-turn subprocess with `--resume <chatId>`

**CLI (`cmd/ynh/`)**
- `agent.go` — `ynh agent run` with flags: `--harness`, `--task`, `--backend`, `--sandbox`, `--model`, `--max-turns`, `--max-tokens`, `--max-wall`, `--convergence-sensor`, `--worktree`, `--emit-jsonl`, `--sensor-overlay`, `--interactive`, `--no-plan`
- `sensors.go` — `--sensor-overlay-json` flag; shallow JSON merge applied before execution
- `cliformat.go` — disabled HTML escaping in structured error envelope so `<harness-name>` renders literally

## Exit codes

| Code | Meaning |
|------|---------|
| 0 | Converged |
| 10 | Turn cap |
| 11 | Token budget |
| 12 | Wall-clock limit |
| 13 | Stuck |
| 14 | Tamper detected |
| 20 | Worker error |
| 30 | User aborted |

## Testing
- [x] `make check` passes — 0 lint issues, all tests green, both binaries build
- [x] `make e2e` passes — full E2E suite green
- [x] Unit tests for all new packages: budget, watchdog, trajectory, control, sensor, claude, codex, cursor, loop integration, cliformat

🤖 Generated with [Claude Code](https://claude.com/claude-code)
