### PR TITLE
docs: prep for 0.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ ynh manages the **guide layer** of that harness: the proactive steering that hap
 
 ## What you can do
 
-**Build** — Create harnesses with skills, agents, rules, and commands. Pull artifacts from any Git repo with cherry-picking (`pick`). Declare hooks, MCP servers, environment-specific profiles, and [sensors](docs/sensors.md) — observation surfaces that loop drivers consume between agent turns.
+**Build** — Create harnesses with skills, agents, rules, and commands. Pull artifacts from any Git repo with cherry-picking (`pick`). Declare hooks, MCP servers, environment-specific profiles, [focuses](docs/focus.md) — named prompt-and-profile bindings for repeatable runs — and [sensors](docs/sensors.md) — observation surfaces that loop drivers consume between agent turns.
 
-**Refine** — Scaffold with `ynd create`, lint and validate with `ynd lint`/`ynd validate`, compress prompts with `ynd compress`, preview assembled output with `ynd preview`, diff across vendors with `ynd diff`.
+**Refine** — Scaffold with `ynd create`, lint and validate with `ynd lint`/`ynd validate`, compress prompts with `ynd compress`, preview assembled output with `ynd preview`, diff across vendors with `ynd diff`. Edit focuses, profiles, hooks, MCP servers, includes, and delegates from the CLI with `ynh focus`/`profile`/`hook`/`mcp`/`include`/`delegate` — the same surface a GUI consumer drives.
 
 **Share** — Export as vendor-native plugins with `ynd export`. Build team marketplaces with `ynd marketplace build`. Publish to registries. Bake harnesses into Docker images for CI/CD.
 
@@ -79,7 +79,7 @@ Full docs at **[eyelock.github.io/ynh](https://eyelock.github.io/ynh)**:
 
 - **[Getting Started](https://eyelock.github.io/ynh/#/getting-started)** — Create and run your first harness
 - **[Harness Engineering](https://eyelock.github.io/ynh/#/harness-engineering)** — Why harness management matters
-- **[Tutorials](https://eyelock.github.io/ynh/#/tutorial/)** — 13 progressive tutorials from first harness to Docker images
+- **[Tutorials](https://eyelock.github.io/ynh/#/tutorial/)** — 18 progressive tutorials from first harness to sensors
 - **[Artifacts Guide](https://eyelock.github.io/ynh/#/artifacts)** — Skills, agents, rules, commands
 - **[CLI Reference](https://eyelock.github.io/ynh/#/reference)** — Full command reference for ynh and ynd
 - **[Agent Skills Standard](https://eyelock.github.io/ynh/#/skills-standard)** — Cross-platform spec, discovery paths, catalog budget

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -12,6 +12,7 @@
   * [Hooks](hooks.md)
   * [MCP Servers](mcp.md)
   * [Profiles](profiles.md)
+  * [Focus](focus.md)
   * [Sensors](sensors.md)
   * [Namespacing](namespacing.md)
   * [Vendor Support](vendors.md)

--- a/docs/focus.md
+++ b/docs/focus.md
@@ -1,0 +1,117 @@
+# Focus
+
+A focus is a named binding of a prompt to an optional profile. It captures a recurring intent — "review staged changes", "audit dependencies", "summarise this release" — so the same harness can be run for that specific job in a single, repeatable invocation.
+
+## Why Focus Matters
+
+Profiles change *how* a harness runs (hooks, MCP servers, includes). Prompts express *what* the agent should do. The two are usually paired: a "security audit" prompt only makes sense when the audit profile's tools are loaded; a "format docs" prompt only matters when the formatter MCP is available. Focus encodes that pairing once so operators do not have to remember the right `--profile` + prompt combination each time.
+
+A focus is the unit of automation. CI pipelines, schedulers, and loop drivers can drive a harness by name (`ynh run my-harness --focus security`) instead of by ad-hoc command construction.
+
+## Manifest Format
+
+Focuses live under the `focuses` key in `.ynh-plugin/plugin.json`. Each focus name maps to an object with a required `prompt` and an optional `profile`:
+
+```json
+{
+  "name": "my-harness",
+  "version": "0.1.0",
+  "profiles": {
+    "ci": { "hooks": { "before_tool": [{"command": "./scripts/strict-lint.sh"}] } },
+    "security": { "mcp_servers": { "sast": {"command": "semgrep-mcp"} } }
+  },
+  "focuses": {
+    "review":   { "prompt": "Review the staged changes and report findings." },
+    "audit":    { "prompt": "Audit the codebase for vulnerabilities.", "profile": "security" },
+    "ci-check": { "prompt": "Run the CI checklist and report failures.", "profile": "ci" }
+  }
+}
+```
+
+When `--focus audit` is used, the harness runs with the `security` profile loaded *and* the audit prompt as the initial instruction. A focus without a `profile` runs against the top-level (default) configuration.
+
+## Selection
+
+Focus is selected through a flag or environment variable:
+
+| Method | Example | Precedence |
+|--------|---------|------------|
+| `--focus` flag | `ynh run my-harness --focus audit` | Highest |
+| `YNH_FOCUS` env var | `YNH_FOCUS=audit ynh run my-harness` | Middle |
+| _(none)_ | `ynh run my-harness` | Lowest — interactive, top-level config |
+
+The `--focus` flag is supported on `ynh run`, `ynd preview`, `ynd diff`, and `ynd export`. When both the flag and the environment variable are set, the flag wins.
+
+## Mutual Exclusivity
+
+`--focus` and `--profile` are mutually exclusive. A focus already names a profile (or names "no profile" by omission); accepting `--profile` alongside it would create ambiguity over which profile wins.
+
+Similarly, `--focus` is mutually exclusive with a trailing prompt on `ynh run` — the focus carries its own prompt and a second prompt would be silently dropped.
+
+```
+$ ynh run my-harness --focus audit --profile security
+Error: cannot use --focus and --profile together (focus includes a profile)
+
+$ ynh run my-harness --focus audit -- "and also format the docs"
+Error: cannot use --focus and a trailing prompt together (focus includes a prompt)
+```
+
+## Non-Interactive Implication
+
+Specifying `--focus` implies non-interactive mode by default — the focus prompt is fed to the vendor CLI as the initial instruction and execution proceeds without further user input. Pass `--interactive` alongside `--focus` to override and keep the session interactive after the focus prompt is delivered.
+
+## Missing Focus Behavior
+
+Selecting a focus that is not defined is a hard error:
+
+```
+Error: focus "release-notes" not defined in harness
+```
+
+This matches profile-not-found behaviour — a typo in a CI pipeline should fail loudly rather than silently fall back to defaults.
+
+## Validation
+
+`ynd validate` checks each focus's contents:
+
+- `prompt` is required and must be a non-empty string.
+- `profile`, if present, must reference a profile defined in the same manifest.
+- Unknown fields inside a focus block are rejected.
+- A focus referencing a missing profile fails validation with the focus name for context:
+
+```
+Error: focus "audit": profile "security" not defined in harness manifest
+```
+
+Profile removal is also focus-aware: `ynh profile remove` refuses to delete a profile while any focus still references it, listing the blocking focuses.
+
+## CLI Editing
+
+Focuses can be edited from the command line as well as authored directly in the manifest. Edits route through the same resolver as `ynh include` and `ynh profile`, so changes to a pointer-form local install land in your source tree.
+
+```bash
+# Add a focus (prompt required; profile optional)
+ynh focus add <harness> <name> "<prompt>" [--profile <name>]
+
+# Remove a focus
+ynh focus remove <harness> <name>
+
+# Update a focus — change prompt, change profile, or clear the profile binding
+ynh focus update <harness> <name> [--prompt "<new>"] [--profile <name>] [--clear-profile]
+```
+
+`<harness>` is a canonical id from `ynh ls` (e.g. `local/my-harness` or `github.com/<org>/<repo>/<name>`). For tree-form (registry/git) installs the edits land in the install copy; for pointer-form (local source) installs they land in your source tree.
+
+See [reference.md](reference.md) for the complete flag matrix.
+
+## Inline Focus in Sensors
+
+A sensor's `focus` source can be either a string reference to a top-level focus or an inline focus object scoped to that sensor only. Inline focuses do not appear in the top-level `focuses` map and are not selectable via `--focus`. See [Sensors → focus source](sensors.md) for details.
+
+## See Also
+
+- [Profiles](profiles.md) — environment-specific runtime overrides
+- [Hooks](hooks.md) — lifecycle commands a profile can declare
+- [MCP Servers](mcp.md) — tool dependencies a profile can declare
+- [Sensors](sensors.md) — observation surfaces that can carry an inline focus
+- [Tutorial 7: Focus](tutorial/14-focus.md) — guided walkthrough

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -176,6 +176,7 @@ See [reference.md](reference.md) for the complete flag matrix.
 
 ## See Also
 
+- [Focus](focus.md) — bind a prompt to a profile for repeatable, non-interactive runs
 - [Hooks](hooks.md) — hook format and vendor translation
 - [MCP Servers](mcp.md) — MCP server format and vendor translation
 - [Sensors](sensors.md) — observation surfaces declared by the harness

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9,6 +9,7 @@ Centralized reference for both `ynh` and `ynd` binaries — environment variable
 | `YNH_HOME` | `~/.ynh` | `ynh` (global) | — |
 | `YNH_VENDOR` | _(none)_ | `ynh run`, `ynd preview/export/create/compress/inspect/marketplace` | `-v` flag |
 | `YNH_PROFILE` | _(none)_ | `ynh run`, `ynd export/preview/diff` | `--profile` flag |
+| `YNH_FOCUS` | _(none)_ | `ynh run`, `ynd export/preview/diff` | `--focus` flag |
 | `YNH_HARNESS` | _(none)_ | `ynd preview/export/diff/validate/lint/fmt` | `--harness` flag / positional arg |
 | `YNH_YES` | _(none)_ | `ynd compress/inspect` | `-y` flag |
 | `CI` | _(none)_ | `ynd compress/inspect` | (lowest priority skip-confirm) |
@@ -22,6 +23,7 @@ Centralized reference for both `ynh` and `ynd` binaries — environment variable
 |---------|-----------------|
 | Vendor | `-v` flag > `YNH_VENDOR` > harness `default_vendor` > global config |
 | Profile | `--profile` flag > `YNH_PROFILE` > no profile (top-level) |
+| Focus | `--focus` flag > `YNH_FOCUS` > no focus (mutually exclusive with `--profile`) |
 | Harness source | `--harness` flag > `YNH_HARNESS` > positional arg > `.` (CWD) or error |
 | Non-interactive | `-y` flag > `YNH_YES` > `CI` |
 
@@ -32,7 +34,7 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | Command | Key Flags |
 |---------|-----------|
 | `ynh install <source>` | `--path`, `-v` |
-| `ynh run [harness]` | `-v`, `--profile`, `--install`, `--clean` |
+| `ynh run [harness]` | `-v`, `--profile`, `--focus`, `--install`, `--clean` |
 | `ynh uninstall <harness>` | |
 | `ynh update [harness]` | |
 | `ynh fork <name>` | `--to <path>`, `--name <new>`, `--format <text\|json>` |
@@ -90,9 +92,9 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | `ynd compose <source>` | `--harness`, `--profile`, `--format <text\|json>` |
 | `ynd compress [files...]` | `-v`, `-y`, `--restore`, `--list-backups`, `--pick` |
 | `ynd inspect` | `-v`, `-y`, `-o` |
-| `ynd preview <source>` | `-v`, `-o`, `--harness`, `--profile` |
-| `ynd diff <source>` | `-v`, `--harness`, `--profile` |
-| `ynd export <source>` | `-v`, `-o`, `--harness`, `--profile`, `--path`, `--merged`, `--clean` |
+| `ynd preview <source>` | `-v`, `-o`, `--harness`, `--profile`, `--focus` |
+| `ynd diff <source>` | `-v`, `--harness`, `--profile`, `--focus` |
+| `ynd export <source>` | `-v`, `-o`, `--harness`, `--profile`, `--focus`, `--path`, `--merged`, `--clean` |
 | `ynd marketplace build` | `-v`, `-o`, `--clean` |
 
 See [ynd Developer Tools](ynd.md) for detailed command documentation.

--- a/docs/tutorial/04-delegation.md
+++ b/docs/tutorial/04-delegation.md
@@ -154,4 +154,4 @@ ynh uninstall local/team-lead
 
 ## Next
 
-[Tutorial 10: Export](tutorial/05-export.md) — produce vendor-native distributable plugins.
+[Tutorial 13: Export](tutorial/05-export.md) — produce vendor-native distributable plugins.

--- a/docs/tutorial/05-export.md
+++ b/docs/tutorial/05-export.md
@@ -287,4 +287,4 @@ rm -rf /tmp/ynh-tutorial/no-inst-out
 
 ## Next
 
-[Tutorial 11: Marketplace](tutorial/06-marketplace.md) — generate marketplace indexes for distribution.
+[Tutorial 14: Marketplace](tutorial/06-marketplace.md) — generate marketplace indexes for distribution.

--- a/docs/tutorial/06-marketplace.md
+++ b/docs/tutorial/06-marketplace.md
@@ -255,4 +255,4 @@ rm -rf /tmp/ynh-tutorial/marketplace-*
 
 ## Next
 
-[Tutorial 12: Registry & Discovery](tutorial/07-registry-and-discovery.md) — search and install from curated indexes.
+[Tutorial 15: Registry & Discovery](tutorial/07-registry-and-discovery.md) — search and install from curated indexes.

--- a/docs/tutorial/07-registry-and-discovery.md
+++ b/docs/tutorial/07-registry-and-discovery.md
@@ -441,4 +441,4 @@ ynh uninstall github.com/eyelock/assistants/tester 2>/dev/null
 
 ## Next
 
-[Tutorial 13: Docker Images](tutorial/09-docker-image.md) — build harness appliance images for CI/CD.
+[Tutorial 16: Docker Images](tutorial/09-docker-image.md) — build harness appliance images for CI/CD.

--- a/docs/tutorial/08-developer-tools.md
+++ b/docs/tutorial/08-developer-tools.md
@@ -240,6 +240,6 @@ rm -rf /tmp/ynh-tutorial
 - `ynd inspect` analyzes a project and generates skills/agents
 - All ynd commands work on the current directory by default, or target specific files
 
-## Complete
+## Next
 
-[Tutorial 8: Developer Preview](tutorial/12-developer-preview.md) — preview and diff assembled output across vendors.
+[Tutorial 10: Developer Preview](tutorial/12-developer-preview.md) — preview and diff assembled output across vendors.

--- a/docs/tutorial/09-docker-image.md
+++ b/docs/tutorial/09-docker-image.md
@@ -291,3 +291,7 @@ rm -rf /tmp/ynh-tutorial
 - Vendor flags pass through to the underlying CLI
 - `--entrypoint` overrides give full ynh/ynd access
 - Harness images are ready for CI/CD pipelines with no host setup
+
+## Next
+
+[Tutorial 17: Namespacing & Migration](tutorial/18-namespacing-and-migration.md) — resolve name collisions across registries and migrate legacy installs.

--- a/docs/tutorial/13-profiles.md
+++ b/docs/tutorial/13-profiles.md
@@ -329,4 +329,4 @@ rm -rf /tmp/ynh-tutorial
 
 ## Next
 
-[Tutorial 7: Developer Tools](tutorial/08-developer-tools.md) — scaffold, lint, validate, format, compress, inspect with ynd.
+[Tutorial 7: Focus](tutorial/14-focus.md) — bind a prompt and profile for repeatable, non-interactive runs.

--- a/docs/tutorial/14-focus.md
+++ b/docs/tutorial/14-focus.md
@@ -208,4 +208,4 @@ rm -rf /tmp/ynh-tutorial
 
 ## Next
 
-[Tutorial 15: Project-Local Config](15-project-local-config.md) — use `.ynh-plugin/plugin.json` in your project root for zero-install AI configuration.
+[Tutorial 8: Project-Local Config](tutorial/15-project-local-config.md) — use `.ynh-plugin/plugin.json` in your project root for zero-install AI configuration.

--- a/docs/tutorial/15-project-local-config.md
+++ b/docs/tutorial/15-project-local-config.md
@@ -92,9 +92,9 @@ rm -rf /tmp/ynh-tutorial
 - `ynh run --harness-file <path>` points to a specific `.ynh-plugin/plugin.json` file
 - The file format is identical to installed harnesses — same hooks, MCP servers, profiles, and focus entries
 
-## Next
+## Composition with focus
 
-The project-local config pattern works well with focus entries (Tutorial 14) for CI automation:
+The project-local config pattern works well with focus entries (Tutorial 7) for CI automation:
 
 ```json
 {
@@ -106,3 +106,7 @@ The project-local config pattern works well with focus entries (Tutorial 14) for
   }
 }
 ```
+
+## Next
+
+[Tutorial 9: Developer Tools](tutorial/08-developer-tools.md) — scaffold, lint, validate, format, compress, inspect with ynd.

--- a/docs/tutorial/18-namespacing-and-migration.md
+++ b/docs/tutorial/18-namespacing-and-migration.md
@@ -343,6 +343,8 @@ rm -rf /tmp/ynh-ns-tutorial
 
 ## Next
 
+[Tutorial 18: Sensors](tutorial/19-sensors.md) — declare observation surfaces a loop driver consumes.
+
 See [docs/namespacing.md](../namespacing.md) for the full canonical-id
 reference and [docs/migration.md](../migration.md) for a complete 0.1 → 0.2
 migration guide.

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -14,31 +14,33 @@ Progressive tutorials from first steps to advanced configurations. Each tutorial
 | 4 | [Hooks](tutorial/10-hooks.md) | Declare vendor-agnostic lifecycle hooks |
 | 5 | [MCP Servers](tutorial/11-mcp-servers.md) | Declare MCP server dependencies per harness |
 | 6 | [Profiles](tutorial/13-profiles.md) | Environment-specific overrides with profiles |
+| 7 | [Focus](tutorial/14-focus.md) | Bind a prompt and profile for repeatable, non-interactive runs |
+| 8 | [Project-Local Config](tutorial/15-project-local-config.md) | Zero-install `.ynh-plugin/plugin.json` in your project root |
 
 ### Refine
 
 | # | Tutorial | What you'll learn |
 |---|----------|-------------------|
-| 7 | [Developer Tools](tutorial/08-developer-tools.md) | Scaffold, lint, validate, format, compress, inspect with ynd |
-| 8 | [Developer Preview](tutorial/12-developer-preview.md) | Preview and diff assembled output across vendors |
-| 9 | [Include Editing](tutorial/17-include-editing.md) | Add, remove, and update includes in an installed harness |
+| 9 | [Developer Tools](tutorial/08-developer-tools.md) | Scaffold, lint, validate, format, compress, inspect with ynd |
+| 10 | [Developer Preview](tutorial/12-developer-preview.md) | Preview and diff assembled output across vendors |
 
 ### Automate
 
 | # | Tutorial | What you'll learn |
 |---|----------|-------------------|
-| 9 | [Structured Output](tutorial/16-structured-output.md) | Use `--format json` for scripts, CI, and tool integration |
+| 11 | [Structured Output](tutorial/16-structured-output.md) | Use `--format json` for scripts, CI, and tool integration |
 
 ### Share & Scale
 
 | # | Tutorial | What you'll learn |
 |---|----------|-------------------|
-| 10 | [Delegation](tutorial/04-delegation.md) | Chain harnesses together as subagents |
-| 11 | [Export](tutorial/05-export.md) | Produce vendor-native distributable plugins |
-| 12 | [Marketplace](tutorial/06-marketplace.md) | Generate marketplace indexes for team distribution |
-| 13 | [Registry & Discovery](tutorial/07-registry-and-discovery.md) | Search and install harnesses from curated registries |
-| 14 | [Docker Images](tutorial/09-docker-image.md) | Build harness appliance images for CI/CD |
-| 15 | [Sensors](tutorial/19-sensors.md) | Declare observation surfaces a loop driver consumes |
+| 12 | [Delegation](tutorial/04-delegation.md) | Chain harnesses together as subagents |
+| 13 | [Export](tutorial/05-export.md) | Produce vendor-native distributable plugins |
+| 14 | [Marketplace](tutorial/06-marketplace.md) | Generate marketplace indexes for team distribution |
+| 15 | [Registry & Discovery](tutorial/07-registry-and-discovery.md) | Search and install harnesses from curated registries |
+| 16 | [Docker Images](tutorial/09-docker-image.md) | Build harness appliance images for CI/CD |
+| 17 | [Namespacing & Migration](tutorial/18-namespacing-and-migration.md) | Resolve name collisions across registries and migrate legacy installs |
+| 18 | [Sensors](tutorial/19-sensors.md) | Declare observation surfaces a loop driver consumes |
 
 ## Manual Test Plan
 

--- a/docs/ynd.md
+++ b/docs/ynd.md
@@ -104,6 +104,7 @@ ynd preview ./my-harness                    # default: Claude vendor, stdout
 ynd preview ./my-harness -v cursor          # specific vendor
 ynd preview ./my-harness -v claude -o ./out # write to directory
 ynd preview ./my-harness --profile strict   # preview with a specific profile
+ynd preview ./my-harness --focus review     # preview with a focus (resolves to its profile)
 ynd preview --harness ./my-harness          # explicit harness flag
 ```
 
@@ -113,6 +114,7 @@ ynd preview --harness ./my-harness          # explicit harness flag
 | `-o, --output <dir>` | Write output to directory instead of stdout |
 | `--harness <dir>` | Harness source directory (alternative to positional arg) |
 | `--profile <name>` | Profile to apply during assembly |
+| `--focus <name>` | Focus to apply during assembly (mutually exclusive with `--profile`) |
 
 When no `-o` flag is given, preview prints a tree with file contents to stdout. With `-o`, it writes the full assembled output to the specified directory.
 
@@ -130,6 +132,7 @@ ynd diff ./my-harness claude cursor         # compare specific vendors (position
 ynd diff ./my-harness -v claude,cursor      # compare specific vendors (flag)
 ynd diff ./my-harness claude cursor codex   # three-way comparison
 ynd diff ./my-harness --profile strict      # diff with a specific profile applied
+ynd diff ./my-harness --focus review        # diff with a focus applied
 ynd diff --harness ./my-harness             # explicit harness flag
 ```
 
@@ -153,6 +156,7 @@ ynd export ./my-harness -o ./out                  # custom output directory
 ynd export ./my-harness --merged                  # single dir with dual manifests
 ynd export ./my-harness --clean                   # remove output dir before export
 ynd export ./my-harness --profile strict          # export with a specific profile applied
+ynd export ./my-harness --focus review            # export with a focus applied (mutex with --profile)
 ynd export --harness ./my-harness                 # explicit harness flag
 ynd export github.com/user/repo --path harnesses/david  # from a monorepo
 ```
@@ -285,7 +289,8 @@ See [Tutorial 11: Marketplace](tutorial/06-marketplace.md) for a guided walkthro
 | `--harness <dir>` | preview, diff, export, validate, lint, fmt | Harness source directory. Alternative to positional arg. Also honored via `YNH_HARNESS` env var. |
 | `--clean` | export, marketplace | Remove output directory before writing. |
 | `--merged` | export | Single output dir with dual vendor manifests. |
-| `--profile <name>` | preview, diff, export | Profile to apply during assembly. |
+| `--profile <name>` | preview, diff, export | Profile to apply during assembly. Also honored via `YNH_PROFILE`. |
+| `--focus <name>` | preview, diff, export | Focus to apply (resolves its bound profile). Mutually exclusive with `--profile`. Also honored via `YNH_FOCUS`. |
 | `--path <subdir>` | export | Subdirectory within source (for monorepos). Must be a relative path with no `..` traversal. |
 | `--restore` | compress | Restore a file from its latest backup. |
 | `--list-backups` | compress | Show backup history for a file. |


### PR DESCRIPTION
## Summary

Bring reference docs and the tutorial chain in line with PR #160 (focus + new `ynh focus/profile/hook/mcp` editing commands) and the current `_sidebar.md` ordering. Pure docs — no code changes.

### Blockers fixed
- `reference.md` — `YNH_FOCUS` env var, `--focus` on `ynh run` / `ynd preview|diff|export`, focus priority rule
- `ynd.md` — `--focus` documented in preview/diff/export sections and Common Options
- `tutorial/README.md` — sync table to `_sidebar.md` (adds Focus, Project-Local Config, Namespacing & Migration; renumbers Refine/Automate/Share)
- Tutorial "Next"-link chain — realigned every link to the new ordering (delegation→export, export→marketplace, marketplace→registry, registry→docker, docker→namespacing, namespacing→sensors, profiles→focus, focus→project-local-config, project-local-config→dev-tools, dev-tools→dev-preview)

### Polish
- New `docs/focus.md` reference page (format, selection, mutex with `--profile`, validation, CLI editing)
- `_sidebar.md` — Focus added to **Configure**
- `profiles.md` — cross-link Focus in **See Also**
- `README.md` — feature blurb mentions focuses and the CLI editing surface; tutorial count 13→18

## Test plan

- [x] `make check` green on this branch
- [ ] Spot-check rendered Docsify navigation locally / on Pages
- [ ] CI green on PR