### PR TITLE
fix(ls): derive load id from entry namespace, not hard-coded local/

### DIFF
--- a/cmd/ynh/list.go
+++ b/cmd/ynh/list.go
@@ -204,7 +204,7 @@ func printListText(w io.Writer) error {
 	for _, e := range entries {
 		// For pointer-form installs (local harnesses), load via the pointer first
 		// so provenance is included. Fall back to LoadDir for tree-form installs.
-		p, err := harness.LoadByID("local/" + e.Name)
+		p, err := harness.LoadByID(canonicalIDForEntry(e))
 		if err != nil {
 			// Not a pointer-form install; try loading as a tree-form install
 			p, err = harness.LoadDir(e.Dir)
@@ -241,7 +241,7 @@ func printListJSON(w io.Writer, checkUpdates bool) error {
 	for _, e := range all {
 		// For pointer-form installs (local harnesses), load via the pointer first
 		// so provenance is included. Fall back to LoadDir for tree-form installs.
-		p, loadErr := harness.LoadByID("local/" + e.Name)
+		p, loadErr := harness.LoadByID(canonicalIDForEntry(e))
 		if loadErr != nil {
 			// Not a pointer-form install; try loading as a tree-form install
 			p, loadErr = harness.LoadDir(e.Dir)
@@ -258,7 +258,7 @@ func printListJSON(w io.Writer, checkUpdates bool) error {
 			// so entries written by both fork generations are covered.
 			ptr, _ := harness.LoadPointer(e.Name)
 			if ptr == nil {
-				ptr, _ = harness.LoadPointerByID("local/" + e.Name)
+				ptr, _ = harness.LoadPointerByID(canonicalIDForEntry(e))
 			}
 			if ptr != nil {
 				id := namespace.CanonicalID(ptr.Source, ptr.Name)
@@ -361,6 +361,17 @@ func canonicalNamespaceForHarness(p *harness.Harness) string {
 		return ""
 	}
 	return ns
+}
+
+// canonicalIDForEntry reconstructs the canonical id for a ListAll result.
+// Pointer-form entries arrive with empty Namespace and are conventionally
+// addressed as "local/<name>" (see topology.go). Tree-form entries carry
+// their full namespace (e.g. "github.com/eyelock/assistants").
+func canonicalIDForEntry(e harness.ListEntry) string {
+	if e.Namespace == "" {
+		return "local/" + e.Name
+	}
+	return e.Namespace + "/" + e.Name
 }
 
 // buildListEntry assembles the structured-output entry for a loaded harness.

--- a/cmd/ynh/list_test.go
+++ b/cmd/ynh/list_test.go
@@ -654,3 +654,175 @@ func TestCmdListJSONOrphanPointerEmptyArrays(t *testing.T) {
 		t.Error("DelegatesTo is nil; want empty slice")
 	}
 }
+
+// writePluginTree creates a minimal schema-3 harness tree at dir with the
+// given name and installed.json provenance. Used by the fork+registry
+// regression tests below.
+func writePluginTree(t *testing.T, dir, name string, ins *plugin.InstalledJSON) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, plugin.PluginDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hj := `{"name":"` + name + `","version":"0.1.0","default_vendor":"claude"}`
+	if err := os.WriteFile(filepath.Join(dir, plugin.PluginDir, plugin.PluginFile), []byte(hj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if ins != nil {
+		if err := plugin.SaveInstalledJSON(dir, ins); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestCmdList_ForkAndRegistryWithSameLeafNameAreDistinct verifies that
+// `ynh ls --format json` emits two entries with distinct canonical ids,
+// distinct kinds, and distinct sources when a leaf name exists as both a
+// local-fork pointer and a registry/tree-form install. Regression test for
+// the list.go load shadowing bug introduced by the schema-3 read-symmetry
+// change in PR #158, where the per-row load hard-coded "local/<name>" and
+// shadowed the tree-form entry with the pointer-form harness.
+func TestCmdList_ForkAndRegistryWithSameLeafNameAreDistinct(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// Pointer-shaped local fork (local/termq-dev). Provenance carries
+	// forked_from so classifyKind returns "local-fork".
+	forkDir := filepath.Join(t.TempDir(), "termq-dev-fork")
+	writePluginTree(t, forkDir, "termq-dev", &plugin.InstalledJSON{
+		SourceType:  "local",
+		Source:      forkDir,
+		InstalledAt: "2026-05-01T00:00:00Z",
+		ForkedFrom: &plugin.ForkedFromJSON{
+			SourceType: "registry",
+			Source:     "github.com/eyelock/assistants",
+		},
+	})
+	if err := harness.SavePointer(&harness.Pointer{
+		Name: "termq-dev",
+		InstalledJSON: plugin.InstalledJSON{
+			SourceType:  "local",
+			Source:      forkDir,
+			InstalledAt: "2026-05-01T00:00:00Z",
+			ForkedFrom: &plugin.ForkedFromJSON{
+				SourceType: "registry",
+				Source:     "github.com/eyelock/assistants",
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tree-form registry install at the schema-2 path. The dir name is
+	// the id-fsname so ListAll classifies it as namespaced.
+	registryDir := filepath.Join(home, "harnesses", "github.com--eyelock--assistants--termq-dev")
+	writePluginTree(t, registryDir, "termq-dev", &plugin.InstalledJSON{
+		SourceType:  "registry",
+		Source:      "github.com/eyelock/assistants",
+		InstalledAt: "2026-05-02T00:00:00Z",
+	})
+
+	var stdout bytes.Buffer
+	if err := cmdListTo([]string{"--format", "json"}, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdListTo: %v", err)
+	}
+	var env listEnvelope
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, stdout.String())
+	}
+
+	var rows []listEntry
+	for _, e := range env.Harnesses {
+		if e.Name == "termq-dev" {
+			rows = append(rows, e)
+		}
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 termq-dev rows, got %d; output: %s", len(rows), stdout.String())
+	}
+
+	idsByKind := map[string]string{}
+	sourcesByKind := map[string]string{}
+	for _, r := range rows {
+		idsByKind[r.Kind] = r.ID
+		if r.InstalledFrom != nil {
+			sourcesByKind[r.Kind] = r.InstalledFrom.Source
+		}
+	}
+
+	if idsByKind["local-fork"] != "local/termq-dev" {
+		t.Errorf("local-fork id = %q, want local/termq-dev", idsByKind["local-fork"])
+	}
+	if idsByKind["registry"] != "github.com/eyelock/assistants/termq-dev" {
+		t.Errorf("registry id = %q, want github.com/eyelock/assistants/termq-dev", idsByKind["registry"])
+	}
+	if sourcesByKind["local-fork"] == sourcesByKind["registry"] {
+		t.Errorf("fork and registry rows share source %q; expected distinct sources", sourcesByKind["local-fork"])
+	}
+}
+
+// TestCmdList_TextFormat_ForkAndRegistry mirrors the JSON regression test
+// against the text printer. Two rows must appear with distinct KIND and
+// SOURCE columns.
+func TestCmdList_TextFormat_ForkAndRegistry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	forkDir := filepath.Join(t.TempDir(), "termq-dev-fork")
+	writePluginTree(t, forkDir, "termq-dev", &plugin.InstalledJSON{
+		SourceType:  "local",
+		Source:      forkDir,
+		InstalledAt: "2026-05-01T00:00:00Z",
+		ForkedFrom: &plugin.ForkedFromJSON{
+			SourceType: "registry",
+			Source:     "github.com/eyelock/assistants",
+		},
+	})
+	if err := harness.SavePointer(&harness.Pointer{
+		Name: "termq-dev",
+		InstalledJSON: plugin.InstalledJSON{
+			SourceType:  "local",
+			Source:      forkDir,
+			InstalledAt: "2026-05-01T00:00:00Z",
+			ForkedFrom: &plugin.ForkedFromJSON{
+				SourceType: "registry",
+				Source:     "github.com/eyelock/assistants",
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	registryDir := filepath.Join(home, "harnesses", "github.com--eyelock--assistants--termq-dev")
+	writePluginTree(t, registryDir, "termq-dev", &plugin.InstalledJSON{
+		SourceType:  "registry",
+		Source:      "github.com/eyelock/assistants",
+		InstalledAt: "2026-05-02T00:00:00Z",
+	})
+
+	var stdout bytes.Buffer
+	if err := cmdListTo(nil, &stdout, io.Discard); err != nil {
+		t.Fatalf("cmdListTo: %v", err)
+	}
+	out := stdout.String()
+
+	var termqLines []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "termq-dev") {
+			termqLines = append(termqLines, line)
+		}
+	}
+	if len(termqLines) != 2 {
+		t.Fatalf("expected 2 termq-dev rows, got %d; output:\n%s", len(termqLines), out)
+	}
+	if termqLines[0] == termqLines[1] {
+		t.Errorf("fork and registry rows render identically:\n  %s\n  %s", termqLines[0], termqLines[1])
+	}
+	sawLocalFork := strings.Contains(termqLines[0], "local-fork") || strings.Contains(termqLines[1], "local-fork")
+	sawRegistry := strings.Contains(termqLines[0], "registry") || strings.Contains(termqLines[1], "registry")
+	if !sawLocalFork {
+		t.Errorf("expected one row with KIND=local-fork; got:\n%s", out)
+	}
+	if !sawRegistry {
+		t.Errorf("expected one row with KIND=registry; got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

- `ynh ls` was loading each row via `LoadByID(\"local/\" + e.Name)`, ignoring the entry's namespace. When a leaf name existed as both a local-fork pointer and a tree-form registry install (e.g. `local/termq-dev` + `github.com/eyelock/assistants/termq-dev`), the schema-1 pointer matched for both rows and stamped fork-shaped id/kind/source onto the registry entry — the registry tree never appeared, and TermQ's Harness panel showed two identical "local-fork" rows.
- Adds `canonicalIDForEntry(harness.ListEntry)` that prefers `e.Namespace + \"/\" + e.Name` and falls back to `\"local/\" + e.Name` only when namespace is empty (pointer-form, where `local` is the topology default). Replaces the three hard-coded call sites in the text printer, JSON printer, and broken-pointer fallback.
- Regression introduced by #158 (schema-3 pointer-form read/write symmetry). `ListAll` itself was already correct — the bug was purely in the renderer.

## Test plan

- [x] `TestCmdList_ForkAndRegistryWithSameLeafNameAreDistinct` — JSON output emits two rows with distinct ids/kinds/sources
- [x] `TestCmdList_TextFormat_ForkAndRegistry` — text output emits two distinguishable rows
- [x] `make check` clean (lint, format, all tests, both binaries build)
- [x] Verified live against TermQ Harness panel — registry and local-fork rows now distinct

🤖 Generated with [Claude Code](https://claude.com/claude-code)