### PR TITLE
feat(ynh): focus, profile, hook, and mcp editing commands

### DIFF
--- a/.claude/agents/evals.md
+++ b/.claude/agents/evals.md
@@ -11,14 +11,62 @@ Evaluate ALL tutorials. This is a release gate — the verdict must be PASS befo
 
 1. Build and install the latest binaries: `make build && make install`
 2. For EVERY tutorial in `docs/tutorial/` (01 through the highest-numbered tutorial, excluding README.md):
-   - Set up an isolated environment: `export HOME=$(mktemp -d) && export YNH_HOME=""`
+   - **Isolate per tutorial** — see "Sandbox isolation" below. Failure to isolate pollutes the user's real `~/.ynh` and leaves dangling pointers; this is non-negotiable.
    - Use binaries at `/Users/david/.ynh/bin/ynh` and `/Users/david/.ynh/bin/ynd`
    - **ALL file creation and commands MUST run in `/tmp/`** — never in the repo directory. The repo has real `skills/`, `agents/`, `rules/`, `commands/` directories; creating test files there pollutes the working tree. Use `cd /tmp` or absolute `/tmp/...` paths for all tutorial commands.
    - **Use only the Bash tool** for creating files outside the repo. Do NOT use Write/Edit tools for `/tmp/` files (they trigger permission prompts).
    - Execute each step that produces verifiable output
    - Compare actual output against the expected output documented in the tutorial
    - Skip steps that require: network access (git clone from GitHub), vendor CLIs (claude, codex, cursor), or Docker
+   - **Tear down the sandbox** with `rm -rf /tmp/ynh-eval-T<N>` after the tutorial passes
 3. Run the manual test plan (`docs/tutorial/manual-test-plan.md`) error-case section (all E-numbered cases)
+
+## Sandbox isolation
+
+**Each Bash tool invocation runs in a fresh shell.** `export` statements do not survive between calls — anything you set in one Bash call is gone by the next. Relying on `export HOME=...; export YNH_HOME=...` at the top of a tutorial sequence has caused real damage: tutorial 19 installed a harness into the user's real `~/.ynh` and left a dangling pointer after cleanup, because the next Bash call no longer had the sandbox env.
+
+**Use deterministic per-tutorial sandbox paths and prefix every `ynh`/`ynd` invocation inline.** The pattern:
+
+1. **Once at tutorial start** (single Bash invocation):
+
+   ```bash
+   SANDBOX=/tmp/ynh-eval-T<N>            # e.g. T19 for tutorial 19
+   rm -rf "$SANDBOX"
+   mkdir -p "$SANDBOX/.ynh"
+   ```
+
+2. **Every subsequent Bash invocation** for that tutorial prefixes each command:
+
+   ```bash
+   HOME=/tmp/ynh-eval-T<N> YNH_HOME=/tmp/ynh-eval-T<N>/.ynh \
+       /Users/david/.ynh/bin/ynh install /tmp/ynh-tutorial/sensor-harness
+   ```
+
+   The `VAR=val cmd` form sets the variable for that invocation only — no `export`, no reliance on shell state. Works identically across every fresh Bash shell.
+
+3. **Once at tutorial end** (single Bash invocation):
+
+   ```bash
+   rm -rf /tmp/ynh-eval-T<N>
+   ```
+
+**Verify isolation after each tutorial.** Before tearing down, run:
+
+```bash
+ls /tmp/ynh-eval-T<N>/.ynh/harnesses 2>/dev/null
+ls /tmp/ynh-eval-T<N>/.ynh/installed 2>/dev/null
+```
+
+If a tutorial used `ynh install`, the installed entry must appear in the sandbox. If the sandbox is empty AND the tutorial called `ynh install`, isolation failed — the install landed in the real `~/.ynh`. Stop and report; do not continue evaluating other tutorials in that state.
+
+**Anti-pattern — do NOT do this:**
+
+```bash
+# WRONG: export does not survive to the next Bash invocation
+export HOME=$(mktemp -d)
+export YNH_HOME=""
+ynh install /tmp/ynh-tutorial/sensor-harness   # ← real ~/.ynh gets polluted
+```
 
 ## What is locally testable (do NOT skip these)
 

--- a/cmd/ynd/compose.go
+++ b/cmd/ynd/compose.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -15,19 +16,19 @@ import (
 
 // composeOutput is the top-level JSON shape for `ynd compose`.
 type composeOutput struct {
-	Name          string                   `json:"name"`
-	Version       string                   `json:"version"`
-	Description   string                   `json:"description,omitempty"`
-	DefaultVendor string                   `json:"default_vendor"`
-	Artifacts     composeArtifacts         `json:"artifacts"`
-	Includes      []composeInclude         `json:"includes"`
-	DelegatesTo   []composeDelegate        `json:"delegates_to"`
-	Hooks         map[string][]composeHook `json:"hooks,omitempty"`
-	MCPServers    map[string]composeMCP    `json:"mcp_servers,omitempty"`
-	Profiles      []string                 `json:"profiles"`
-	Focuses       map[string]composeFocus  `json:"focuses,omitempty"`
-	Sensors       map[string]composeSensor `json:"sensors,omitempty"`
-	Counts        composeCounts            `json:"counts"`
+	Name          string                    `json:"name"`
+	Version       string                    `json:"version"`
+	Description   string                    `json:"description,omitempty"`
+	DefaultVendor string                    `json:"default_vendor"`
+	Artifacts     composeArtifacts          `json:"artifacts"`
+	Includes      []composeInclude          `json:"includes"`
+	DelegatesTo   []composeDelegate         `json:"delegates_to"`
+	Hooks         map[string][]composeHook  `json:"hooks,omitempty"`
+	MCPServers    map[string]composeMCP     `json:"mcp_servers,omitempty"`
+	Profiles      map[string]composeProfile `json:"profiles"`
+	Focuses       map[string]composeFocus   `json:"focuses,omitempty"`
+	Sensors       map[string]composeSensor  `json:"sensors,omitempty"`
+	Counts        composeCounts             `json:"counts"`
 }
 
 type composeSensor struct {
@@ -94,6 +95,12 @@ type composeMCP struct {
 	Env     map[string]string `json:"env,omitempty"`
 	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type composeProfile struct {
+	Hooks      map[string][]composeHook `json:"hooks,omitempty"`
+	MCPServers map[string]*composeMCP   `json:"mcp_servers,omitempty"`
+	Includes   []composeInclude         `json:"includes,omitempty"`
 }
 
 type composeFocus struct {
@@ -368,10 +375,47 @@ func buildComposeOutput(h *harness.Harness, srcDir string, resolved []resolver.R
 		out.MCPServers = servers
 	}
 
-	// Profiles — just names
-	profiles := make([]string, 0, len(h.Profiles))
-	for name := range h.Profiles {
-		profiles = append(profiles, name)
+	// Profiles — full content so consumers can render/diff without re-parsing
+	// the underlying manifest. Always emit a non-nil map so JSON consumers see
+	// an object (possibly empty) rather than null.
+	profiles := make(map[string]composeProfile, len(h.Profiles))
+	for name, p := range h.Profiles {
+		cp := composeProfile{}
+		if len(p.Hooks) > 0 {
+			cp.Hooks = make(map[string][]composeHook, len(p.Hooks))
+			for event, entries := range p.Hooks {
+				ch := make([]composeHook, len(entries))
+				for i, e := range entries {
+					ch[i] = composeHook{Command: e.Command, Matcher: e.Matcher}
+				}
+				cp.Hooks[event] = ch
+			}
+		}
+		if len(p.MCPServers) > 0 {
+			cp.MCPServers = make(map[string]*composeMCP, len(p.MCPServers))
+			for sName, srv := range p.MCPServers {
+				if srv == nil {
+					cp.MCPServers[sName] = nil
+					continue
+				}
+				cp.MCPServers[sName] = &composeMCP{
+					Command: srv.Command,
+					Args:    srv.Args,
+					Env:     srv.Env,
+					URL:     srv.URL,
+					Headers: srv.Headers,
+				}
+			}
+		}
+		for _, inc := range p.Includes {
+			cp.Includes = append(cp.Includes, composeInclude{
+				Git:  inc.Git,
+				Ref:  inc.Ref,
+				Path: inc.Path,
+				Pick: inc.Pick,
+			})
+		}
+		profiles[name] = cp
 	}
 	out.Profiles = profiles
 
@@ -523,7 +567,12 @@ func printComposeText(w io.Writer, out composeOutput) error {
 	}
 
 	if len(out.Profiles) > 0 {
-		_, _ = fmt.Fprintf(w, "\nProfiles: %s\n", strings.Join(out.Profiles, ", "))
+		names := make([]string, 0, len(out.Profiles))
+		for name := range out.Profiles {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		_, _ = fmt.Fprintf(w, "\nProfiles: %s\n", strings.Join(names, ", "))
 	}
 
 	if len(out.Focuses) > 0 {

--- a/cmd/ynd/compose_test.go
+++ b/cmd/ynd/compose_test.go
@@ -168,8 +168,11 @@ func TestCmdComposeJSONBasic(t *testing.T) {
 	}
 
 	// Profiles
-	if len(got.Profiles) != 1 || got.Profiles[0] != "staging" {
-		t.Errorf("profiles = %v, want [staging]", got.Profiles)
+	if len(got.Profiles) != 1 {
+		t.Errorf("profiles = %v, want 1 entry", got.Profiles)
+	}
+	if _, ok := got.Profiles["staging"]; !ok {
+		t.Errorf("profiles missing staging key, got %v", got.Profiles)
 	}
 
 	// Focuses
@@ -225,9 +228,9 @@ func TestCmdComposeJSONEmptyArrays(t *testing.T) {
 	if !strings.Contains(out, `"delegates_to": []`) {
 		t.Errorf("expected delegates_to: [], got: %s", out)
 	}
-	// Profiles should be []
-	if !strings.Contains(out, `"profiles": []`) {
-		t.Errorf("expected profiles: [], got: %s", out)
+	// Profiles should be {} (empty object, not null)
+	if !strings.Contains(out, `"profiles": {}`) {
+		t.Errorf("expected profiles: {}, got: %s", out)
 	}
 }
 

--- a/cmd/ynd/export.go
+++ b/cmd/ynd/export.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/exporter"
+	"github.com/eyelock/ynh/internal/harness"
 	"github.com/eyelock/ynh/internal/migration"
+	"github.com/eyelock/ynh/internal/namespace"
 	"github.com/eyelock/ynh/internal/plugin"
 	"github.com/eyelock/ynh/internal/resolver"
 	"github.com/eyelock/ynh/internal/vendor"
@@ -211,8 +213,13 @@ func cmdExport(args []string) error {
 	return nil
 }
 
-// resolveSource determines if source is a local path or Git URL and returns
-// the local directory path. For Git URLs, it resolves via the shared cache.
+// resolveSource determines whether source is a local path, an installed
+// harness canonical id, or a Git URL, and returns the local directory
+// path. Canonical ids (e.g. "local/<name>" or "github.com/<org>/<repo>/<name>")
+// are resolved against the user's installed harnesses via harness.LoadByID,
+// so consumers driving ynd off `ynh ls --format json` ids work without
+// converting them back to filesystem paths. Bare names and other invalid
+// ref shapes fall through to the Git-URL path, preserving prior behaviour.
 func resolveSource(source string) (string, error) {
 	// Local path
 	if strings.HasPrefix(source, ".") || strings.HasPrefix(source, "/") {
@@ -233,6 +240,19 @@ func resolveSource(source string) (string, error) {
 			return "", err
 		}
 		return abs, nil
+	}
+
+	// Installed harness id (canonical ref). When the input lexically looks
+	// like a canonical id, try the installed-harness lookup first so
+	// commands like `ynd compose local/foo` resolve to the on-disk install
+	// instead of attempting a git clone. We only attempt this when the
+	// lookup succeeds; on miss we fall through to the git-URL path, since
+	// a canonical-shaped string that isn't installed is still a valid
+	// upstream reference to clone (e.g. github.com/org/repo/sub).
+	if namespace.Classify(source) == namespace.RefID {
+		if p, err := harness.LoadByID(source); err == nil {
+			return p.Dir, nil
+		}
 	}
 
 	// Git URL — resolve via cache

--- a/cmd/ynd/resolve_source_test.go
+++ b/cmd/ynd/resolve_source_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// writeMinimalHarness creates a directory with a plugin.json so harness.LoadByID
+// can resolve it via the pointer's source path.
+func writeMinimalHarness(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hj := &plugin.HarnessJSON{Name: name, Version: "0.1.0"}
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestResolveSource_CanonicalIDResolvesToInstalledPointer verifies that
+// a canonical id like "local/<name>" returned by `ynh ls` resolves to the
+// installed harness directory rather than being treated as a Git URL.
+// Regression test for TermQ's `ynd compose <harness-id>` flow.
+func TestResolveSource_CanonicalIDResolvesToInstalledPointer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	sourceDir := filepath.Join(t.TempDir(), "my-fork")
+	writeMinimalHarness(t, sourceDir, "my-fork")
+
+	ptr := &harness.Pointer{
+		ID:   "local/my-fork",
+		Name: "my-fork",
+		InstalledJSON: plugin.InstalledJSON{
+			SourceType:  "local",
+			Source:      sourceDir,
+			InstalledAt: "2026-01-01T00:00:00Z",
+		},
+	}
+	if err := harness.SavePointerByID(ptr); err != nil {
+		t.Fatalf("save pointer: %v", err)
+	}
+
+	got, err := resolveSource("local/my-fork")
+	if err != nil {
+		t.Fatalf("resolveSource: %v", err)
+	}
+	if got != sourceDir {
+		t.Errorf("resolveSource resolved to %q, want %q", got, sourceDir)
+	}
+}
+
+// TestResolveSource_CanonicalIDFallsThroughWhenNotInstalled verifies the
+// fall-through semantics: a canonical-shaped string that isn't an
+// installed harness is still passed to the Git-URL resolver, since users
+// may reference upstream repos by canonical form.
+func TestResolveSource_CanonicalIDFallsThroughWhenNotInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	// No pointer installed for this id. The Git resolver will reject it
+	// (no real network in tests), so we expect an error — but specifically
+	// NOT a "harness not found" error, which would indicate the lookup
+	// short-circuited rather than falling through.
+	_, err := resolveSource("github.com/nonexistent/repo/sub")
+	if err == nil {
+		t.Fatal("expected resolveSource to fail on unresolvable id, got nil")
+	}
+	// The error should come from the Git resolver (EnsureRepo), not from
+	// the harness lookup. Verify by checking the error wraps "resolving".
+	if got := err.Error(); !contains(got, "resolving") {
+		t.Errorf("expected git-resolver error, got: %v", err)
+	}
+}
+
+// TestResolveSource_LocalPathTakesPrecedence verifies that a leading
+// "./" or "/" still gets treated as a filesystem path even if its name
+// happens to match an installed harness id (defensive ordering check).
+func TestResolveSource_LocalPathTakesPrecedence(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	dir := filepath.Join(t.TempDir(), "explicit-path")
+	writeMinimalHarness(t, dir, "anything")
+
+	got, err := resolveSource(dir)
+	if err != nil {
+		t.Fatalf("resolveSource: %v", err)
+	}
+	if got != dir {
+		t.Errorf("expected explicit path to resolve as-is, got %q", got)
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/ynh/focus.go
+++ b/cmd/ynh/focus.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/eyelock/ynh/internal/harness"
+)
+
+func cmdFocus(args []string) error {
+	return cmdFocusTo(args, os.Stdout)
+}
+
+func cmdFocusTo(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: ynh focus <add|remove|update>")
+	}
+	switch args[0] {
+	case "add":
+		return cmdFocusAdd(args[1:], stdout)
+	case "remove":
+		return cmdFocusRemove(args[1:], stdout)
+	case "update":
+		return cmdFocusUpdate(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown focus subcommand: %s\nUsage: ynh focus <add|remove|update>", args[0])
+	}
+}
+
+func cmdFocusAdd(args []string, stdout io.Writer) error {
+	var opts harness.FocusAddOptions
+	var positional []string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--profile":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--profile requires a value")
+			}
+			i++
+			opts.Profile = args[i]
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+
+	if len(positional) != 3 {
+		return fmt.Errorf("usage: ynh focus add <harness> <name> <prompt> [--profile <name>]")
+	}
+
+	harnessRef, name, prompt := positional[0], positional[1], positional[2]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+
+	if err := harness.AddFocus(dir, name, prompt, opts); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(stdout, "Added focus %q\n", name)
+	return nil
+}
+
+func cmdFocusRemove(args []string, stdout io.Writer) error {
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		if strings.HasPrefix(args[i], "-") {
+			return fmt.Errorf("unknown flag: %s", args[i])
+		}
+		positional = append(positional, args[i])
+	}
+
+	if len(positional) != 2 {
+		return fmt.Errorf("usage: ynh focus remove <harness> <name>")
+	}
+
+	harnessRef, name := positional[0], positional[1]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+
+	if err := harness.RemoveFocus(dir, name); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(stdout, "Removed focus %q\n", name)
+	return nil
+}
+
+func cmdFocusUpdate(args []string, stdout io.Writer) error {
+	var opts harness.FocusUpdateOptions
+	var positional []string
+	var clearProfile bool
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--prompt":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--prompt requires a value")
+			}
+			i++
+			v := args[i]
+			opts.Prompt = &v
+		case "--profile":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--profile requires a value")
+			}
+			i++
+			v := args[i]
+			opts.Profile = &v
+		case "--clear-profile":
+			clearProfile = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+
+	if clearProfile {
+		if opts.Profile != nil {
+			return fmt.Errorf("--profile and --clear-profile are mutually exclusive")
+		}
+		empty := ""
+		opts.Profile = &empty
+	}
+
+	if len(positional) != 2 {
+		return fmt.Errorf("usage: ynh focus update <harness> <name> [--prompt <text>] [--profile <name>] [--clear-profile]")
+	}
+
+	if opts.Prompt == nil && opts.Profile == nil {
+		return fmt.Errorf("ynh focus update: at least one of --prompt, --profile, or --clear-profile must be specified")
+	}
+
+	harnessRef, name := positional[0], positional[1]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+
+	if err := harness.UpdateFocus(dir, name, opts); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(stdout, "Updated focus %q\n", name)
+	return nil
+}

--- a/cmd/ynh/focus_test.go
+++ b/cmd/ynh/focus_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+func writeFocusTestHarness(t *testing.T, dir, name string) {
+	t.Helper()
+	hj := &plugin.HarnessJSON{Name: name, Version: "0.1.0"}
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func loadTestFocuses(t *testing.T, dir string) map[string]plugin.Focus {
+	t.Helper()
+	hj, err := plugin.LoadPluginJSON(dir)
+	if err != nil {
+		t.Fatalf("LoadPluginJSON: %v", err)
+	}
+	return hj.Focuses
+}
+
+func TestCmdFocus_NoArgs(t *testing.T) {
+	err := cmdFocus([]string{})
+	if err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
+func TestCmdFocus_UnknownSubcommand(t *testing.T) {
+	err := cmdFocus([]string{"bogus"})
+	if err == nil || !strings.Contains(err.Error(), "unknown focus subcommand") {
+		t.Errorf("expected unknown subcommand error, got: %v", err)
+	}
+}
+
+func TestCmdFocusAdd_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeFocusTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdFocusTo([]string{"add", dir, "review", "review this code"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestFocuses(t, dir)
+	f, ok := got["review"]
+	if !ok || f.Prompt != "review this code" {
+		t.Errorf("expected focus review with prompt, got %+v", got)
+	}
+	if !strings.Contains(buf.String(), "Added focus") {
+		t.Errorf("expected confirmation, got: %q", buf.String())
+	}
+}
+
+func TestCmdFocusAdd_WithProfile(t *testing.T) {
+	dir := t.TempDir()
+	hj := &plugin.HarnessJSON{
+		Name: "h", Version: "0.1.0",
+		Profiles: map[string]plugin.Profile{"thorough": {}},
+	}
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := cmdFocusTo([]string{"add", dir, "deep", "audit this", "--profile", "thorough"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestFocuses(t, dir)
+	if f := got["deep"]; f.Profile != "thorough" {
+		t.Errorf("expected profile thorough, got %+v", f)
+	}
+}
+
+func TestCmdFocusAdd_UnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeFocusTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdFocusTo([]string{"add", dir, "deep", "audit", "--profile", "nope"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "unknown profile") {
+		t.Errorf("expected unknown profile error, got: %v", err)
+	}
+}
+
+func TestCmdFocusAdd_Duplicate(t *testing.T) {
+	dir := t.TempDir()
+	writeFocusTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdFocusTo([]string{"add", dir, "f", "p"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	err := cmdFocusTo([]string{"add", dir, "f", "p2"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected already-exists error, got: %v", err)
+	}
+}
+
+func TestCmdFocusAdd_EmptyPrompt(t *testing.T) {
+	dir := t.TempDir()
+	writeFocusTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdFocusTo([]string{"add", dir, "f", ""}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "prompt must not be empty") {
+		t.Errorf("expected empty-prompt error, got: %v", err)
+	}
+}
+
+func TestCmdFocusRemove_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeFocusTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdFocusTo([]string{"add", dir, "f", "p"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	if err := cmdFocusTo([]string{"remove", dir, "f"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(loadTestFocuses(t, dir)) != 0 {
+		t.Errorf("expected no focuses after remove")
+	}
+}
+
+func TestCmdFocusRemove_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeFocusTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdFocusTo([]string{"remove", dir, "f"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error, got: %v", err)
+	}
+}
+
+func TestCmdFocusUpdate_Prompt(t *testing.T) {
+	dir := t.TempDir()
+	writeFocusTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdFocusTo([]string{"add", dir, "f", "old"}, &buf)
+	buf.Reset()
+
+	if err := cmdFocusTo([]string{"update", dir, "f", "--prompt", "new"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestFocuses(t, dir)
+	if got["f"].Prompt != "new" {
+		t.Errorf("expected new prompt, got %+v", got["f"])
+	}
+}
+
+func TestCmdFocusUpdate_ClearProfile(t *testing.T) {
+	dir := t.TempDir()
+	hj := &plugin.HarnessJSON{
+		Name: "h", Version: "0.1.0",
+		Profiles: map[string]plugin.Profile{"x": {}},
+		Focuses:  map[string]plugin.Focus{"f": {Profile: "x", Prompt: "p"}},
+	}
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := cmdFocusTo([]string{"update", dir, "f", "--clear-profile"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestFocuses(t, dir)
+	if got["f"].Profile != "" {
+		t.Errorf("expected profile cleared, got %q", got["f"].Profile)
+	}
+}
+
+func TestCmdFocusUpdate_ProfileAndClearMutex(t *testing.T) {
+	dir := t.TempDir()
+	writeFocusTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdFocusTo([]string{"add", dir, "f", "p"}, &buf)
+
+	err := cmdFocusTo([]string{"update", dir, "f", "--profile", "x", "--clear-profile"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected mutually-exclusive error, got: %v", err)
+	}
+}
+
+func TestCmdFocusUpdate_NoFlags(t *testing.T) {
+	dir := t.TempDir()
+	writeFocusTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdFocusTo([]string{"add", dir, "f", "p"}, &buf)
+
+	err := cmdFocusTo([]string{"update", dir, "f"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "at least one of") {
+		t.Errorf("expected required-flag error, got: %v", err)
+	}
+}

--- a/cmd/ynh/hook.go
+++ b/cmd/ynh/hook.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/eyelock/ynh/internal/harness"
+)
+
+func cmdHook(args []string) error {
+	return cmdHookTo(args, os.Stdout)
+}
+
+func cmdHookTo(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: ynh hook <add|remove>")
+	}
+	switch args[0] {
+	case "add":
+		return cmdHookAdd(args[1:], stdout)
+	case "remove":
+		return cmdHookRemove(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown hook subcommand: %s\nUsage: ynh hook <add|remove>", args[0])
+	}
+}
+
+func cmdHookAdd(args []string, stdout io.Writer) error {
+	var opts harness.HookAddOptions
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--matcher":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--matcher requires a value")
+			}
+			i++
+			opts.Matcher = args[i]
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+	if len(positional) != 3 {
+		return fmt.Errorf("usage: ynh hook add <harness> <event> <command> [--matcher <pattern>]")
+	}
+	harnessRef, event, command := positional[0], positional[1], positional[2]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+	if err := harness.AddHook(dir, event, command, opts); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Added hook (event %s)\n", event)
+	return nil
+}
+
+func cmdHookRemove(args []string, stdout io.Writer) error {
+	var positional []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			return fmt.Errorf("unknown flag: %s", a)
+		}
+		positional = append(positional, a)
+	}
+	if len(positional) != 3 {
+		return fmt.Errorf("usage: ynh hook remove <harness> <event> <index>")
+	}
+	harnessRef, event, idxStr := positional[0], positional[1], positional[2]
+	index, err := strconv.Atoi(idxStr)
+	if err != nil {
+		return fmt.Errorf("hook index must be an integer: %s", idxStr)
+	}
+
+	dir, _, rErr := harness.ResolveEditTarget(harnessRef)
+	if rErr != nil {
+		return rErr
+	}
+	if err := harness.RemoveHook(dir, event, index); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Removed hook %d (event %s)\n", index, event)
+	return nil
+}

--- a/cmd/ynh/hook_test.go
+++ b/cmd/ynh/hook_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+func writeHookTestHarness(t *testing.T, dir, name string) {
+	t.Helper()
+	hj := &plugin.HarnessJSON{Name: name, Version: "0.1.0"}
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func loadTestHarness(t *testing.T, dir string) *plugin.HarnessJSON {
+	t.Helper()
+	hj, err := plugin.LoadPluginJSON(dir)
+	if err != nil {
+		t.Fatalf("LoadPluginJSON: %v", err)
+	}
+	return hj
+}
+
+func TestCmdHook_NoArgs(t *testing.T) {
+	err := cmdHook([]string{})
+	if err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
+func TestCmdHook_UnknownSubcommand(t *testing.T) {
+	err := cmdHook([]string{"bogus"})
+	if err == nil || !strings.Contains(err.Error(), "unknown hook subcommand") {
+		t.Errorf("expected unknown subcommand error, got: %v", err)
+	}
+}
+
+func TestCmdHookAdd_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeHookTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdHookTo([]string{"add", dir, "before_tool", "echo go"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hj := loadTestHarness(t, dir)
+	entries := hj.Hooks["before_tool"]
+	if len(entries) != 1 || entries[0].Command != "echo go" {
+		t.Errorf("expected one hook, got %+v", entries)
+	}
+}
+
+func TestCmdHookAdd_WithMatcher(t *testing.T) {
+	dir := t.TempDir()
+	writeHookTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdHookTo([]string{"add", dir, "before_tool", "echo x", "--matcher", "Write"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hj := loadTestHarness(t, dir)
+	if hj.Hooks["before_tool"][0].Matcher != "Write" {
+		t.Errorf("expected matcher=Write, got %+v", hj.Hooks["before_tool"][0])
+	}
+}
+
+func TestCmdHookAdd_UnknownEvent(t *testing.T) {
+	dir := t.TempDir()
+	writeHookTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdHookTo([]string{"add", dir, "bogus", "cmd"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "unknown hook event") {
+		t.Errorf("expected unknown-event error, got: %v", err)
+	}
+}
+
+func TestCmdHookRemove_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeHookTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdHookTo([]string{"add", dir, "before_tool", "a"}, &buf)
+	_ = cmdHookTo([]string{"add", dir, "before_tool", "b"}, &buf)
+
+	if err := cmdHookTo([]string{"remove", dir, "before_tool", "0"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hj := loadTestHarness(t, dir)
+	entries := hj.Hooks["before_tool"]
+	if len(entries) != 1 || entries[0].Command != "b" {
+		t.Errorf("expected single remaining entry 'b', got %+v", entries)
+	}
+}
+
+func TestCmdHookRemove_LastEntryDropsKey(t *testing.T) {
+	dir := t.TempDir()
+	writeHookTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdHookTo([]string{"add", dir, "before_tool", "a"}, &buf)
+
+	if err := cmdHookTo([]string{"remove", dir, "before_tool", "0"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hj := loadTestHarness(t, dir)
+	if _, ok := hj.Hooks["before_tool"]; ok {
+		t.Errorf("expected event key removed when empty")
+	}
+}
+
+func TestCmdHookRemove_OutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	writeHookTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdHookTo([]string{"add", dir, "before_tool", "a"}, &buf)
+
+	err := cmdHookTo([]string{"remove", dir, "before_tool", "5"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("expected out-of-range error, got: %v", err)
+	}
+}
+
+func TestCmdHookRemove_NonInteger(t *testing.T) {
+	dir := t.TempDir()
+	writeHookTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdHookTo([]string{"remove", dir, "before_tool", "not-int"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "must be an integer") {
+		t.Errorf("expected integer error, got: %v", err)
+	}
+}

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -79,6 +79,10 @@ func main() {
 		err = cmdFork(os.Args[2:])
 	case "include":
 		err = cmdInclude(os.Args[2:])
+	case "focus":
+		err = cmdFocus(os.Args[2:])
+	case "profile":
+		err = cmdProfile(os.Args[2:])
 	case "sensors":
 		err = cmdSensors(os.Args[2:])
 	case "agent":
@@ -139,6 +143,19 @@ Commands:
   include add <harness> <url>  Add a Git include to a harness
   include remove <harness> <url>  Remove a Git include from a harness
   include update <harness> <url>  Update a Git include's options
+  focus add <harness> <name> <prompt> [--profile <name>]   Add a named focus
+  focus remove <harness> <name>                             Remove a named focus
+  focus update <harness> <name> [--prompt] [--profile] [--clear-profile]  Update a focus
+  profile add <harness> <name>                              Add a named profile
+  profile remove <harness> <name>                           Remove a named profile
+  profile hook add <harness> <profile> <event> <command>    Add a hook to a profile
+  profile hook remove <harness> <profile> <event> <index>   Remove a profile hook by index
+  profile mcp add <harness> <profile> <name> [flags]        Add an MCP server to a profile
+  profile mcp remove <harness> <profile> <name>             Remove a profile MCP server
+  profile mcp update <harness> <profile> <name> [flags]     Update a profile MCP server
+  profile include add <harness> <profile> <url> [flags]     Add a Git include to a profile
+  profile include remove <harness> <profile> <url>          Remove a profile include
+  profile include update <harness> <profile> <url> [flags]  Update a profile include
   sensors ls <harness>         List declared sensors (supports --format json)
   sensors show <harness> <name>  Resolve a sensor declaration (supports --format text|json)
   sensors run <harness> <name>   Run a sensor and emit a JSON result (loop drivers consume this)

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -83,6 +83,10 @@ func main() {
 		err = cmdFocus(os.Args[2:])
 	case "profile":
 		err = cmdProfile(os.Args[2:])
+	case "hook":
+		err = cmdHook(os.Args[2:])
+	case "mcp":
+		err = cmdMCP(os.Args[2:])
 	case "sensors":
 		err = cmdSensors(os.Args[2:])
 	case "agent":
@@ -156,6 +160,11 @@ Commands:
   profile include add <harness> <profile> <url> [flags]     Add a Git include to a profile
   profile include remove <harness> <profile> <url>          Remove a profile include
   profile include update <harness> <profile> <url> [flags]  Update a profile include
+  hook add <harness> <event> <command> [--matcher <pattern>] Add a top-level hook
+  hook remove <harness> <event> <index>                     Remove a top-level hook by index
+  mcp add <harness> <name> [flags]                          Add a top-level MCP server
+  mcp remove <harness> <name>                               Remove a top-level MCP server
+  mcp update <harness> <name> [flags]                       Update a top-level MCP server
   sensors ls <harness>         List declared sensors (supports --format json)
   sensors show <harness> <name>  Resolve a sensor declaration (supports --format text|json)
   sensors run <harness> <name>   Run a sensor and emit a JSON result (loop drivers consume this)

--- a/cmd/ynh/mcp.go
+++ b/cmd/ynh/mcp.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/eyelock/ynh/internal/harness"
+)
+
+func cmdMCP(args []string) error {
+	return cmdMCPTo(args, os.Stdout)
+}
+
+func cmdMCPTo(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: ynh mcp <add|remove|update>")
+	}
+	switch args[0] {
+	case "add":
+		return cmdMCPAdd(args[1:], stdout)
+	case "remove":
+		return cmdMCPRemove(args[1:], stdout)
+	case "update":
+		return cmdMCPUpdate(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown mcp subcommand: %s\nUsage: ynh mcp <add|remove|update>", args[0])
+	}
+}
+
+func cmdMCPAdd(args []string, stdout io.Writer) error {
+	var opts harness.MCPAddOptions
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--command":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--command requires a value")
+			}
+			i++
+			opts.Command = args[i]
+		case "--arg":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--arg requires a value")
+			}
+			i++
+			opts.Args = append(opts.Args, args[i])
+		case "--env":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--env requires a value")
+			}
+			i++
+			k, v, err := parseKV(args[i])
+			if err != nil {
+				return fmt.Errorf("--env: %w", err)
+			}
+			if opts.Env == nil {
+				opts.Env = make(map[string]string)
+			}
+			opts.Env[k] = v
+		case "--url":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--url requires a value")
+			}
+			i++
+			opts.URL = args[i]
+		case "--header":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--header requires a value")
+			}
+			i++
+			k, v, err := parseKV(args[i])
+			if err != nil {
+				return fmt.Errorf("--header: %w", err)
+			}
+			if opts.Headers == nil {
+				opts.Headers = make(map[string]string)
+			}
+			opts.Headers[k] = v
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+	if len(positional) != 2 {
+		return fmt.Errorf("usage: ynh mcp add <harness> <name> [--command <cmd> | --url <url>] [--arg <v>...] [--env K=V...] [--header K=V...]")
+	}
+	harnessRef, serverName := positional[0], positional[1]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+	if err := harness.AddMCP(dir, serverName, opts); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Added mcp server %q\n", serverName)
+	return nil
+}
+
+func cmdMCPRemove(args []string, stdout io.Writer) error {
+	var positional []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			return fmt.Errorf("unknown flag: %s", a)
+		}
+		positional = append(positional, a)
+	}
+	if len(positional) != 2 {
+		return fmt.Errorf("usage: ynh mcp remove <harness> <name>")
+	}
+	harnessRef, serverName := positional[0], positional[1]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+	if err := harness.RemoveMCP(dir, serverName); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Removed mcp server %q\n", serverName)
+	return nil
+}
+
+func cmdMCPUpdate(args []string, stdout io.Writer) error {
+	var opts harness.MCPUpdateOptions
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--command":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--command requires a value")
+			}
+			i++
+			v := args[i]
+			opts.Command = &v
+		case "--arg":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--arg requires a value")
+			}
+			i++
+			opts.Args = append(opts.Args, args[i])
+			opts.SetArgs = true
+		case "--clear-args":
+			opts.SetArgs = true
+		case "--env":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--env requires a value")
+			}
+			i++
+			k, v, err := parseKV(args[i])
+			if err != nil {
+				return fmt.Errorf("--env: %w", err)
+			}
+			if opts.Env == nil {
+				opts.Env = make(map[string]string)
+			}
+			opts.Env[k] = v
+			opts.SetEnv = true
+		case "--clear-env":
+			opts.SetEnv = true
+		case "--url":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--url requires a value")
+			}
+			i++
+			v := args[i]
+			opts.URL = &v
+		case "--header":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--header requires a value")
+			}
+			i++
+			k, v, err := parseKV(args[i])
+			if err != nil {
+				return fmt.Errorf("--header: %w", err)
+			}
+			if opts.Headers == nil {
+				opts.Headers = make(map[string]string)
+			}
+			opts.Headers[k] = v
+			opts.SetHeaders = true
+		case "--clear-headers":
+			opts.SetHeaders = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+	if len(positional) != 2 {
+		return fmt.Errorf("usage: ynh mcp update <harness> <name> [--command <cmd>] [--url <url>] [--arg <v>...] [--env K=V...] [--header K=V...] [--clear-args|--clear-env|--clear-headers]")
+	}
+	harnessRef, serverName := positional[0], positional[1]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+	if err := harness.UpdateMCP(dir, serverName, opts); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Updated mcp server %q\n", serverName)
+	return nil
+}

--- a/cmd/ynh/mcp_test.go
+++ b/cmd/ynh/mcp_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+func writeMCPTestHarness(t *testing.T, dir, name string) {
+	t.Helper()
+	hj := &plugin.HarnessJSON{Name: name, Version: "0.1.0"}
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func loadTestMCPServers(t *testing.T, dir string) map[string]plugin.MCPServer {
+	t.Helper()
+	hj, err := plugin.LoadPluginJSON(dir)
+	if err != nil {
+		t.Fatalf("LoadPluginJSON: %v", err)
+	}
+	return hj.MCPServers
+}
+
+func TestCmdMCP_NoArgs(t *testing.T) {
+	err := cmdMCP([]string{})
+	if err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
+func TestCmdMCP_UnknownSubcommand(t *testing.T) {
+	err := cmdMCP([]string{"bogus"})
+	if err == nil || !strings.Contains(err.Error(), "unknown mcp subcommand") {
+		t.Errorf("expected unknown subcommand error, got: %v", err)
+	}
+}
+
+func TestCmdMCPAdd_Command(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdMCPTo([]string{
+		"add", dir, "github",
+		"--command", "gh", "--arg", "mcp", "--env", "TOK=abc",
+	}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	srvs := loadTestMCPServers(t, dir)
+	srv, ok := srvs["github"]
+	if !ok || srv.Command != "gh" || len(srv.Args) != 1 || srv.Env["TOK"] != "abc" {
+		t.Errorf("expected gh mcp server, got %+v", srv)
+	}
+}
+
+func TestCmdMCPAdd_URL(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdMCPTo([]string{
+		"add", dir, "api",
+		"--url", "https://example.com", "--header", "Authorization=Bearer xyz",
+	}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	srv := loadTestMCPServers(t, dir)["api"]
+	if srv.URL != "https://example.com" || srv.Headers["Authorization"] != "Bearer xyz" {
+		t.Errorf("expected url-based server, got %+v", srv)
+	}
+}
+
+func TestCmdMCPAdd_BothCommandAndURL(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdMCPTo([]string{
+		"add", dir, "x", "--command", "c", "--url", "u",
+	}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "cannot have both") {
+		t.Errorf("expected both-error, got: %v", err)
+	}
+}
+
+func TestCmdMCPAdd_Neither(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdMCPTo([]string{"add", dir, "x"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "requires --command or --url") {
+		t.Errorf("expected requires-flag error, got: %v", err)
+	}
+}
+
+func TestCmdMCPAdd_NoNullSupport(t *testing.T) {
+	// Harness-level entries can't be null — there's no inheritance source
+	// to suppress. Verify --null is rejected as an unknown flag.
+	dir := t.TempDir()
+	writeMCPTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdMCPTo([]string{"add", dir, "x", "--null"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("expected unknown-flag error for --null, got: %v", err)
+	}
+}
+
+func TestCmdMCPAdd_Duplicate(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdMCPTo([]string{"add", dir, "x", "--command", "c"}, &buf)
+	err := cmdMCPTo([]string{"add", dir, "x", "--command", "c2"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "already present") {
+		t.Errorf("expected duplicate error, got: %v", err)
+	}
+}
+
+func TestCmdMCPRemove_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdMCPTo([]string{"add", dir, "x", "--command", "c"}, &buf)
+
+	if err := cmdMCPTo([]string{"remove", dir, "x"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := loadTestMCPServers(t, dir)["x"]; ok {
+		t.Errorf("expected server removed")
+	}
+}
+
+func TestCmdMCPRemove_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdMCPTo([]string{"remove", dir, "x"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error, got: %v", err)
+	}
+}
+
+func TestCmdMCPUpdate_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdMCPTo([]string{"add", dir, "x", "--command", "old"}, &buf)
+
+	if err := cmdMCPTo([]string{"update", dir, "x", "--command", "new"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if loadTestMCPServers(t, dir)["x"].Command != "new" {
+		t.Errorf("expected command=new, got %+v", loadTestMCPServers(t, dir)["x"])
+	}
+}
+
+func TestCmdMCPUpdate_NoFlags(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdMCPTo([]string{"add", dir, "x", "--command", "c"}, &buf)
+
+	err := cmdMCPTo([]string{"update", dir, "x"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "at least one") {
+		t.Errorf("expected at-least-one error, got: %v", err)
+	}
+}
+
+func TestCmdMCPUpdate_SwitchCommandToURL(t *testing.T) {
+	// command → url switch requires clearing command and setting url, but
+	// since update applies pointer fields, --command "" + --url x should
+	// produce a valid url-only server.
+	dir := t.TempDir()
+	writeMCPTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdMCPTo([]string{"add", dir, "x", "--command", "c"}, &buf)
+
+	if err := cmdMCPTo([]string{
+		"update", dir, "x", "--command", "", "--url", "https://example",
+	}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	srv := loadTestMCPServers(t, dir)["x"]
+	if srv.Command != "" || srv.URL != "https://example" {
+		t.Errorf("expected url-only after switch, got %+v", srv)
+	}
+}
+
+func TestCmdMCPUpdate_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeMCPTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	err := cmdMCPTo([]string{"update", dir, "x", "--command", "c"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error, got: %v", err)
+	}
+}

--- a/cmd/ynh/profile.go
+++ b/cmd/ynh/profile.go
@@ -102,7 +102,7 @@ func cmdProfileHook(args []string, stdout io.Writer) error {
 }
 
 func cmdProfileHookAdd(args []string, stdout io.Writer) error {
-	var opts harness.ProfileHookAddOptions
+	var opts harness.HookAddOptions
 	var positional []string
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -289,7 +289,7 @@ func cmdProfileMCPRemove(args []string, stdout io.Writer) error {
 }
 
 func cmdProfileMCPUpdate(args []string, stdout io.Writer) error {
-	var opts harness.ProfileMCPUpdateOptions
+	var opts harness.MCPUpdateOptions
 	var positional []string
 	for i := 0; i < len(args); i++ {
 		switch args[i] {

--- a/cmd/ynh/profile.go
+++ b/cmd/ynh/profile.go
@@ -1,0 +1,541 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/resolver"
+)
+
+func cmdProfile(args []string) error {
+	return cmdProfileTo(args, os.Stdout)
+}
+
+func cmdProfileTo(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: ynh profile <add|remove|hook|mcp|include>")
+	}
+	switch args[0] {
+	case "add":
+		return cmdProfileAdd(args[1:], stdout)
+	case "remove":
+		return cmdProfileRemove(args[1:], stdout)
+	case "hook":
+		return cmdProfileHook(args[1:], stdout)
+	case "mcp":
+		return cmdProfileMCP(args[1:], stdout)
+	case "include":
+		return cmdProfileInclude(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown profile subcommand: %s\nUsage: ynh profile <add|remove|hook|mcp|include>", args[0])
+	}
+}
+
+// ---- profile add/remove ---------------------------------------------
+
+func cmdProfileAdd(args []string, stdout io.Writer) error {
+	var positional []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			return fmt.Errorf("unknown flag: %s", a)
+		}
+		positional = append(positional, a)
+	}
+	if len(positional) != 2 {
+		return fmt.Errorf("usage: ynh profile add <harness> <name>")
+	}
+	harnessRef, name := positional[0], positional[1]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+	if err := harness.AddProfile(dir, name); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Added profile %q\n", name)
+	return nil
+}
+
+func cmdProfileRemove(args []string, stdout io.Writer) error {
+	var positional []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			return fmt.Errorf("unknown flag: %s", a)
+		}
+		positional = append(positional, a)
+	}
+	if len(positional) != 2 {
+		return fmt.Errorf("usage: ynh profile remove <harness> <name>")
+	}
+	harnessRef, name := positional[0], positional[1]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+	if err := harness.RemoveProfile(dir, name); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Removed profile %q\n", name)
+	return nil
+}
+
+// ---- profile hook ---------------------------------------------------
+
+func cmdProfileHook(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: ynh profile hook <add|remove>")
+	}
+	switch args[0] {
+	case "add":
+		return cmdProfileHookAdd(args[1:], stdout)
+	case "remove":
+		return cmdProfileHookRemove(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown profile hook subcommand: %s\nUsage: ynh profile hook <add|remove>", args[0])
+	}
+}
+
+func cmdProfileHookAdd(args []string, stdout io.Writer) error {
+	var opts harness.ProfileHookAddOptions
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--matcher":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--matcher requires a value")
+			}
+			i++
+			opts.Matcher = args[i]
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+	if len(positional) != 4 {
+		return fmt.Errorf("usage: ynh profile hook add <harness> <profile> <event> <command> [--matcher <pattern>]")
+	}
+	harnessRef, profileName, event, command := positional[0], positional[1], positional[2], positional[3]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+	if err := harness.AddProfileHook(dir, profileName, event, command, opts); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Added hook to profile %q (event %s)\n", profileName, event)
+	return nil
+}
+
+func cmdProfileHookRemove(args []string, stdout io.Writer) error {
+	var positional []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			return fmt.Errorf("unknown flag: %s", a)
+		}
+		positional = append(positional, a)
+	}
+	if len(positional) != 4 {
+		return fmt.Errorf("usage: ynh profile hook remove <harness> <profile> <event> <index>")
+	}
+	harnessRef, profileName, event, idxStr := positional[0], positional[1], positional[2], positional[3]
+	index, err := strconv.Atoi(idxStr)
+	if err != nil {
+		return fmt.Errorf("hook index must be an integer: %s", idxStr)
+	}
+
+	dir, _, rErr := harness.ResolveEditTarget(harnessRef)
+	if rErr != nil {
+		return rErr
+	}
+	if err := harness.RemoveProfileHook(dir, profileName, event, index); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Removed hook %d from profile %q (event %s)\n", index, profileName, event)
+	return nil
+}
+
+// ---- profile mcp ----------------------------------------------------
+
+func cmdProfileMCP(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: ynh profile mcp <add|remove|update>")
+	}
+	switch args[0] {
+	case "add":
+		return cmdProfileMCPAdd(args[1:], stdout)
+	case "remove":
+		return cmdProfileMCPRemove(args[1:], stdout)
+	case "update":
+		return cmdProfileMCPUpdate(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown profile mcp subcommand: %s\nUsage: ynh profile mcp <add|remove|update>", args[0])
+	}
+}
+
+// parseKV splits a K=V flag value; errors if no '='.
+func parseKV(s string) (string, string, error) {
+	idx := strings.Index(s, "=")
+	if idx <= 0 {
+		return "", "", fmt.Errorf("expected K=V form, got %q", s)
+	}
+	return s[:idx], s[idx+1:], nil
+}
+
+func cmdProfileMCPAdd(args []string, stdout io.Writer) error {
+	var opts harness.ProfileMCPAddOptions
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--command":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--command requires a value")
+			}
+			i++
+			opts.Command = args[i]
+		case "--arg":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--arg requires a value")
+			}
+			i++
+			opts.Args = append(opts.Args, args[i])
+		case "--env":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--env requires a value")
+			}
+			i++
+			k, v, err := parseKV(args[i])
+			if err != nil {
+				return fmt.Errorf("--env: %w", err)
+			}
+			if opts.Env == nil {
+				opts.Env = make(map[string]string)
+			}
+			opts.Env[k] = v
+		case "--url":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--url requires a value")
+			}
+			i++
+			opts.URL = args[i]
+		case "--header":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--header requires a value")
+			}
+			i++
+			k, v, err := parseKV(args[i])
+			if err != nil {
+				return fmt.Errorf("--header: %w", err)
+			}
+			if opts.Headers == nil {
+				opts.Headers = make(map[string]string)
+			}
+			opts.Headers[k] = v
+		case "--null":
+			opts.Null = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+	if len(positional) != 3 {
+		return fmt.Errorf("usage: ynh profile mcp add <harness> <profile> <name> [--command <cmd> | --url <url> | --null] [--arg <v>...] [--env K=V...] [--header K=V...]")
+	}
+	harnessRef, profileName, serverName := positional[0], positional[1], positional[2]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+	if err := harness.AddProfileMCP(dir, profileName, serverName, opts); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Added mcp server %q to profile %q\n", serverName, profileName)
+	return nil
+}
+
+func cmdProfileMCPRemove(args []string, stdout io.Writer) error {
+	var positional []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			return fmt.Errorf("unknown flag: %s", a)
+		}
+		positional = append(positional, a)
+	}
+	if len(positional) != 3 {
+		return fmt.Errorf("usage: ynh profile mcp remove <harness> <profile> <name>")
+	}
+	harnessRef, profileName, serverName := positional[0], positional[1], positional[2]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+	if err := harness.RemoveProfileMCP(dir, profileName, serverName); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Removed mcp server %q from profile %q\n", serverName, profileName)
+	return nil
+}
+
+func cmdProfileMCPUpdate(args []string, stdout io.Writer) error {
+	var opts harness.ProfileMCPUpdateOptions
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--command":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--command requires a value")
+			}
+			i++
+			v := args[i]
+			opts.Command = &v
+		case "--arg":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--arg requires a value")
+			}
+			i++
+			opts.Args = append(opts.Args, args[i])
+			opts.SetArgs = true
+		case "--clear-args":
+			opts.SetArgs = true
+		case "--env":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--env requires a value")
+			}
+			i++
+			k, v, err := parseKV(args[i])
+			if err != nil {
+				return fmt.Errorf("--env: %w", err)
+			}
+			if opts.Env == nil {
+				opts.Env = make(map[string]string)
+			}
+			opts.Env[k] = v
+			opts.SetEnv = true
+		case "--clear-env":
+			opts.SetEnv = true
+		case "--url":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--url requires a value")
+			}
+			i++
+			v := args[i]
+			opts.URL = &v
+		case "--header":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--header requires a value")
+			}
+			i++
+			k, v, err := parseKV(args[i])
+			if err != nil {
+				return fmt.Errorf("--header: %w", err)
+			}
+			if opts.Headers == nil {
+				opts.Headers = make(map[string]string)
+			}
+			opts.Headers[k] = v
+			opts.SetHeaders = true
+		case "--clear-headers":
+			opts.SetHeaders = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+	if len(positional) != 3 {
+		return fmt.Errorf("usage: ynh profile mcp update <harness> <profile> <name> [--command <cmd>] [--url <url>] [--arg <v>...] [--env K=V...] [--header K=V...] [--clear-args|--clear-env|--clear-headers]")
+	}
+	harnessRef, profileName, serverName := positional[0], positional[1], positional[2]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+	if err := harness.UpdateProfileMCP(dir, profileName, serverName, opts); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Updated mcp server %q in profile %q\n", serverName, profileName)
+	return nil
+}
+
+// ---- profile include ------------------------------------------------
+
+func cmdProfileInclude(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: ynh profile include <add|remove|update>")
+	}
+	switch args[0] {
+	case "add":
+		return cmdProfileIncludeAdd(args[1:], stdout)
+	case "remove":
+		return cmdProfileIncludeRemove(args[1:], stdout)
+	case "update":
+		return cmdProfileIncludeUpdate(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown profile include subcommand: %s\nUsage: ynh profile include <add|remove|update>", args[0])
+	}
+}
+
+func cmdProfileIncludeAdd(args []string, stdout io.Writer) error {
+	var opts harness.AddOptions
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--path":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--path requires a value")
+			}
+			i++
+			opts.Path = args[i]
+		case "--ref":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--ref requires a value")
+			}
+			i++
+			opts.Ref = args[i]
+		case "--replace":
+			opts.Replace = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+	if len(positional) != 3 {
+		return fmt.Errorf("usage: ynh profile include add <harness> <profile> <url> [--path <subdir>] [--ref <ref>] [--replace]")
+	}
+	harnessRef, profileName, url := positional[0], positional[1], positional[2]
+
+	dir, installed, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+
+	if installed {
+		gs := harness.GitSource{Git: url, Ref: opts.Ref, Path: opts.Path}
+		if _, _, fetchErr := resolver.ResolveGitSource(gs); fetchErr != nil {
+			return fmt.Errorf("fetching include: %w", fetchErr)
+		}
+	}
+
+	if err := harness.AddProfileInclude(dir, profileName, url, opts); err != nil {
+		return err
+	}
+	action := "Added"
+	if opts.Replace {
+		action = "Replaced"
+	}
+	_, _ = fmt.Fprintf(stdout, "%s include %q in profile %q\n", action, url, profileName)
+	return nil
+}
+
+func cmdProfileIncludeRemove(args []string, stdout io.Writer) error {
+	var opts harness.RemoveOptions
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--path":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--path requires a value")
+			}
+			i++
+			opts.Path = args[i]
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+	if len(positional) != 3 {
+		return fmt.Errorf("usage: ynh profile include remove <harness> <profile> <url> [--path <subdir>]")
+	}
+	harnessRef, profileName, url := positional[0], positional[1], positional[2]
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+	if err := harness.RemoveProfileInclude(dir, profileName, url, opts); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Removed include %q from profile %q\n", url, profileName)
+	return nil
+}
+
+func cmdProfileIncludeUpdate(args []string, stdout io.Writer) error {
+	var opts harness.UpdateOptions
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--from-path":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--from-path requires a value")
+			}
+			i++
+			opts.FromPath = args[i]
+		case "--path":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--path requires a value")
+			}
+			i++
+			v := args[i]
+			opts.NewPath = &v
+		case "--ref":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--ref requires a value")
+			}
+			i++
+			v := args[i]
+			opts.Ref = &v
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+	if len(positional) != 3 {
+		return fmt.Errorf("usage: ynh profile include update <harness> <profile> <url> [--from-path <subdir>] [--path <subdir>] [--ref <ref>]")
+	}
+	if opts.NewPath == nil && opts.Ref == nil {
+		return fmt.Errorf("ynh profile include update: at least one of --path or --ref must be specified")
+	}
+	harnessRef, profileName, url := positional[0], positional[1], positional[2]
+
+	dir, installed, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+
+	if installed {
+		finalInc, ferr := harness.FindProfileIncludeUpdateTarget(dir, profileName, url, opts)
+		if ferr != nil {
+			return ferr
+		}
+		gs := harness.GitSource{Git: url, Ref: finalInc.Ref, Path: finalInc.Path}
+		if _, _, fetchErr := resolver.ResolveGitSource(gs); fetchErr != nil {
+			return fmt.Errorf("fetching include: %w", fetchErr)
+		}
+	}
+
+	if err := harness.UpdateProfileInclude(dir, profileName, url, opts); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Updated include %q in profile %q\n", url, profileName)
+	return nil
+}

--- a/cmd/ynh/profile_test.go
+++ b/cmd/ynh/profile_test.go
@@ -1,0 +1,406 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+func writeProfileTestHarness(t *testing.T, dir, name string) {
+	t.Helper()
+	hj := &plugin.HarnessJSON{Name: name, Version: "0.1.0"}
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func loadTestProfiles(t *testing.T, dir string) map[string]plugin.Profile {
+	t.Helper()
+	hj, err := plugin.LoadPluginJSON(dir)
+	if err != nil {
+		t.Fatalf("LoadPluginJSON: %v", err)
+	}
+	return hj.Profiles
+}
+
+// ---- routing -----------------------------------------------------
+
+func TestCmdProfile_NoArgs(t *testing.T) {
+	err := cmdProfile([]string{})
+	if err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
+func TestCmdProfile_UnknownSubcommand(t *testing.T) {
+	err := cmdProfile([]string{"bogus"})
+	if err == nil || !strings.Contains(err.Error(), "unknown profile subcommand") {
+		t.Errorf("expected unknown subcommand error, got: %v", err)
+	}
+}
+
+// ---- add / remove ------------------------------------------------
+
+func TestCmdProfileAdd_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	if err := cmdProfileTo([]string{"add", dir, "thorough"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestProfiles(t, dir)
+	if _, ok := got["thorough"]; !ok {
+		t.Errorf("expected profile thorough, got %+v", got)
+	}
+}
+
+func TestCmdProfileAdd_Duplicate(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	err := cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected duplicate error, got: %v", err)
+	}
+}
+
+func TestCmdProfileRemove_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	buf.Reset()
+
+	if err := cmdProfileTo([]string{"remove", dir, "p"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(loadTestProfiles(t, dir)) != 0 {
+		t.Errorf("expected no profiles after remove")
+	}
+}
+
+func TestCmdProfileRemove_BlockedByFocus(t *testing.T) {
+	dir := t.TempDir()
+	hj := &plugin.HarnessJSON{
+		Name: "h", Version: "0.1.0",
+		Profiles: map[string]plugin.Profile{"p": {}},
+		Focuses:  map[string]plugin.Focus{"f": {Profile: "p", Prompt: "x"}},
+	}
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err := cmdProfileTo([]string{"remove", dir, "p"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "referenced by focus") {
+		t.Errorf("expected referenced-by error, got: %v", err)
+	}
+}
+
+// ---- hook --------------------------------------------------------
+
+func TestCmdProfileHookAdd_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	buf.Reset()
+
+	if err := cmdProfileTo([]string{"hook", "add", dir, "p", "before_tool", "echo before"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestProfiles(t, dir)
+	entries := got["p"].Hooks["before_tool"]
+	if len(entries) != 1 || entries[0].Command != "echo before" {
+		t.Errorf("expected one hook entry, got %+v", entries)
+	}
+}
+
+func TestCmdProfileHookAdd_UnknownEvent(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+
+	err := cmdProfileTo([]string{"hook", "add", dir, "p", "garbage", "cmd"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "unknown hook event") {
+		t.Errorf("expected unknown-event error, got: %v", err)
+	}
+}
+
+func TestCmdProfileHookRemove_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	_ = cmdProfileTo([]string{"hook", "add", dir, "p", "before_tool", "a"}, &buf)
+	_ = cmdProfileTo([]string{"hook", "add", dir, "p", "before_tool", "b"}, &buf)
+	buf.Reset()
+
+	if err := cmdProfileTo([]string{"hook", "remove", dir, "p", "before_tool", "0"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestProfiles(t, dir)
+	entries := got["p"].Hooks["before_tool"]
+	if len(entries) != 1 || entries[0].Command != "b" {
+		t.Errorf("expected single remaining entry 'b', got %+v", entries)
+	}
+}
+
+func TestCmdProfileHookRemove_LastEntryDropsKey(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	_ = cmdProfileTo([]string{"hook", "add", dir, "p", "before_tool", "a"}, &buf)
+
+	if err := cmdProfileTo([]string{"hook", "remove", dir, "p", "before_tool", "0"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestProfiles(t, dir)
+	if _, ok := got["p"].Hooks["before_tool"]; ok {
+		t.Errorf("expected before_tool key to be removed when empty")
+	}
+}
+
+func TestCmdProfileHookRemove_OutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	_ = cmdProfileTo([]string{"hook", "add", dir, "p", "before_tool", "a"}, &buf)
+
+	err := cmdProfileTo([]string{"hook", "remove", dir, "p", "before_tool", "5"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("expected out-of-range error, got: %v", err)
+	}
+}
+
+// ---- mcp ---------------------------------------------------------
+
+func TestCmdProfileMCPAdd_Command(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	buf.Reset()
+
+	if err := cmdProfileTo([]string{
+		"mcp", "add", dir, "p", "github",
+		"--command", "gh", "--arg", "mcp", "--env", "TOK=abc",
+	}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestProfiles(t, dir)
+	srv := got["p"].MCPServers["github"]
+	if srv == nil || srv.Command != "gh" || len(srv.Args) != 1 || srv.Args[0] != "mcp" || srv.Env["TOK"] != "abc" {
+		t.Errorf("expected gh mcp server, got %+v", srv)
+	}
+}
+
+func TestCmdProfileMCPAdd_Null(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+
+	if err := cmdProfileTo([]string{"mcp", "add", dir, "p", "ditched", "--null"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestProfiles(t, dir)
+	srv, ok := got["p"].MCPServers["ditched"]
+	if !ok || srv != nil {
+		t.Errorf("expected null entry, got %v ok=%v", srv, ok)
+	}
+}
+
+func TestCmdProfileMCPAdd_BothCommandAndURL(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+
+	err := cmdProfileTo([]string{
+		"mcp", "add", dir, "p", "x", "--command", "c", "--url", "u",
+	}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "not both") && !strings.Contains(err.Error(), "cannot have both") {
+		t.Errorf("expected both-error, got: %v", err)
+	}
+}
+
+func TestCmdProfileMCPAdd_Neither(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+
+	err := cmdProfileTo([]string{"mcp", "add", dir, "p", "x"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "requires --command") {
+		t.Errorf("expected requires-flag error, got: %v", err)
+	}
+}
+
+func TestCmdProfileMCPAdd_BadEnv(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+
+	err := cmdProfileTo([]string{
+		"mcp", "add", dir, "p", "x", "--command", "c", "--env", "MISSING_EQ",
+	}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "K=V") {
+		t.Errorf("expected K=V error, got: %v", err)
+	}
+}
+
+func TestCmdProfileMCPRemove_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	_ = cmdProfileTo([]string{"mcp", "add", dir, "p", "x", "--command", "c"}, &buf)
+
+	if err := cmdProfileTo([]string{"mcp", "remove", dir, "p", "x"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestProfiles(t, dir)
+	if _, ok := got["p"].MCPServers["x"]; ok {
+		t.Errorf("expected server removed")
+	}
+}
+
+func TestCmdProfileMCPUpdate_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	_ = cmdProfileTo([]string{"mcp", "add", dir, "p", "x", "--command", "old"}, &buf)
+
+	if err := cmdProfileTo([]string{"mcp", "update", dir, "p", "x", "--command", "new"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestProfiles(t, dir)
+	if got["p"].MCPServers["x"].Command != "new" {
+		t.Errorf("expected command=new, got %+v", got["p"].MCPServers["x"])
+	}
+}
+
+func TestCmdProfileMCPUpdate_NullEntry(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	_ = cmdProfileTo([]string{"mcp", "add", dir, "p", "x", "--null"}, &buf)
+
+	err := cmdProfileTo([]string{"mcp", "update", dir, "p", "x", "--command", "c"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "null entry") {
+		t.Errorf("expected null-entry error, got: %v", err)
+	}
+}
+
+func TestCmdProfileMCPUpdate_NoFlags(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	_ = cmdProfileTo([]string{"mcp", "add", dir, "p", "x", "--command", "c"}, &buf)
+
+	err := cmdProfileTo([]string{"mcp", "update", dir, "p", "x"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "at least one") {
+		t.Errorf("expected at-least-one error, got: %v", err)
+	}
+}
+
+// ---- include -----------------------------------------------------
+
+func TestCmdProfileIncludeAdd_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+
+	if err := cmdProfileTo([]string{
+		"include", "add", dir, "p", "github.com/acme/tools",
+	}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestProfiles(t, dir)
+	incs := got["p"].Includes
+	if len(incs) != 1 || incs[0].Git != "github.com/acme/tools" {
+		t.Errorf("expected one include, got %+v", incs)
+	}
+}
+
+func TestCmdProfileIncludeRemove_Basic(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	_ = cmdProfileTo([]string{"include", "add", dir, "p", "github.com/acme/tools"}, &buf)
+
+	if err := cmdProfileTo([]string{
+		"include", "remove", dir, "p", "github.com/acme/tools",
+	}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestProfiles(t, dir)
+	if len(got["p"].Includes) != 0 {
+		t.Errorf("expected no includes after remove")
+	}
+}
+
+func TestCmdProfileIncludeUpdate_Ref(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	_ = cmdProfileTo([]string{"include", "add", dir, "p", "github.com/acme/tools", "--ref", "v1"}, &buf)
+
+	if err := cmdProfileTo([]string{
+		"include", "update", dir, "p", "github.com/acme/tools", "--ref", "v2",
+	}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := loadTestProfiles(t, dir)
+	if got["p"].Includes[0].Ref != "v2" {
+		t.Errorf("expected ref=v2, got %+v", got["p"].Includes[0])
+	}
+}
+
+func TestCmdProfileIncludeUpdate_NoFlags(t *testing.T) {
+	dir := t.TempDir()
+	writeProfileTestHarness(t, dir, "h")
+
+	var buf bytes.Buffer
+	_ = cmdProfileTo([]string{"add", dir, "p"}, &buf)
+	_ = cmdProfileTo([]string{"include", "add", dir, "p", "github.com/acme/tools"}, &buf)
+
+	err := cmdProfileTo([]string{"include", "update", dir, "p", "github.com/acme/tools"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "at least one") {
+		t.Errorf("expected at-least-one error, got: %v", err)
+	}
+}

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -181,6 +181,24 @@ When writing hook scripts for use across vendors:
 
 Hooks fire mid-session (push) and can produce artifacts that [sensors](sensors.md) declare a contract over (pull). The most common production pattern is `after_tool` writing a results file that a `files`-sourced sensor reads — implicit coupling by shared file path. See [Sensors §"Relationship to hooks"](sensors.md#relationship-to-hooks) for the full push/pull comparison and the canonical pairing pattern.
 
+## CLI Editing
+
+Hooks can be added and removed from the command line as well as authored directly in the manifest. The CLI distinguishes harness-level (default) hooks from profile-level overrides:
+
+```bash
+# Top-level harness hooks
+ynh hook add <harness> <event> "<command>" [--matcher <pattern>]
+ynh hook remove <harness> <event> <index>
+
+# Profile-level hooks (override the harness-level set when the profile is active)
+ynh profile hook add <harness> <profile> <event> "<command>" [--matcher <pattern>]
+ynh profile hook remove <harness> <profile> <event> <index>
+```
+
+`<event>` is validated against the canonical set: `before_tool`, `after_tool`, `before_prompt`, `on_stop`. `<index>` is zero-based. When the last entry for an event is removed, the event key is dropped from the manifest entirely.
+
+See [reference.md](reference.md) for the complete flag matrix and [profiles.md](profiles.md#cli-editing) for the surrounding profile-editor surface.
+
 ## See Also
 
 - [Tutorial 4: Hooks](tutorial/10-hooks.md) — step-by-step walkthrough

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -143,6 +143,31 @@ If an included harness requires an MCP server, add the server declaration to the
 
 The [Agentic AI Foundation (AAIF)](https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation) is working on standardizing MCP configuration across vendors. When a standard format emerges, ynh will adopt it as the canonical format and translate to any vendor that has not yet adopted the standard.
 
+## CLI Editing
+
+MCP servers can be added, updated, and removed from the command line. The CLI distinguishes harness-level entries from profile-level overlays:
+
+```bash
+# Top-level harness MCP servers
+ynh mcp add <harness> <name> --command <cmd> [--arg <v>...] [--env K=V...]
+ynh mcp add <harness> <name> --url <url> [--header K=V...]
+ynh mcp update <harness> <name> [flags] [--clear-args|--clear-env|--clear-headers]
+ynh mcp remove <harness> <name>
+
+# Profile-level MCP servers (override or extend the harness-level set when the profile is active)
+ynh profile mcp add <harness> <profile> <name> [...flags] [--null]
+ynh profile mcp update <harness> <profile> <name> [flags] [--clear-args|--clear-env|--clear-headers]
+ynh profile mcp remove <harness> <profile> <name>
+```
+
+`--command` and `--url` are mutually exclusive; at least one is required at add time. `--arg` builds the args array in declaration order; `--env K=V` and `--header K=V` are repeatable.
+
+**`--null` is profile-only.** A profile MCP entry can be a JSON null to suppress an inherited harness-level server when the profile is active — there is no harness-level analogue because there is nothing to inherit from. Passing `--null` to `ynh mcp add` is rejected.
+
+`mcp update` requires at least one flag. The `--clear-*` flags zero out a collection (args, env, headers) without supplying replacement content — useful for "remove all args" without writing the empty list out manually.
+
+See [reference.md](reference.md) for the complete flag matrix and [profiles.md](profiles.md#cli-editing) for the surrounding profile-editor surface.
+
 ## See Also
 
 - [Tutorial 5: MCP Servers](tutorial/11-mcp-servers.md) — step-by-step walkthrough

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -142,6 +142,38 @@ Error: profile "ci": hooks.before_tool[0]: missing "command" field
 
 A profile cannot override or add sensors — sensors are observation declarations, not runtime context, and live only at the top level. An [inline focus inside a sensor](sensors.md#focus) can name a profile, but the sensor itself is profile-independent.
 
+## CLI Editing
+
+Profiles can be edited from the command line as well as authored directly in the manifest. The CLI mirrors `ynh include` / `ynh delegate` and routes edits through the same resolver, so changes to a pointer-form local install land in your source tree.
+
+```bash
+# Create / remove a profile (errors if any focus still references it)
+ynh profile add <harness> <name>
+ynh profile remove <harness> <name>
+
+# Hooks inside a profile
+ynh profile hook add <harness> <profile> <event> "<command>" [--matcher <pattern>]
+ynh profile hook remove <harness> <profile> <event> <index>
+
+# MCP servers inside a profile
+ynh profile mcp add <harness> <profile> <name> --command <cmd> [--arg <v>...] [--env K=V...]
+ynh profile mcp add <harness> <profile> <name> --url <url> [--header K=V...]
+ynh profile mcp add <harness> <profile> <name> --null         # suppress an inherited server
+ynh profile mcp update <harness> <profile> <name> [flags] [--clear-args|--clear-env|--clear-headers]
+ynh profile mcp remove <harness> <profile> <name>
+
+# Profile-level Git includes (no --pick; whole include is merged in)
+ynh profile include add <harness> <profile> <url> [--path <subdir>] [--ref <ref>] [--replace]
+ynh profile include remove <harness> <profile> <url> [--path <subdir>]
+ynh profile include update <harness> <profile> <url> [--from-path <subdir>] [--path <subdir>] [--ref <ref>]
+```
+
+`<harness>` is a canonical id from `ynh ls` (e.g. `local/my-harness` or `github.com/<org>/<repo>/<name>`). For tree-form (registry/git) installs the edits land in the install copy; for pointer-form (local source) installs they land in your source tree.
+
+`profile remove` refuses if any focus still references the profile and lists the blocking focuses — fix the focuses first, then retry.
+
+See [reference.md](reference.md) for the complete flag matrix.
+
 ## See Also
 
 - [Hooks](hooks.md) — hook format and vendor translation

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -46,6 +46,24 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | `ynh include add <harness> <url>` | `--path`, `--pick`, `--ref`, `--replace` |
 | `ynh include remove <harness> <url>` | `--path` |
 | `ynh include update <harness> <url>` | `--from-path`, `--path`, `--pick`, `--ref` |
+| `ynh focus add <harness> <name> <prompt>` | `--profile <name>` |
+| `ynh focus remove <harness> <name>` | |
+| `ynh focus update <harness> <name>` | `--prompt`, `--profile`, `--clear-profile` |
+| `ynh profile add <harness> <name>` | |
+| `ynh profile remove <harness> <name>` | (refuses if any focus references it) |
+| `ynh profile hook add <harness> <profile> <event> <command>` | `--matcher` |
+| `ynh profile hook remove <harness> <profile> <event> <index>` | |
+| `ynh profile mcp add <harness> <profile> <name>` | `--command`, `--url`, `--arg`, `--env`, `--header`, `--null` |
+| `ynh profile mcp remove <harness> <profile> <name>` | |
+| `ynh profile mcp update <harness> <profile> <name>` | `--command`, `--url`, `--arg`, `--env`, `--header`, `--clear-args`, `--clear-env`, `--clear-headers` |
+| `ynh profile include add <harness> <profile> <url>` | `--path`, `--ref`, `--replace` |
+| `ynh profile include remove <harness> <profile> <url>` | `--path` |
+| `ynh profile include update <harness> <profile> <url>` | `--from-path`, `--path`, `--ref` |
+| `ynh hook add <harness> <event> <command>` | `--matcher` — top-level harness hook |
+| `ynh hook remove <harness> <event> <index>` | top-level harness hook |
+| `ynh mcp add <harness> <name>` | `--command`, `--url`, `--arg`, `--env`, `--header` — top-level harness MCP server (no `--null`; harness-level entries cannot be null) |
+| `ynh mcp remove <harness> <name>` | top-level harness MCP server |
+| `ynh mcp update <harness> <name>` | `--command`, `--url`, `--arg`, `--env`, `--header`, `--clear-args`, `--clear-env`, `--clear-headers` |
 | `ynh sensors ls <harness>` | `--format <text\|json>` |
 | `ynh sensors show <harness> <name>` | `--format <text\|json>` |
 | `ynh sensors run <harness> <name>` | `--cwd <dir>`, `--no-content` |
@@ -85,7 +103,7 @@ Commands that take `--format json` emit machine-readable output conforming to [S
 
 | Command | Structured fields |
 |---------|-------------------|
-| `ynd compose` | Composed harness: `name`, `version`, `description`, `default_vendor`, `artifacts` (with source), `includes`, `delegates_to`, `hooks`, `mcp_servers`, `profiles`, `focuses`, `sensors`, `counts` |
+| `ynd compose` | Composed harness: `name`, `version`, `description`, `default_vendor`, `artifacts` (with source), `includes`, `delegates_to`, `hooks`, `mcp_servers`, `profiles` (object keyed by name — see breaking change note below), `focuses`, `sensors`, `counts` |
 | `ynh sensors ls <harness>` | Array of sensor summaries: `name`, `category`, `role`, `source_kind`, `format`, `inline_focus` (bool) — see [Sensors](sensors.md) |
 | `ynh sensors show <harness> <name>` | Resolved sensor object with inline-focus expansion |
 | `ynh sensors run <harness> <name>` | Sensor run result: `kind`, `exit_code`, `duration_ms`, `output` (raw signal — no `passed` field; pass/fail is loop-driver policy) |
@@ -99,6 +117,38 @@ Commands that take `--format json` emit machine-readable output conforming to [S
 | `ynh sources list` | Array of source objects: `name`, `path`, `description`, `harnesses` (discovery count) |
 
 Human-readable tabwriter output remains the default for every command. Structured mode is strictly opt-in.
+
+### `ynd compose`: `profiles` field shape (breaking change)
+
+As of this release, `ynd compose --format json` emits `profiles` as a **map keyed by profile name** rather than an array of names. Each value carries the full content of the profile so consumers can render and diff state without re-parsing the manifest:
+
+```json
+{
+  "profiles": {
+    "thorough": {
+      "hooks": {
+        "before_tool": [{"command": "echo before"}]
+      },
+      "mcp_servers": {
+        "github": {"command": "gh", "args": ["mcp"]}
+      },
+      "includes": []
+    }
+  }
+}
+```
+
+Empty case is `"profiles": {}` (empty object), no longer `"profiles": []`. This change is **not backwards-compatible**: decoders written against the old array shape will fail. Update consumers to decode `profiles` as a `map[string]<profile-content>` before upgrading the binary.
+
+### `ynd compose` source argument
+
+`ynd compose <source>` accepts three forms of source:
+
+- **Filesystem path** — absolute, relative, or anything that exists on disk.
+- **Canonical harness id** from `ynh ls --format json` — `local/<name>` or `<host>/<org>/<repo>/<name>`. Resolved against installed harnesses; no clone is attempted.
+- **Git URL** — falls through when the input is neither a path nor an installed canonical id.
+
+`ynd preview`, `diff`, and `export` accept the same forms through the shared resolver.
 
 ### Envelope and harness fields
 

--- a/docs/tutorial/10-hooks.md
+++ b/docs/tutorial/10-hooks.md
@@ -221,6 +221,24 @@ Expected output shows:
 
 The key difference: the same three hooks declared once in `.ynh-plugin/plugin.json` produce three structurally different config files, each native to the vendor.
 
+## Edit hooks from the command line
+
+Hooks can also be added and removed from the CLI — useful for scripted setup and for GUI consumers. The CLI distinguishes harness-level (default) hooks from profile-level overrides:
+
+```bash
+# Top-level hooks
+ynh hook add /tmp/ynh-tutorial/hook-harness before_tool "echo guard" --matcher Write
+ynh hook remove /tmp/ynh-tutorial/hook-harness before_tool 0
+
+# Profile-level hooks
+ynh profile hook add /tmp/ynh-tutorial/hook-harness <profile> after_tool "echo done"
+ynh profile hook remove /tmp/ynh-tutorial/hook-harness <profile> after_tool 0
+```
+
+The first positional argument accepts either a filesystem path (during authoring) or a canonical harness id (`local/<name>`, `github.com/<org>/<repo>/<name>`) once installed.
+
+`<event>` is validated against the canonical set (`before_tool`, `after_tool`, `before_prompt`, `on_stop`). `<index>` is zero-based; removing the last entry for an event drops the event key entirely. See [hooks.md §"CLI Editing"](../hooks.md#cli-editing) and [reference.md](../reference.md) for the full flag matrix.
+
 ## Clean up
 
 ```bash
@@ -234,6 +252,7 @@ rm -rf /tmp/ynh-tutorial
 - Claude, Cursor, and Codex each use different event names and nesting structures
 - Hook scripts should exit with code 2 to block actions and include remediation instructions
 - `ynd diff` compares the assembled output across vendors side by side
+- Hooks can be edited from the CLI with `ynh hook add/remove` (top-level) and `ynh profile hook add/remove` (profile-level) — the same surface a GUI consumer drives
 
 Hooks often pair with sensors — a hook produces an artifact mid-session that a sensor declares a contract over. See [Tutorial 19: Sensors](19-sensors.md).
 

--- a/docs/tutorial/11-mcp-servers.md
+++ b/docs/tutorial/11-mcp-servers.md
@@ -209,6 +209,34 @@ Expected output shows:
 - `.mcp.json` only in Codex (at plugin root)
 - The same two servers appear in all three, in the same JSON format but at different file locations
 
+## Edit MCP servers from the command line
+
+MCP servers can be authored from the CLI as well as in the manifest:
+
+```bash
+# Top-level (default) MCP server using stdio
+ynh mcp add /tmp/ynh-tutorial/mcp-harness github \
+    --command npx --arg -y --arg @modelcontextprotocol/server-github \
+    --env GITHUB_TOKEN=ghp_xxx
+
+# HTTP transport
+ynh mcp add /tmp/ynh-tutorial/mcp-harness api \
+    --url https://mcp.example.com --header Authorization=Bearer xyz
+
+# Update an existing entry
+ynh mcp update /tmp/ynh-tutorial/mcp-harness github --env GITHUB_TOKEN=ghp_new
+
+# Remove an entry
+ynh mcp remove /tmp/ynh-tutorial/mcp-harness api
+
+# Profile-level overlay (with optional --null to suppress an inherited entry)
+ynh profile mcp add /tmp/ynh-tutorial/mcp-harness <profile> postgres --null
+```
+
+`--command` and `--url` are mutually exclusive; at least one is required at add time. `--null` is profile-only (harness-level entries cannot be null — see [mcp.md §"CLI Editing"](../mcp.md#cli-editing)).
+
+The first positional argument accepts either a filesystem path (during authoring) or a canonical harness id (`local/<name>`, `github.com/<org>/<repo>/<name>`) once installed.
+
 ## Clean up
 
 ```bash
@@ -222,6 +250,7 @@ rm -rf /tmp/ynh-tutorial
 - All three vendors use JSON with a `mcpServers` key, but in different file locations
 - Claude places MCP config at `.claude/.mcp.json`, Cursor at `.cursor/mcp.json`, and Codex at `.mcp.json` (plugin root)
 - `ynd preview` and `ynd diff` let you verify MCP config without installing
+- MCP servers can be edited from the CLI with `ynh mcp add/update/remove` (top-level) and `ynh profile mcp add/update/remove` (profile-level), with `--null` available on profile-level to suppress an inherited entry
 
 ## Next
 

--- a/docs/tutorial/13-profiles.md
+++ b/docs/tutorial/13-profiles.md
@@ -274,6 +274,39 @@ ynd preview /tmp/ynh-tutorial/profile-harness -v claude --profile dev | grep dee
 
 Paths in `local` are relative to the harness root (or absolute). The `pick` field filters which artifacts to include from the source. A profile cannot remove base includes — it only appends.
 
+## T13.6: Edit profiles from the command line
+
+Profiles can be authored by hand-editing `.ynh-plugin/plugin.json` — that is what every step above did. They can also be edited from the command line, which is what an interactive consumer like TermQ uses. The CLI mirrors `ynh include` and routes through the same resolver, so edits land in the source tree for pointer-form local installs.
+
+```bash
+# Add a new profile (empty) and a hook inside it
+ynh profile add /tmp/ynh-tutorial/profile-harness staging
+ynh profile hook add /tmp/ynh-tutorial/profile-harness staging before_tool "echo staging guard"
+
+# Add an MCP server to the profile
+ynh profile mcp add /tmp/ynh-tutorial/profile-harness staging \
+    notes --command npx --arg -y --arg @modelcontextprotocol/server-memory
+
+# Verify it landed in the manifest
+ynd compose /tmp/ynh-tutorial/profile-harness --profile staging --format json | grep staging
+# Expected: profiles.staging present with the new hook and mcp_server
+
+# Update the MCP server
+ynh profile mcp update /tmp/ynh-tutorial/profile-harness staging \
+    notes --arg -y --arg @modelcontextprotocol/server-memory --arg --verbose
+
+# Remove individual entries
+ynh profile hook remove /tmp/ynh-tutorial/profile-harness staging before_tool 0
+ynh profile mcp remove /tmp/ynh-tutorial/profile-harness staging notes
+
+# Remove the profile itself (refused if any focus still references it)
+ynh profile remove /tmp/ynh-tutorial/profile-harness staging
+```
+
+The first positional argument is either a filesystem path (as above, while you are authoring) or a canonical harness id (`local/profile-demo`, `github.com/<org>/<repo>/<name>`) once the harness is installed.
+
+See [reference.md](../reference.md) for the full set of `ynh profile` flags and [profiles.md §"CLI Editing"](../profiles.md#cli-editing) for the surrounding surface.
+
 ## Clean up
 
 ```bash
@@ -292,6 +325,7 @@ rm -rf /tmp/ynh-tutorial
 - Invalid profile names produce helpful errors listing available profiles
 - Profile-level `includes` support both remote (`git`) and local (`local`) sources — same shape as top-level includes
 - `ynd validate` checks profile schema validity
+- Profiles can be edited with `ynh profile add/remove`, `ynh profile hook add/remove`, `ynh profile mcp add/update/remove`, and `ynh profile include add/remove/update` — the same surface a GUI consumer drives
 
 ## Next
 

--- a/docs/tutorial/14-focus.md
+++ b/docs/tutorial/14-focus.md
@@ -168,6 +168,26 @@ Profiles:
   ci    hooks: before_tool    mcp_servers: github
 ```
 
+## T14.5: Edit focuses from the command line
+
+Hand-editing the manifest is fine for an author. For an interactive consumer (TermQ, scripts, ad-hoc tweaks) the CLI provides the same surface:
+
+```bash
+# Add a focus
+ynh focus add /tmp/ynh-tutorial/focus-harness security "audit this PR for security issues" --profile ci
+
+# Update prompt or profile binding
+ynh focus update /tmp/ynh-tutorial/focus-harness security --prompt "audit thoroughly for security issues"
+ynh focus update /tmp/ynh-tutorial/focus-harness security --clear-profile
+
+# Remove a focus
+ynh focus remove /tmp/ynh-tutorial/focus-harness security
+```
+
+`--profile` and `--clear-profile` are mutually exclusive on `update`. Adding a focus that references a profile name not defined in the manifest is rejected with an error. Removing a profile referenced by any focus is also rejected (the focus has to be updated or removed first) — see [Tutorial 13: Profiles §"Edit profiles from the command line"](13-profiles.md#t136-edit-profiles-from-the-command-line).
+
+The first positional argument is either a filesystem path (as above, while authoring) or a canonical id (`local/focus-demo`, `github.com/<org>/<repo>/<name>`) once the harness is installed.
+
 ## Clean up
 
 ```bash
@@ -184,6 +204,7 @@ rm -rf /tmp/ynh-tutorial
 - `--focus` and `--profile` are mutually exclusive — focus already includes a profile
 - Focus entries that reference a non-existent profile are caught by `ynd validate`
 - `ynh info` displays focus entries and profiles
+- Focuses can be edited with `ynh focus add/remove/update` — the same surface a GUI consumer drives
 
 ## Next
 

--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/eyelock/ynh/internal/migration"
@@ -532,6 +533,460 @@ func ambiguousDelegateError(url string, delegates []plugin.DelegateMeta, indices
 		"delegate %q matches multiple entries:\n%s\nUse --path (remove) or --from-path (update) to disambiguate",
 		url, strings.Join(paths, "\n"),
 	)
+}
+
+// ---- focus ----------------------------------------------------------
+
+// FocusAddOptions controls ynh focus add behaviour.
+type FocusAddOptions struct {
+	Profile string
+}
+
+// FocusUpdateOptions controls ynh focus update behaviour.
+// Non-nil pointer fields are applied; nil leaves the field unchanged.
+// A non-nil empty Profile clears the focus's profile binding.
+type FocusUpdateOptions struct {
+	Prompt  *string
+	Profile *string
+}
+
+// AddFocus adds a new focus to a harness directory.
+func AddFocus(dir, name, prompt string, opts FocusAddOptions) error {
+	if name == "" {
+		return fmt.Errorf("focus name must not be empty")
+	}
+	if prompt == "" {
+		return fmt.Errorf("focus prompt must not be empty")
+	}
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	if _, exists := hj.Focuses[name]; exists {
+		return fmt.Errorf("focus %q already exists in harness %q.\nUse 'ynh focus update' to change it", name, hj.Name)
+	}
+	if opts.Profile != "" {
+		if _, ok := hj.Profiles[opts.Profile]; !ok {
+			return fmt.Errorf("focus %q references unknown profile %q", name, opts.Profile)
+		}
+	}
+	if hj.Focuses == nil {
+		hj.Focuses = make(map[string]plugin.Focus)
+	}
+	hj.Focuses[name] = plugin.Focus{Profile: opts.Profile, Prompt: prompt}
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// RemoveFocus removes a focus by name.
+func RemoveFocus(dir, name string) error {
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	if _, ok := hj.Focuses[name]; !ok {
+		return fmt.Errorf("focus %q not found in harness %q", name, hj.Name)
+	}
+	delete(hj.Focuses, name)
+	if len(hj.Focuses) == 0 {
+		hj.Focuses = nil
+	}
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// UpdateFocus mutates fields on an existing focus.
+func UpdateFocus(dir, name string, opts FocusUpdateOptions) error {
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	f, ok := hj.Focuses[name]
+	if !ok {
+		return fmt.Errorf("focus %q not found in harness %q", name, hj.Name)
+	}
+	if opts.Prompt != nil {
+		if *opts.Prompt == "" {
+			return fmt.Errorf("focus prompt must not be empty")
+		}
+		f.Prompt = *opts.Prompt
+	}
+	if opts.Profile != nil {
+		if *opts.Profile != "" {
+			if _, pok := hj.Profiles[*opts.Profile]; !pok {
+				return fmt.Errorf("focus %q references unknown profile %q", name, *opts.Profile)
+			}
+		}
+		f.Profile = *opts.Profile
+	}
+	hj.Focuses[name] = f
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// ---- profile --------------------------------------------------------
+
+// AddProfile creates a new empty profile.
+func AddProfile(dir, name string) error {
+	if name == "" {
+		return fmt.Errorf("profile name must not be empty")
+	}
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	if _, exists := hj.Profiles[name]; exists {
+		return fmt.Errorf("profile %q already exists in harness %q", name, hj.Name)
+	}
+	if hj.Profiles == nil {
+		hj.Profiles = make(map[string]plugin.Profile)
+	}
+	hj.Profiles[name] = plugin.Profile{}
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// RemoveProfile removes a profile by name. Fails if any focus still
+// references the profile, so the caller can fix those first.
+func RemoveProfile(dir, name string) error {
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	if _, ok := hj.Profiles[name]; !ok {
+		return fmt.Errorf("profile %q not found in harness %q", name, hj.Name)
+	}
+	var blockers []string
+	for fname, f := range hj.Focuses {
+		if f.Profile == name {
+			blockers = append(blockers, fname)
+		}
+	}
+	if len(blockers) > 0 {
+		sort.Strings(blockers)
+		return fmt.Errorf("profile %q is referenced by focus(es): %s.\nUpdate or remove those focuses first", name, strings.Join(blockers, ", "))
+	}
+	delete(hj.Profiles, name)
+	if len(hj.Profiles) == 0 {
+		hj.Profiles = nil
+	}
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// ---- profile hooks --------------------------------------------------
+
+// ProfileHookAddOptions controls ynh profile hook add behaviour.
+type ProfileHookAddOptions struct {
+	Matcher string
+}
+
+// AddProfileHook appends a hook entry to an event in a profile.
+func AddProfileHook(dir, profileName, event, command string, opts ProfileHookAddOptions) error {
+	if !plugin.ValidHookEvents[event] {
+		return fmt.Errorf("unknown hook event %q (valid: before_tool, after_tool, before_prompt, on_stop)", event)
+	}
+	if command == "" {
+		return fmt.Errorf("hook command must not be empty")
+	}
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	p, ok := hj.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found in harness %q", profileName, hj.Name)
+	}
+	if p.Hooks == nil {
+		p.Hooks = make(map[string][]plugin.HookEntry)
+	}
+	p.Hooks[event] = append(p.Hooks[event], plugin.HookEntry{Matcher: opts.Matcher, Command: command})
+	hj.Profiles[profileName] = p
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// RemoveProfileHook removes a single hook entry by zero-based index. When
+// the last entry for an event is removed, the event key is also deleted.
+func RemoveProfileHook(dir, profileName, event string, index int) error {
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	p, ok := hj.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found in harness %q", profileName, hj.Name)
+	}
+	entries, ok := p.Hooks[event]
+	if !ok {
+		return fmt.Errorf("profile %q has no hooks for event %q", profileName, event)
+	}
+	if index < 0 || index >= len(entries) {
+		return fmt.Errorf("hook index %d out of range [0, %d) for event %q in profile %q", index, len(entries), event, profileName)
+	}
+	entries = append(entries[:index], entries[index+1:]...)
+	if len(entries) == 0 {
+		delete(p.Hooks, event)
+	} else {
+		p.Hooks[event] = entries
+	}
+	if len(p.Hooks) == 0 {
+		p.Hooks = nil
+	}
+	hj.Profiles[profileName] = p
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// ---- profile mcp ----------------------------------------------------
+
+// ProfileMCPAddOptions controls ynh profile mcp add behaviour.
+type ProfileMCPAddOptions struct {
+	Command string
+	Args    []string
+	Env     map[string]string
+	URL     string
+	Headers map[string]string
+	Null    bool // explicitly remove an inherited server (null JSON entry)
+}
+
+// ProfileMCPUpdateOptions controls ynh profile mcp update behaviour.
+// Pointer fields and Set* booleans disambiguate "not provided" from "empty".
+type ProfileMCPUpdateOptions struct {
+	Command    *string
+	Args       []string
+	SetArgs    bool
+	Env        map[string]string
+	SetEnv     bool
+	URL        *string
+	Headers    map[string]string
+	SetHeaders bool
+}
+
+// AddProfileMCP adds a new MCP server entry to a profile.
+// Null=true writes a JSON null (suppresses an inherited server during merge).
+func AddProfileMCP(dir, profileName, serverName string, opts ProfileMCPAddOptions) error {
+	if serverName == "" {
+		return fmt.Errorf("mcp server name must not be empty")
+	}
+	if opts.Null {
+		if opts.Command != "" || opts.URL != "" {
+			return fmt.Errorf("--null cannot be combined with --command or --url")
+		}
+	} else {
+		if opts.Command == "" && opts.URL == "" {
+			return fmt.Errorf("mcp add requires --command, --url, or --null")
+		}
+		if opts.Command != "" && opts.URL != "" {
+			return fmt.Errorf("mcp add cannot have both --command and --url")
+		}
+	}
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	p, ok := hj.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found in harness %q", profileName, hj.Name)
+	}
+	if _, exists := p.MCPServers[serverName]; exists {
+		return fmt.Errorf("mcp server %q already present in profile %q.\nUse 'ynh profile mcp update' to change it", serverName, profileName)
+	}
+	if p.MCPServers == nil {
+		p.MCPServers = make(map[string]*plugin.MCPServer)
+	}
+	if opts.Null {
+		p.MCPServers[serverName] = nil
+	} else {
+		p.MCPServers[serverName] = &plugin.MCPServer{
+			Command: opts.Command,
+			Args:    opts.Args,
+			Env:     opts.Env,
+			URL:     opts.URL,
+			Headers: opts.Headers,
+		}
+	}
+	hj.Profiles[profileName] = p
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// RemoveProfileMCP deletes the named MCP server entry from a profile.
+// This is different from a null entry — remove drops the key entirely,
+// so the inherited server (if any) is no longer suppressed.
+func RemoveProfileMCP(dir, profileName, serverName string) error {
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	p, ok := hj.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found in harness %q", profileName, hj.Name)
+	}
+	if _, exists := p.MCPServers[serverName]; !exists {
+		return fmt.Errorf("mcp server %q not found in profile %q", serverName, profileName)
+	}
+	delete(p.MCPServers, serverName)
+	if len(p.MCPServers) == 0 {
+		p.MCPServers = nil
+	}
+	hj.Profiles[profileName] = p
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// UpdateProfileMCP mutates fields on an existing MCP server in a profile.
+// Null entries cannot be updated — remove and re-add instead.
+func UpdateProfileMCP(dir, profileName, serverName string, opts ProfileMCPUpdateOptions) error {
+	if opts.Command == nil && !opts.SetArgs && !opts.SetEnv && opts.URL == nil && !opts.SetHeaders {
+		return fmt.Errorf("ynh profile mcp update: at least one flag must be specified")
+	}
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	p, ok := hj.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found in harness %q", profileName, hj.Name)
+	}
+	srv, exists := p.MCPServers[serverName]
+	if !exists {
+		return fmt.Errorf("mcp server %q not found in profile %q", serverName, profileName)
+	}
+	if srv == nil {
+		return fmt.Errorf("mcp server %q in profile %q is a null entry; remove it and add a new one to replace", serverName, profileName)
+	}
+	if opts.Command != nil {
+		srv.Command = *opts.Command
+	}
+	if opts.SetArgs {
+		srv.Args = opts.Args
+	}
+	if opts.SetEnv {
+		srv.Env = opts.Env
+	}
+	if opts.URL != nil {
+		srv.URL = *opts.URL
+	}
+	if opts.SetHeaders {
+		srv.Headers = opts.Headers
+	}
+	if srv.Command == "" && srv.URL == "" {
+		return fmt.Errorf("mcp server %q must have either command or url after update", serverName)
+	}
+	if srv.Command != "" && srv.URL != "" {
+		return fmt.Errorf("mcp server %q cannot have both command and url after update", serverName)
+	}
+	p.MCPServers[serverName] = srv
+	hj.Profiles[profileName] = p
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// ---- profile includes -----------------------------------------------
+
+// AddProfileInclude mirrors AddInclude but targets a profile's includes slice.
+func AddProfileInclude(dir, profileName, url string, opts AddOptions) error {
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	p, ok := hj.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found in harness %q", profileName, hj.Name)
+	}
+	idx := findInclude(p.Includes, url, opts.Path)
+	if idx >= 0 {
+		if !opts.Replace {
+			msg := fmt.Sprintf("include %q already present in profile %q", url, profileName)
+			if opts.Path != "" {
+				msg = fmt.Sprintf("include %q (path: %q) already present in profile %q", url, opts.Path, profileName)
+			}
+			return fmt.Errorf("%s.\nUse 'ynh profile include update' to change its options, or pass --replace to overwrite", msg)
+		}
+		p.Includes[idx] = plugin.IncludeMeta{Git: url, Ref: opts.Ref, Path: opts.Path, Pick: opts.Pick}
+	} else {
+		p.Includes = append(p.Includes, plugin.IncludeMeta{Git: url, Ref: opts.Ref, Path: opts.Path, Pick: opts.Pick})
+	}
+	hj.Profiles[profileName] = p
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// RemoveProfileInclude mirrors RemoveInclude but targets a profile's includes.
+func RemoveProfileInclude(dir, profileName, url string, opts RemoveOptions) error {
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	p, ok := hj.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found in harness %q", profileName, hj.Name)
+	}
+	matches := findAllIncludes(p.Includes, url)
+	if len(matches) == 0 {
+		return fmt.Errorf("include %q not found in profile %q", url, profileName)
+	}
+	if opts.Path == "" && len(matches) > 1 {
+		return ambiguousIncludeError(url, p.Includes, matches)
+	}
+	keep := p.Includes[:0]
+	for _, inc := range p.Includes {
+		if inc.Git == url && (opts.Path == "" || inc.Path == opts.Path) {
+			continue
+		}
+		keep = append(keep, inc)
+	}
+	if len(keep) == len(p.Includes) {
+		return fmt.Errorf("include %q (path: %q) not found in profile %q", url, opts.Path, profileName)
+	}
+	p.Includes = keep
+	hj.Profiles[profileName] = p
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// UpdateProfileInclude mirrors UpdateInclude but targets a profile's includes.
+func UpdateProfileInclude(dir, profileName, url string, opts UpdateOptions) error {
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	p, ok := hj.Profiles[profileName]
+	if !ok {
+		return fmt.Errorf("profile %q not found in harness %q", profileName, hj.Name)
+	}
+	targetIdx, findErr := findUpdateTarget(p.Includes, url, opts.FromPath, profileName)
+	if findErr != nil {
+		return findErr
+	}
+	inc := &p.Includes[targetIdx]
+	if opts.NewPath != nil {
+		inc.Path = *opts.NewPath
+	}
+	if opts.SetPick {
+		inc.Pick = opts.Pick
+	}
+	if opts.Ref != nil {
+		inc.Ref = *opts.Ref
+	}
+	hj.Profiles[profileName] = p
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// FindProfileIncludeUpdateTarget mirrors FindUpdateTarget for profile includes.
+func FindProfileIncludeUpdateTarget(dir, profileName, url string, opts UpdateOptions) (plugin.IncludeMeta, error) {
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return plugin.IncludeMeta{}, err
+	}
+	p, ok := hj.Profiles[profileName]
+	if !ok {
+		return plugin.IncludeMeta{}, fmt.Errorf("profile %q not found in harness %q", profileName, hj.Name)
+	}
+	targetIdx, findErr := findUpdateTarget(p.Includes, url, opts.FromPath, profileName)
+	if findErr != nil {
+		return plugin.IncludeMeta{}, findErr
+	}
+	inc := p.Includes[targetIdx]
+	if opts.NewPath != nil {
+		inc.Path = *opts.NewPath
+	}
+	if opts.SetPick {
+		inc.Pick = opts.Pick
+	}
+	if opts.Ref != nil {
+		inc.Ref = *opts.Ref
+	}
+	return inc, nil
 }
 
 func formatAvailable(names []string) string {

--- a/internal/harness/editor.go
+++ b/internal/harness/editor.go
@@ -669,15 +669,62 @@ func RemoveProfile(dir, name string) error {
 	return plugin.SavePluginJSON(dir, hj)
 }
 
-// ---- profile hooks --------------------------------------------------
+// ---- hooks (harness + profile) -------------------------------------
 
-// ProfileHookAddOptions controls ynh profile hook add behaviour.
-type ProfileHookAddOptions struct {
+// HookAddOptions controls hook-add behaviour. Shared by harness-level
+// (AddHook) and profile-level (AddProfileHook) since the field set is
+// identical — only the storage scope differs.
+type HookAddOptions struct {
 	Matcher string
 }
 
+// AddHook appends a hook entry to a top-level event on the harness.
+func AddHook(dir, event, command string, opts HookAddOptions) error {
+	if !plugin.ValidHookEvents[event] {
+		return fmt.Errorf("unknown hook event %q (valid: before_tool, after_tool, before_prompt, on_stop)", event)
+	}
+	if command == "" {
+		return fmt.Errorf("hook command must not be empty")
+	}
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	if hj.Hooks == nil {
+		hj.Hooks = make(map[string][]plugin.HookEntry)
+	}
+	hj.Hooks[event] = append(hj.Hooks[event], plugin.HookEntry{Matcher: opts.Matcher, Command: command})
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// RemoveHook removes a single top-level hook entry by zero-based index.
+// When the last entry for an event is removed, the event key is also deleted.
+func RemoveHook(dir, event string, index int) error {
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	entries, ok := hj.Hooks[event]
+	if !ok {
+		return fmt.Errorf("harness %q has no hooks for event %q", hj.Name, event)
+	}
+	if index < 0 || index >= len(entries) {
+		return fmt.Errorf("hook index %d out of range [0, %d) for event %q in harness %q", index, len(entries), event, hj.Name)
+	}
+	entries = append(entries[:index], entries[index+1:]...)
+	if len(entries) == 0 {
+		delete(hj.Hooks, event)
+	} else {
+		hj.Hooks[event] = entries
+	}
+	if len(hj.Hooks) == 0 {
+		hj.Hooks = nil
+	}
+	return plugin.SavePluginJSON(dir, hj)
+}
+
 // AddProfileHook appends a hook entry to an event in a profile.
-func AddProfileHook(dir, profileName, event, command string, opts ProfileHookAddOptions) error {
+func AddProfileHook(dir, profileName, event, command string, opts HookAddOptions) error {
 	if !plugin.ValidHookEvents[event] {
 		return fmt.Errorf("unknown hook event %q (valid: before_tool, after_tool, before_prompt, on_stop)", event)
 	}
@@ -731,21 +778,24 @@ func RemoveProfileHook(dir, profileName, event string, index int) error {
 	return plugin.SavePluginJSON(dir, hj)
 }
 
-// ---- profile mcp ----------------------------------------------------
+// ---- mcp (harness + profile) ---------------------------------------
 
-// ProfileMCPAddOptions controls ynh profile mcp add behaviour.
-type ProfileMCPAddOptions struct {
+// MCPAddOptions controls ynh mcp add behaviour (harness-level). The
+// profile-level variant adds a Null flag (see ProfileMCPAddOptions);
+// harness-level entries can't be null — there's nothing to inherit from.
+type MCPAddOptions struct {
 	Command string
 	Args    []string
 	Env     map[string]string
 	URL     string
 	Headers map[string]string
-	Null    bool // explicitly remove an inherited server (null JSON entry)
 }
 
-// ProfileMCPUpdateOptions controls ynh profile mcp update behaviour.
-// Pointer fields and Set* booleans disambiguate "not provided" from "empty".
-type ProfileMCPUpdateOptions struct {
+// MCPUpdateOptions controls mcp update behaviour. Shared by harness-level
+// (UpdateMCP) and profile-level (UpdateProfileMCP) since the update
+// semantics are identical — pointer fields and Set* booleans disambiguate
+// "not provided" from "empty" in both scopes.
+type MCPUpdateOptions struct {
 	Command    *string
 	Args       []string
 	SetArgs    bool
@@ -754,6 +804,103 @@ type ProfileMCPUpdateOptions struct {
 	URL        *string
 	Headers    map[string]string
 	SetHeaders bool
+}
+
+// ProfileMCPAddOptions controls ynh profile mcp add behaviour. Adds the
+// Null flag to MCPAddOptions for explicitly suppressing an inherited
+// harness-level server during merge.
+type ProfileMCPAddOptions struct {
+	Command string
+	Args    []string
+	Env     map[string]string
+	URL     string
+	Headers map[string]string
+	Null    bool
+}
+
+// AddMCP adds a new top-level MCP server entry to the harness.
+func AddMCP(dir, serverName string, opts MCPAddOptions) error {
+	if serverName == "" {
+		return fmt.Errorf("mcp server name must not be empty")
+	}
+	if opts.Command == "" && opts.URL == "" {
+		return fmt.Errorf("mcp add requires --command or --url")
+	}
+	if opts.Command != "" && opts.URL != "" {
+		return fmt.Errorf("mcp add cannot have both --command and --url")
+	}
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	if _, exists := hj.MCPServers[serverName]; exists {
+		return fmt.Errorf("mcp server %q already present in harness %q.\nUse 'ynh mcp update' to change it", serverName, hj.Name)
+	}
+	if hj.MCPServers == nil {
+		hj.MCPServers = make(map[string]plugin.MCPServer)
+	}
+	hj.MCPServers[serverName] = plugin.MCPServer{
+		Command: opts.Command,
+		Args:    opts.Args,
+		Env:     opts.Env,
+		URL:     opts.URL,
+		Headers: opts.Headers,
+	}
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// RemoveMCP deletes a top-level MCP server entry from the harness.
+func RemoveMCP(dir, serverName string) error {
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	if _, exists := hj.MCPServers[serverName]; !exists {
+		return fmt.Errorf("mcp server %q not found in harness %q", serverName, hj.Name)
+	}
+	delete(hj.MCPServers, serverName)
+	if len(hj.MCPServers) == 0 {
+		hj.MCPServers = nil
+	}
+	return plugin.SavePluginJSON(dir, hj)
+}
+
+// UpdateMCP mutates fields on an existing top-level MCP server.
+func UpdateMCP(dir, serverName string, opts MCPUpdateOptions) error {
+	if opts.Command == nil && !opts.SetArgs && !opts.SetEnv && opts.URL == nil && !opts.SetHeaders {
+		return fmt.Errorf("ynh mcp update: at least one flag must be specified")
+	}
+	hj, err := loadManifest(dir)
+	if err != nil {
+		return err
+	}
+	srv, exists := hj.MCPServers[serverName]
+	if !exists {
+		return fmt.Errorf("mcp server %q not found in harness %q", serverName, hj.Name)
+	}
+	if opts.Command != nil {
+		srv.Command = *opts.Command
+	}
+	if opts.SetArgs {
+		srv.Args = opts.Args
+	}
+	if opts.SetEnv {
+		srv.Env = opts.Env
+	}
+	if opts.URL != nil {
+		srv.URL = *opts.URL
+	}
+	if opts.SetHeaders {
+		srv.Headers = opts.Headers
+	}
+	if srv.Command == "" && srv.URL == "" {
+		return fmt.Errorf("mcp server %q must have either command or url after update", serverName)
+	}
+	if srv.Command != "" && srv.URL != "" {
+		return fmt.Errorf("mcp server %q cannot have both command and url after update", serverName)
+	}
+	hj.MCPServers[serverName] = srv
+	return plugin.SavePluginJSON(dir, hj)
 }
 
 // AddProfileMCP adds a new MCP server entry to a profile.
@@ -828,7 +975,7 @@ func RemoveProfileMCP(dir, profileName, serverName string) error {
 
 // UpdateProfileMCP mutates fields on an existing MCP server in a profile.
 // Null entries cannot be updated — remove and re-add instead.
-func UpdateProfileMCP(dir, profileName, serverName string, opts ProfileMCPUpdateOptions) error {
+func UpdateProfileMCP(dir, profileName, serverName string, opts MCPUpdateOptions) error {
 	if opts.Command == nil && !opts.SetArgs && !opts.SetEnv && opts.URL == nil && !opts.SetHeaders {
 		return fmt.Errorf("ynh profile mcp update: at least one flag must be specified")
 	}

--- a/test/e2e/focus_profile_edit_test.go
+++ b/test/e2e/focus_profile_edit_test.go
@@ -1,0 +1,254 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// extendedManifest carries the manifest fields the new editor commands
+// touch — focuses, profiles, top-level hooks, top-level mcp_servers.
+// Subset of plugin.HarnessJSON sufficient to assert end-to-end round-trips.
+type extendedManifest struct {
+	Name       string                       `json:"name"`
+	Version    string                       `json:"version"`
+	Hooks      map[string][]manifestHook    `json:"hooks,omitempty"`
+	MCPServers map[string]manifestMCPServer `json:"mcp_servers,omitempty"`
+	Focuses    map[string]manifestFocus     `json:"focuses,omitempty"`
+	Profiles   map[string]manifestProfile   `json:"profiles,omitempty"`
+}
+
+type manifestHook struct {
+	Matcher string `json:"matcher,omitempty"`
+	Command string `json:"command"`
+}
+
+type manifestMCPServer struct {
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type manifestFocus struct {
+	Profile string `json:"profile,omitempty"`
+	Prompt  string `json:"prompt"`
+}
+
+type manifestProfile struct {
+	Hooks      map[string][]manifestHook     `json:"hooks,omitempty"`
+	MCPServers map[string]*manifestMCPServer `json:"mcp_servers,omitempty"`
+	Includes   []manifestSourceJSON          `json:"includes,omitempty"`
+}
+
+func readExtendedManifest(t *testing.T, harnessDir string) extendedManifest {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(harnessDir, ".ynh-plugin", "plugin.json"))
+	if err != nil {
+		t.Fatalf("reading plugin.json: %v", err)
+	}
+	var mf extendedManifest
+	if err := json.Unmarshal(body, &mf); err != nil {
+		t.Fatalf("parsing plugin.json: %v\n%s", err, body)
+	}
+	return mf
+}
+
+// TestFocus_LocalInstall_RoundTrip exercises the focus editor end-to-end
+// against a pointer-form local install:
+//   - install creates a pointer; no copy dir
+//   - focus add writes to the user's source tree
+//   - focus update mutates the same entry
+//   - ynh info surfaces the change (read/write symmetry)
+//   - focus remove drops it
+func TestFocus_LocalInstall_RoundTrip(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+
+	s.mustRunYnh(t, "install", sourceDir)
+
+	s.mustRunYnh(t, "focus", "add", "local/minimal", "review", "review this code")
+	mf := readExtendedManifest(t, sourceDir)
+	if f, ok := mf.Focuses["review"]; !ok || f.Prompt != "review this code" {
+		t.Fatalf("expected focus review with prompt, got %+v", mf.Focuses)
+	}
+
+	s.mustRunYnh(t, "focus", "update", "local/minimal", "review", "--prompt", "review carefully")
+	mf = readExtendedManifest(t, sourceDir)
+	if mf.Focuses["review"].Prompt != "review carefully" {
+		t.Errorf("expected updated prompt, got %+v", mf.Focuses["review"])
+	}
+
+	infoOut, _ := s.mustRunYnh(t, "info", "local/minimal", "--format", "json")
+	if !strings.Contains(infoOut, "review carefully") {
+		t.Errorf("focus edit not visible to ynh info — read/write symmetry broken.\noutput:\n%s", infoOut)
+	}
+
+	s.mustRunYnh(t, "focus", "remove", "local/minimal", "review")
+	mf = readExtendedManifest(t, sourceDir)
+	if _, ok := mf.Focuses["review"]; ok {
+		t.Errorf("focus not removed: %+v", mf.Focuses)
+	}
+}
+
+// TestProfile_LocalInstall_HookAndMCP exercises profile creation plus the
+// nested hook and mcp editors on a pointer-form local install.
+func TestProfile_LocalInstall_HookAndMCP(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+
+	s.mustRunYnh(t, "install", sourceDir)
+
+	s.mustRunYnh(t, "profile", "add", "local/minimal", "thorough")
+	s.mustRunYnh(t, "profile", "hook", "add", "local/minimal", "thorough", "before_tool", "echo before")
+	s.mustRunYnh(t, "profile", "mcp", "add", "local/minimal", "thorough", "github",
+		"--command", "gh", "--arg", "mcp", "--env", "TOK=abc")
+
+	mf := readExtendedManifest(t, sourceDir)
+	p, ok := mf.Profiles["thorough"]
+	if !ok {
+		t.Fatalf("expected profile thorough, got %+v", mf.Profiles)
+	}
+	if len(p.Hooks["before_tool"]) != 1 || p.Hooks["before_tool"][0].Command != "echo before" {
+		t.Errorf("expected hook on profile, got %+v", p.Hooks)
+	}
+	srv := p.MCPServers["github"]
+	if srv == nil || srv.Command != "gh" || srv.Env["TOK"] != "abc" {
+		t.Errorf("expected mcp server on profile, got %+v", srv)
+	}
+
+	// Profile-level mcp update is a key path TermQ drives.
+	s.mustRunYnh(t, "profile", "mcp", "update", "local/minimal", "thorough", "github",
+		"--arg", "--verbose")
+	mf = readExtendedManifest(t, sourceDir)
+	srv = mf.Profiles["thorough"].MCPServers["github"]
+	if srv == nil || len(srv.Args) != 1 || srv.Args[0] != "--verbose" {
+		t.Errorf("expected args replaced after update, got %+v", srv)
+	}
+
+	s.mustRunYnh(t, "profile", "hook", "remove", "local/minimal", "thorough", "before_tool", "0")
+	s.mustRunYnh(t, "profile", "mcp", "remove", "local/minimal", "thorough", "github")
+	mf = readExtendedManifest(t, sourceDir)
+	if len(mf.Profiles["thorough"].Hooks) != 0 || len(mf.Profiles["thorough"].MCPServers) != 0 {
+		t.Errorf("profile not cleared, got %+v", mf.Profiles["thorough"])
+	}
+}
+
+// TestHook_HarnessLevel_LocalInstall exercises top-level hook editing on
+// a pointer-form local install. Pins read/write symmetry for the
+// harness-level (not profile-nested) hook surface.
+func TestHook_HarnessLevel_LocalInstall(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+
+	s.mustRunYnh(t, "install", sourceDir)
+
+	s.mustRunYnh(t, "hook", "add", "local/minimal", "before_tool", "echo go", "--matcher", "Write")
+	mf := readExtendedManifest(t, sourceDir)
+	entries := mf.Hooks["before_tool"]
+	if len(entries) != 1 || entries[0].Command != "echo go" || entries[0].Matcher != "Write" {
+		t.Fatalf("expected hook on harness, got %+v", entries)
+	}
+
+	infoOut, _ := s.mustRunYnh(t, "info", "local/minimal", "--format", "json")
+	if !strings.Contains(infoOut, "echo go") {
+		t.Errorf("hook edit not visible to ynh info — read/write symmetry broken.\noutput:\n%s", infoOut)
+	}
+
+	s.mustRunYnh(t, "hook", "remove", "local/minimal", "before_tool", "0")
+	mf = readExtendedManifest(t, sourceDir)
+	if _, ok := mf.Hooks["before_tool"]; ok {
+		t.Errorf("hook event key should be dropped when empty, got %+v", mf.Hooks)
+	}
+}
+
+// TestMCP_HarnessLevel_LocalInstall exercises top-level mcp editing with
+// the add → update → remove lifecycle.
+func TestMCP_HarnessLevel_LocalInstall(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+
+	s.mustRunYnh(t, "install", sourceDir)
+
+	s.mustRunYnh(t, "mcp", "add", "local/minimal", "api",
+		"--url", "https://example.com", "--header", "Authorization=Bearer xyz")
+	mf := readExtendedManifest(t, sourceDir)
+	srv, ok := mf.MCPServers["api"]
+	if !ok || srv.URL != "https://example.com" || srv.Headers["Authorization"] != "Bearer xyz" {
+		t.Fatalf("expected url-based mcp server, got %+v", srv)
+	}
+
+	s.mustRunYnh(t, "mcp", "update", "local/minimal", "api",
+		"--header", "X-Trace=on")
+	mf = readExtendedManifest(t, sourceDir)
+	if mf.MCPServers["api"].Headers["X-Trace"] != "on" {
+		t.Errorf("expected new header after update, got %+v", mf.MCPServers["api"])
+	}
+
+	s.mustRunYnh(t, "mcp", "remove", "local/minimal", "api")
+	mf = readExtendedManifest(t, sourceDir)
+	if _, ok := mf.MCPServers["api"]; ok {
+		t.Errorf("mcp server not removed: %+v", mf.MCPServers)
+	}
+}
+
+// TestYndCompose_AcceptsCanonicalID exercises the ynd compose
+// canonical-id resolver added on this branch. TermQ drives
+// `ynd compose <id>` using ids from `ynh ls --format json`; this test
+// pins that contract so the resolveSource change can't silently regress.
+//
+// Also asserts the new map-shaped profiles field is emitted, which is a
+// breaking change for any pre-existing consumer relying on the old array
+// shape.
+func TestYndCompose_AcceptsCanonicalID(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+
+	s.mustRunYnh(t, "install", sourceDir)
+
+	// Seed a profile so the compose output's profiles map has content
+	// and we can assert on the new shape.
+	s.mustRunYnh(t, "profile", "add", "local/minimal", "p1")
+	s.mustRunYnh(t, "profile", "hook", "add", "local/minimal", "p1", "before_tool", "echo from-p1")
+
+	stdout, _, err := runYndInDirEnv(t, "", []string{"YNH_HOME=" + s.home},
+		"compose", "local/minimal", "--format", "json")
+	if err != nil {
+		t.Fatalf("ynd compose with canonical id failed: %v", err)
+	}
+
+	var got struct {
+		Name     string `json:"name"`
+		Profiles map[string]struct {
+			Hooks map[string][]struct {
+				Command string `json:"command"`
+			} `json:"hooks,omitempty"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal compose output: %v\n%s", err, stdout)
+	}
+
+	if got.Name != "minimal" {
+		t.Errorf("compose name = %q, want minimal", got.Name)
+	}
+
+	p1, ok := got.Profiles["p1"]
+	if !ok {
+		t.Fatalf("compose output missing profile p1; profiles=%+v", got.Profiles)
+	}
+	hooks := p1.Hooks["before_tool"]
+	if len(hooks) != 1 || hooks[0].Command != "echo from-p1" {
+		t.Errorf("expected profile hook surfaced in compose, got %+v", hooks)
+	}
+}

--- a/test/e2e/ynd_compose_diff_test.go
+++ b/test/e2e/ynd_compose_diff_test.go
@@ -70,7 +70,9 @@ func TestYnd_Compose_Focuses(t *testing.T) {
 	out, _ := mustRunYnd(t, "compose", dir, "--format", "json")
 
 	var got struct {
-		Profiles []string `json:"profiles"`
+		// profiles is a map keyed by name with full content; we only need
+		// presence + name here, hence the empty struct as value type.
+		Profiles map[string]struct{} `json:"profiles"`
 		Focuses  map[string]struct {
 			Profile string `json:"profile"`
 			Prompt  string `json:"prompt"`
@@ -79,8 +81,8 @@ func TestYnd_Compose_Focuses(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &got); err != nil {
 		t.Fatalf("parsing compose JSON: %v\n%s", err, out)
 	}
-	if len(got.Profiles) != 1 || got.Profiles[0] != "thorough" {
-		t.Errorf("profiles = %v, want [thorough]", got.Profiles)
+	if _, ok := got.Profiles["thorough"]; !ok || len(got.Profiles) != 1 {
+		t.Errorf("profiles = %v, want {thorough:{}}", got.Profiles)
 	}
 	if len(got.Focuses) != 2 {
 		t.Errorf("focuses len = %d, want 2; output:\n%s", len(got.Focuses), out)


### PR DESCRIPTION
## Summary

Adds the missing CRUD primitives for **focus**, **profile**, **hook**, and **mcp** resources at both harness and profile scopes — completing the editor surface needed by interactive consumers (notably TermQ's Harness Detail pane) to drive end-user configuration of installed harnesses without hand-editing `.ynh-plugin/plugin.json`.

Also fixes two adjacent issues this surface depends on:

- `ynd compose <canonical-id>` now resolves to installed harnesses instead of attempting a git clone (long-standing `ynd` gap, surfaced because TermQ passes ids straight from `ynh ls --format json`).
- The `evals` agent now isolates per Bash invocation rather than per shell export — fixes the real-world bug where tutorial 19 installed into the user's real `~/.ynh` and left a dangling pointer that blocked the schema-3 auto-migration.

## New ynh commands

```
ynh focus add|remove|update <harness> <name> ...
ynh profile add|remove <harness> <name>
ynh profile hook add|remove <harness> <profile> <event> ...
ynh profile mcp add|remove|update <harness> <profile> <name> ...   # supports --null
ynh profile include add|remove|update <harness> <profile> <url> ...
ynh hook add|remove <harness> <event> ...
ynh mcp add|remove|update <harness> <name> ...                     # no --null at harness level
```

All edits route through `harness.ResolveEditTarget`, so they land in the source tree for pointer-form local installs and in the install copy for tree-form (registry/git) installs.

## Breaking change

`ynd compose --format json` now emits `profiles` as an **object keyed by name** (with full hooks/mcp_servers/includes content) rather than an array of names. Empty case is `"profiles": {}`, not `"profiles": []`.

Decoders written against the old shape will fail. TermQ's `HarnessComposition.swift` needs the matching update — both apps are still 0.x and the agreed plan is "update to latest of both within a short window," not dual-shape tolerance.

Loud subsection in `docs/reference.md` calls this out.

## Test plan

- [x] `make check` — 0 lint, all unit tests pass
- [x] `make e2e` — full suite passes (35s) including 5 new tests covering the install → edit → ynd-compose chain end-to-end against pointer-form local installs
- [x] Manual smoke against real `~/.ynh` — `ynd compose local/termq-dev` and `ynd compose github.com/eyelock/assistants/termq-dev` both work
- [x] Every new tutorial bash sequence run live against the dev binary; manifest output verified
- [x] Daily-driven by the author for several days as a dev build before opening this PR

## Deferred? Nothing.

- Reference docs: ✅ updated (new commands, breaking compose change, canonical-id source)
- Per-surface docs (`profiles.md`, `hooks.md`, `mcp.md`): ✅ updated with CLI Editing sections
- Tutorials 10/11/13/14: ✅ updated with in-line CLI sections + What You Learned
- E2E coverage: ✅ added
- Evals isolation regression: ✅ fixed

## Notes for TermQ

Full feedback document at `.claude/plans/termq-feedback-hook-mcp.md` lists every deviation from TermQ's original plan, with rationale. Key points:

1. `mcp add` errors on duplicate name (plan said "replace") — consistency with the rest of ynh; use `mcp update` for mutations.
2. Hook removal is by zero-based index; the last entry removal drops the event key entirely.
3. `--null` is profile-only — no harness-level inheritance source to suppress.
4. Hook event names validate against the canonical set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)