### PR TITLE
test: expand unit coverage for 0.4.0 surface

### DIFF
--- a/internal/agent/loop_helpers_test.go
+++ b/internal/agent/loop_helpers_test.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/harness"
+)
+
+func TestDirOf(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/abs/path/file.txt", "/abs/path"},
+		{"rel/path/file", "rel/path"},
+		{"file", "."},
+		{"", "."},
+		{`win\path\file`, `win\path`},
+	}
+	for _, c := range cases {
+		if got := dirOf(c.in); got != c.want {
+			t.Errorf("dirOf(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestResolveYNHBinary_OverrideWins(t *testing.T) {
+	got, err := resolveYNHBinary("/custom/ynh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/custom/ynh" {
+		t.Errorf("expected /custom/ynh, got %q", got)
+	}
+}
+
+func TestResolveYNHBinary_FallsBackToExecutable(t *testing.T) {
+	got, err := resolveYNHBinary("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == "" {
+		t.Error("expected non-empty path")
+	}
+}
+
+func TestOpenTrajectory_Stdout(t *testing.T) {
+	var buf bytes.Buffer
+	w, cleanup, err := openTrajectory("-", &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if w == nil {
+		t.Fatal("expected non-nil writer")
+	}
+}
+
+func TestOpenTrajectory_File(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "traj.jsonl")
+	w, cleanup, err := openTrajectory(path, io.Discard)
+	if err != nil {
+		t.Fatalf("openTrajectory: %v", err)
+	}
+	defer cleanup()
+	if w == nil {
+		t.Fatal("expected non-nil writer")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file created: %v", err)
+	}
+}
+
+func TestOpenTrajectory_BadPath(t *testing.T) {
+	_, _, err := openTrajectory("/no/such/dir/traj.jsonl", io.Discard)
+	if err == nil {
+		t.Error("expected error opening file in nonexistent dir")
+	}
+}
+
+func TestNewSessionID_NonEmptyAndUnique(t *testing.T) {
+	a := newSessionID()
+	b := newSessionID()
+	if a == "" || b == "" {
+		t.Fatal("session id should be non-empty")
+	}
+	if a == b {
+		t.Errorf("session ids should be unique, got %q twice", a)
+	}
+	if len(a) != 16 {
+		t.Errorf("expected 16-char hex, got %d chars: %q", len(a), a)
+	}
+}
+
+func TestAssembleHarness_UnknownBackend(t *testing.T) {
+	h := &harness.Harness{Name: "x", Dir: t.TempDir()}
+	_, err := assembleHarness(h, "no-such-vendor")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "vendor") {
+		t.Errorf("error should mention vendor: %v", err)
+	}
+}
+
+// gitAutoCommit is FS- and exec-heavy but cheap to exercise end-to-end.
+func TestGitAutoCommit_NothingToCommit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "-C", dir, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	// Configure committer to avoid `commit` failing in CI environments.
+	_ = exec.Command("git", "-C", dir, "config", "user.email", "x@example.com").Run()
+	_ = exec.Command("git", "-C", dir, "config", "user.name", "x").Run()
+
+	// First call: nothing to commit → silently succeeds.
+	if err := gitAutoCommit(dir, 1); err != nil {
+		t.Errorf("expected nil on empty repo, got %v", err)
+	}
+}
+
+func TestGitAutoCommit_CommitsChanges(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "x@example.com"},
+		{"config", "user.name", "x"},
+	} {
+		if out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "f"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := gitAutoCommit(dir, 2); err != nil {
+		t.Fatalf("gitAutoCommit: %v", err)
+	}
+	// Verify a commit landed.
+	out, err := exec.Command("git", "-C", dir, "log", "--oneline").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log: %v: %s", err, out)
+	}
+	if !strings.Contains(string(out), "turn 2") {
+		t.Errorf("expected 'turn 2' in log, got: %s", out)
+	}
+}

--- a/internal/agent/wait_approval_test.go
+++ b/internal/agent/wait_approval_test.go
@@ -1,0 +1,81 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func newControlReaderFromString(s string) *ControlReader {
+	return NewControlReader(strings.NewReader(s))
+}
+
+func TestWaitForApproval_Approve(t *testing.T) {
+	cr := newControlReaderFromString(`{"action":"approve_turn"}` + "\n")
+	got, fb, aborted := waitForApproval(cr, ActionApproveTurn, ActionRejectPlan)
+	if got != ActionApproveTurn {
+		t.Errorf("action = %q, want %q", got, ActionApproveTurn)
+	}
+	if fb != "" {
+		t.Errorf("feedback = %q, want empty", fb)
+	}
+	if aborted {
+		t.Error("should not be aborted")
+	}
+}
+
+func TestWaitForApproval_ReplaceFeedback(t *testing.T) {
+	cr := newControlReaderFromString(`{"action":"replace_feedback","feedback":"do x"}` + "\n")
+	got, fb, aborted := waitForApproval(cr, ActionApproveTurn, ActionRejectPlan)
+	if got != ActionApproveTurn {
+		t.Errorf("replace_feedback should yield approve, got %q", got)
+	}
+	if fb != "do x" {
+		t.Errorf("feedback = %q, want do x", fb)
+	}
+	if aborted {
+		t.Error("should not be aborted")
+	}
+}
+
+func TestWaitForApproval_Reject(t *testing.T) {
+	cr := newControlReaderFromString(`{"action":"reject_plan"}` + "\n")
+	got, _, aborted := waitForApproval(cr, ActionApprovePlan, ActionRejectPlan)
+	if got != ActionRejectPlan {
+		t.Errorf("action = %q, want %q", got, ActionRejectPlan)
+	}
+	if aborted {
+		t.Error("reject is not abort")
+	}
+}
+
+func TestWaitForApproval_Interrupt(t *testing.T) {
+	cr := newControlReaderFromString(`{"action":"interrupt"}` + "\n")
+	got, _, aborted := waitForApproval(cr, ActionApproveTurn, ActionRejectPlan)
+	if got != ActionInterrupt {
+		t.Errorf("action = %q, want interrupt", got)
+	}
+	if !aborted {
+		t.Error("interrupt should be aborted=true")
+	}
+}
+
+func TestWaitForApproval_ChannelClosed(t *testing.T) {
+	cr := newControlReaderFromString("") // EOF immediately
+	got, _, aborted := waitForApproval(cr, ActionApproveTurn, ActionRejectPlan)
+	if got != ActionInterrupt {
+		t.Errorf("closed channel should yield interrupt, got %q", got)
+	}
+	if !aborted {
+		t.Error("EOF should be aborted=true")
+	}
+}
+
+func TestWaitForApproval_IgnoresUnrelated(t *testing.T) {
+	// Send an unrelated approve_plan first, then the expected approve_turn.
+	// The unrelated action falls through the switch and the loop continues.
+	cr := newControlReaderFromString(`{"action":"approve_plan"}` + "\n" + `{"action":"approve_turn"}` + "\n")
+	got, _, _ := waitForApproval(cr, ActionApproveTurn, ActionRejectPlan)
+	if got != ActionApproveTurn {
+		t.Errorf("expected to skip unrelated action, got %q", got)
+	}
+}

--- a/internal/harness/focus_profile_test.go
+++ b/internal/harness/focus_profile_test.go
@@ -1,0 +1,312 @@
+package harness
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// ---- AddFocus -------------------------------------------------------
+
+func TestAddFocus_New(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+
+	if err := AddFocus(dir, "review", "review changes", FocusAddOptions{}); err != nil {
+		t.Fatalf("AddFocus: %v", err)
+	}
+
+	hj, err := plugin.LoadPluginJSON(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, ok := hj.Focuses["review"]
+	if !ok {
+		t.Fatal("focus not persisted")
+	}
+	if f.Prompt != "review changes" {
+		t.Errorf("prompt = %q, want %q", f.Prompt, "review changes")
+	}
+	if f.Profile != "" {
+		t.Errorf("expected no profile binding, got %q", f.Profile)
+	}
+}
+
+func TestAddFocus_WithProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AddFocus(dir, "audit", "audit", FocusAddOptions{Profile: "ci"}); err != nil {
+		t.Fatalf("AddFocus: %v", err)
+	}
+
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if hj.Focuses["audit"].Profile != "ci" {
+		t.Errorf("profile = %q, want ci", hj.Focuses["audit"].Profile)
+	}
+}
+
+func TestAddFocus_EmptyName(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := AddFocus(dir, "", "p", FocusAddOptions{})
+	if err == nil || !strings.Contains(err.Error(), "name") {
+		t.Errorf("want name error, got %v", err)
+	}
+}
+
+func TestAddFocus_EmptyPrompt(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := AddFocus(dir, "x", "", FocusAddOptions{})
+	if err == nil || !strings.Contains(err.Error(), "prompt") {
+		t.Errorf("want prompt error, got %v", err)
+	}
+}
+
+func TestAddFocus_DuplicateErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddFocus(dir, "x", "p", FocusAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	err := AddFocus(dir, "x", "p2", FocusAddOptions{})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("want duplicate error, got %v", err)
+	}
+}
+
+func TestAddFocus_UnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := AddFocus(dir, "x", "p", FocusAddOptions{Profile: "nope"})
+	if err == nil || !strings.Contains(err.Error(), "unknown profile") {
+		t.Errorf("want unknown profile error, got %v", err)
+	}
+}
+
+// ---- RemoveFocus ----------------------------------------------------
+
+func TestRemoveFocus_Removes(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddFocus(dir, "x", "p", FocusAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemoveFocus(dir, "x"); err != nil {
+		t.Fatalf("RemoveFocus: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if len(hj.Focuses) != 0 {
+		t.Errorf("expected focuses cleared, got %v", hj.Focuses)
+	}
+}
+
+func TestRemoveFocus_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := RemoveFocus(dir, "ghost")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found error, got %v", err)
+	}
+}
+
+// ---- UpdateFocus ----------------------------------------------------
+
+func TestUpdateFocus_Prompt(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddFocus(dir, "x", "old", FocusAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	newp := "new prompt"
+	if err := UpdateFocus(dir, "x", FocusUpdateOptions{Prompt: &newp}); err != nil {
+		t.Fatalf("UpdateFocus: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if hj.Focuses["x"].Prompt != "new prompt" {
+		t.Errorf("prompt = %q, want %q", hj.Focuses["x"].Prompt, "new prompt")
+	}
+}
+
+func TestUpdateFocus_EmptyPromptRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddFocus(dir, "x", "old", FocusAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	empty := ""
+	err := UpdateFocus(dir, "x", FocusUpdateOptions{Prompt: &empty})
+	if err == nil || !strings.Contains(err.Error(), "prompt") {
+		t.Errorf("want empty-prompt error, got %v", err)
+	}
+}
+
+func TestUpdateFocus_ClearProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddFocus(dir, "x", "p", FocusAddOptions{Profile: "ci"}); err != nil {
+		t.Fatal(err)
+	}
+	empty := ""
+	if err := UpdateFocus(dir, "x", FocusUpdateOptions{Profile: &empty}); err != nil {
+		t.Fatalf("UpdateFocus: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if hj.Focuses["x"].Profile != "" {
+		t.Errorf("profile should be cleared, got %q", hj.Focuses["x"].Profile)
+	}
+}
+
+func TestUpdateFocus_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	prompt := "x"
+	err := UpdateFocus(dir, "ghost", FocusUpdateOptions{Prompt: &prompt})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+func TestUpdateFocus_UnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddFocus(dir, "x", "p", FocusAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	bad := "nope"
+	err := UpdateFocus(dir, "x", FocusUpdateOptions{Profile: &bad})
+	if err == nil || !strings.Contains(err.Error(), "unknown profile") {
+		t.Errorf("want unknown profile, got %v", err)
+	}
+}
+
+func TestUpdateFocus_OmittedFieldsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddFocus(dir, "x", "p", FocusAddOptions{Profile: "ci"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpdateFocus(dir, "x", FocusUpdateOptions{}); err != nil {
+		t.Fatalf("noop update: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if hj.Focuses["x"].Prompt != "p" || hj.Focuses["x"].Profile != "ci" {
+		t.Errorf("unexpected state: %+v", hj.Focuses["x"])
+	}
+}
+
+// ---- AddProfile / RemoveProfile -------------------------------------
+
+func TestAddProfile_New(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatalf("AddProfile: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if _, ok := hj.Profiles["ci"]; !ok {
+		t.Fatal("profile not persisted")
+	}
+}
+
+func TestAddProfile_EmptyName(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := AddProfile(dir, "")
+	if err == nil || !strings.Contains(err.Error(), "name") {
+		t.Errorf("want name error, got %v", err)
+	}
+}
+
+func TestAddProfile_DuplicateErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	err := AddProfile(dir, "ci")
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("want duplicate, got %v", err)
+	}
+}
+
+func TestRemoveProfile_Removes(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveProfile(dir, "ci"); err != nil {
+		t.Fatalf("RemoveProfile: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if len(hj.Profiles) != 0 {
+		t.Errorf("expected profiles cleared, got %v", hj.Profiles)
+	}
+}
+
+func TestRemoveProfile_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := RemoveProfile(dir, "ghost")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+func TestRemoveProfile_BlockedByFocus(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddFocus(dir, "blocker", "p", FocusAddOptions{Profile: "ci"}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RemoveProfile(dir, "ci")
+	if err == nil {
+		t.Fatal("expected error when focus references profile")
+	}
+	if !strings.Contains(err.Error(), "blocker") || !strings.Contains(err.Error(), "referenced") {
+		t.Errorf("error should mention referencing focus, got: %v", err)
+	}
+}
+
+func TestRemoveProfile_LastsBlockerListSorted(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range []string{"zeta", "alpha", "mu"} {
+		if err := AddFocus(dir, n, "p", FocusAddOptions{Profile: "ci"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	err := RemoveProfile(dir, "ci")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// alpha should appear before mu before zeta in the error
+	msg := err.Error()
+	ai := strings.Index(msg, "alpha")
+	mi := strings.Index(msg, "mu")
+	zi := strings.Index(msg, "zeta")
+	if ai < 0 || mi <= ai || zi <= mi {
+		t.Errorf("blockers not sorted alphabetically: %v", err)
+	}
+}

--- a/internal/harness/hook_editor_test.go
+++ b/internal/harness/hook_editor_test.go
@@ -1,0 +1,223 @@
+package harness
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+// ---- AddHook / RemoveHook (harness-level) ---------------------------
+
+func TestAddHook_New(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+
+	if err := AddHook(dir, "before_tool", "./guard.sh", HookAddOptions{Matcher: "Write"}); err != nil {
+		t.Fatalf("AddHook: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if len(hj.Hooks["before_tool"]) != 1 {
+		t.Fatalf("expected 1 hook, got %d", len(hj.Hooks["before_tool"]))
+	}
+	got := hj.Hooks["before_tool"][0]
+	if got.Command != "./guard.sh" || got.Matcher != "Write" {
+		t.Errorf("unexpected entry: %+v", got)
+	}
+}
+
+func TestAddHook_Appends(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddHook(dir, "before_tool", "a", HookAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddHook(dir, "before_tool", "b", HookAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if len(hj.Hooks["before_tool"]) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(hj.Hooks["before_tool"]))
+	}
+}
+
+func TestAddHook_UnknownEvent(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := AddHook(dir, "bogus_event", "cmd", HookAddOptions{})
+	if err == nil || !strings.Contains(err.Error(), "unknown hook event") {
+		t.Errorf("want unknown event, got %v", err)
+	}
+}
+
+func TestAddHook_EmptyCommand(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := AddHook(dir, "before_tool", "", HookAddOptions{})
+	if err == nil || !strings.Contains(err.Error(), "command") {
+		t.Errorf("want empty-command error, got %v", err)
+	}
+}
+
+func TestRemoveHook_RemovesEntry(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddHook(dir, "before_tool", "a", HookAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddHook(dir, "before_tool", "b", HookAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveHook(dir, "before_tool", 0); err != nil {
+		t.Fatalf("RemoveHook: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if len(hj.Hooks["before_tool"]) != 1 || hj.Hooks["before_tool"][0].Command != "b" {
+		t.Errorf("expected only 'b' remaining, got %+v", hj.Hooks["before_tool"])
+	}
+}
+
+func TestRemoveHook_DropsEmptyEventKey(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddHook(dir, "before_tool", "only", HookAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveHook(dir, "before_tool", 0); err != nil {
+		t.Fatal(err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if _, ok := hj.Hooks["before_tool"]; ok {
+		t.Errorf("event key should be deleted when no entries remain")
+	}
+	if hj.Hooks != nil {
+		t.Errorf("Hooks should be nil after last entry removed, got %v", hj.Hooks)
+	}
+}
+
+func TestRemoveHook_EventNotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := RemoveHook(dir, "before_tool", 0)
+	if err == nil || !strings.Contains(err.Error(), "no hooks") {
+		t.Errorf("want no-hooks error, got %v", err)
+	}
+}
+
+func TestRemoveHook_IndexOutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddHook(dir, "before_tool", "a", HookAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	err := RemoveHook(dir, "before_tool", 5)
+	if err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("want range error, got %v", err)
+	}
+}
+
+// ---- AddProfileHook / RemoveProfileHook -----------------------------
+
+func TestAddProfileHook_New(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileHook(dir, "ci", "before_tool", "lint", HookAddOptions{Matcher: "*"}); err != nil {
+		t.Fatalf("AddProfileHook: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	p := hj.Profiles["ci"]
+	if len(p.Hooks["before_tool"]) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(p.Hooks["before_tool"]))
+	}
+}
+
+func TestAddProfileHook_UnknownEvent(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	err := AddProfileHook(dir, "ci", "bogus", "x", HookAddOptions{})
+	if err == nil || !strings.Contains(err.Error(), "unknown hook event") {
+		t.Errorf("want unknown event, got %v", err)
+	}
+}
+
+func TestAddProfileHook_EmptyCommand(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	err := AddProfileHook(dir, "ci", "before_tool", "", HookAddOptions{})
+	if err == nil || !strings.Contains(err.Error(), "command") {
+		t.Errorf("want empty-command, got %v", err)
+	}
+}
+
+func TestAddProfileHook_UnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := AddProfileHook(dir, "ghost", "before_tool", "x", HookAddOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want profile not-found, got %v", err)
+	}
+}
+
+func TestRemoveProfileHook_DropsEmptyKey(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileHook(dir, "ci", "before_tool", "x", HookAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveProfileHook(dir, "ci", "before_tool", 0); err != nil {
+		t.Fatalf("RemoveProfileHook: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	p := hj.Profiles["ci"]
+	if _, ok := p.Hooks["before_tool"]; ok {
+		t.Errorf("event key should be cleared")
+	}
+}
+
+func TestRemoveProfileHook_UnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := RemoveProfileHook(dir, "ghost", "before_tool", 0)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+func TestRemoveProfileHook_NoHooksForEvent(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	err := RemoveProfileHook(dir, "ci", "before_tool", 0)
+	if err == nil || !strings.Contains(err.Error(), "no hooks") {
+		t.Errorf("want no-hooks, got %v", err)
+	}
+}
+
+func TestRemoveProfileHook_IndexOutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileHook(dir, "ci", "before_tool", "x", HookAddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	err := RemoveProfileHook(dir, "ci", "before_tool", 9)
+	if err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("want range error, got %v", err)
+	}
+}

--- a/internal/harness/mcp_editor_test.go
+++ b/internal/harness/mcp_editor_test.go
@@ -1,0 +1,405 @@
+package harness
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+// ---- AddMCP (harness-level) -----------------------------------------
+
+func TestAddMCP_Command(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+
+	opts := MCPAddOptions{
+		Command: "gh-mcp",
+		Args:    []string{"serve"},
+		Env:     map[string]string{"K": "V"},
+	}
+	if err := AddMCP(dir, "github", opts); err != nil {
+		t.Fatalf("AddMCP: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	srv := hj.MCPServers["github"]
+	if srv.Command != "gh-mcp" || len(srv.Args) != 1 || srv.Args[0] != "serve" || srv.Env["K"] != "V" {
+		t.Errorf("unexpected server: %+v", srv)
+	}
+}
+
+func TestAddMCP_URL(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddMCP(dir, "remote", MCPAddOptions{URL: "https://x", Headers: map[string]string{"H": "1"}}); err != nil {
+		t.Fatalf("AddMCP: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if hj.MCPServers["remote"].URL != "https://x" {
+		t.Errorf("URL not persisted: %+v", hj.MCPServers["remote"])
+	}
+}
+
+func TestAddMCP_EmptyName(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := AddMCP(dir, "", MCPAddOptions{Command: "x"})
+	if err == nil || !strings.Contains(err.Error(), "name") {
+		t.Errorf("want name error, got %v", err)
+	}
+}
+
+func TestAddMCP_NeitherCommandNorURL(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := AddMCP(dir, "s", MCPAddOptions{})
+	if err == nil || !strings.Contains(err.Error(), "command") {
+		t.Errorf("want missing command/url, got %v", err)
+	}
+}
+
+func TestAddMCP_BothCommandAndURL(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := AddMCP(dir, "s", MCPAddOptions{Command: "x", URL: "y"})
+	if err == nil || !strings.Contains(err.Error(), "both") {
+		t.Errorf("want both error, got %v", err)
+	}
+}
+
+func TestAddMCP_Duplicate(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddMCP(dir, "s", MCPAddOptions{Command: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	err := AddMCP(dir, "s", MCPAddOptions{Command: "y"})
+	if err == nil || !strings.Contains(err.Error(), "already present") {
+		t.Errorf("want duplicate error, got %v", err)
+	}
+}
+
+// ---- RemoveMCP ------------------------------------------------------
+
+func TestRemoveMCP_Removes(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddMCP(dir, "s", MCPAddOptions{Command: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveMCP(dir, "s"); err != nil {
+		t.Fatalf("RemoveMCP: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if len(hj.MCPServers) != 0 {
+		t.Errorf("expected mcp_servers cleared, got %v", hj.MCPServers)
+	}
+}
+
+func TestRemoveMCP_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := RemoveMCP(dir, "ghost")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+// ---- UpdateMCP ------------------------------------------------------
+
+func TestUpdateMCP_Command(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddMCP(dir, "s", MCPAddOptions{Command: "old"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpdateMCP(dir, "s", MCPUpdateOptions{Command: ptr("new")}); err != nil {
+		t.Fatalf("UpdateMCP: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if hj.MCPServers["s"].Command != "new" {
+		t.Errorf("command = %q, want new", hj.MCPServers["s"].Command)
+	}
+}
+
+func TestUpdateMCP_ClearArgs(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddMCP(dir, "s", MCPAddOptions{Command: "x", Args: []string{"a", "b"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpdateMCP(dir, "s", MCPUpdateOptions{SetArgs: true, Args: nil}); err != nil {
+		t.Fatalf("UpdateMCP: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	if len(hj.MCPServers["s"].Args) != 0 {
+		t.Errorf("expected args cleared, got %v", hj.MCPServers["s"].Args)
+	}
+}
+
+func TestUpdateMCP_NoFlags(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddMCP(dir, "s", MCPAddOptions{Command: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	err := UpdateMCP(dir, "s", MCPUpdateOptions{})
+	if err == nil || !strings.Contains(err.Error(), "at least one flag") {
+		t.Errorf("want no-flags error, got %v", err)
+	}
+}
+
+func TestUpdateMCP_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := UpdateMCP(dir, "ghost", MCPUpdateOptions{Command: ptr("x")})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+func TestUpdateMCP_LeavesNeitherCommandNorURL(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddMCP(dir, "s", MCPAddOptions{Command: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	err := UpdateMCP(dir, "s", MCPUpdateOptions{Command: ptr("")})
+	if err == nil || !strings.Contains(err.Error(), "either command or url") {
+		t.Errorf("want command-or-url error, got %v", err)
+	}
+}
+
+func TestUpdateMCP_SetsBothCommandAndURL(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddMCP(dir, "s", MCPAddOptions{Command: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	err := UpdateMCP(dir, "s", MCPUpdateOptions{URL: ptr("https://y")})
+	if err == nil || !strings.Contains(err.Error(), "cannot have both") {
+		t.Errorf("want both-set error, got %v", err)
+	}
+}
+
+// ---- AddProfileMCP / RemoveProfileMCP / UpdateProfileMCP -----------
+
+func TestAddProfileMCP_Command(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileMCP(dir, "ci", "s", ProfileMCPAddOptions{Command: "cmd"}); err != nil {
+		t.Fatalf("AddProfileMCP: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	p := hj.Profiles["ci"]
+	if p.MCPServers["s"] == nil || p.MCPServers["s"].Command != "cmd" {
+		t.Errorf("unexpected: %+v", p.MCPServers)
+	}
+}
+
+func TestAddProfileMCP_Null(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileMCP(dir, "ci", "s", ProfileMCPAddOptions{Null: true}); err != nil {
+		t.Fatalf("AddProfileMCP null: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	p := hj.Profiles["ci"]
+	srv, ok := p.MCPServers["s"]
+	if !ok {
+		t.Fatal("null entry not present")
+	}
+	if srv != nil {
+		t.Errorf("expected nil entry (null), got %+v", srv)
+	}
+}
+
+func TestAddProfileMCP_NullRejectsCommand(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	err := AddProfileMCP(dir, "ci", "s", ProfileMCPAddOptions{Null: true, Command: "x"})
+	if err == nil || !strings.Contains(err.Error(), "--null") {
+		t.Errorf("want null+command error, got %v", err)
+	}
+}
+
+func TestAddProfileMCP_RequiresOne(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	err := AddProfileMCP(dir, "ci", "s", ProfileMCPAddOptions{})
+	if err == nil || !strings.Contains(err.Error(), "command") {
+		t.Errorf("want missing-one error, got %v", err)
+	}
+}
+
+func TestAddProfileMCP_BothCommandAndURL(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	err := AddProfileMCP(dir, "ci", "s", ProfileMCPAddOptions{Command: "x", URL: "y"})
+	if err == nil || !strings.Contains(err.Error(), "both") {
+		t.Errorf("want both error, got %v", err)
+	}
+}
+
+func TestAddProfileMCP_EmptyName(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	err := AddProfileMCP(dir, "ci", "", ProfileMCPAddOptions{Command: "x"})
+	if err == nil || !strings.Contains(err.Error(), "name") {
+		t.Errorf("want name error, got %v", err)
+	}
+}
+
+func TestAddProfileMCP_UnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := AddProfileMCP(dir, "ghost", "s", ProfileMCPAddOptions{Command: "x"})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+func TestAddProfileMCP_Duplicate(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileMCP(dir, "ci", "s", ProfileMCPAddOptions{Command: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	err := AddProfileMCP(dir, "ci", "s", ProfileMCPAddOptions{Command: "y"})
+	if err == nil || !strings.Contains(err.Error(), "already present") {
+		t.Errorf("want duplicate, got %v", err)
+	}
+}
+
+func TestRemoveProfileMCP_Removes(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileMCP(dir, "ci", "s", ProfileMCPAddOptions{Command: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveProfileMCP(dir, "ci", "s"); err != nil {
+		t.Fatalf("RemoveProfileMCP: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	p := hj.Profiles["ci"]
+	if len(p.MCPServers) != 0 {
+		t.Errorf("expected cleared, got %v", p.MCPServers)
+	}
+}
+
+func TestRemoveProfileMCP_UnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := RemoveProfileMCP(dir, "ghost", "s")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+func TestRemoveProfileMCP_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	err := RemoveProfileMCP(dir, "ci", "ghost")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+func TestUpdateProfileMCP_Command(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileMCP(dir, "ci", "s", ProfileMCPAddOptions{Command: "old"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpdateProfileMCP(dir, "ci", "s", MCPUpdateOptions{Command: ptr("new")}); err != nil {
+		t.Fatalf("UpdateProfileMCP: %v", err)
+	}
+	hj, _ := plugin.LoadPluginJSON(dir)
+	p := hj.Profiles["ci"]
+	if p.MCPServers["s"].Command != "new" {
+		t.Errorf("command = %q, want new", p.MCPServers["s"].Command)
+	}
+}
+
+func TestUpdateProfileMCP_NoFlags(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileMCP(dir, "ci", "s", ProfileMCPAddOptions{Command: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	err := UpdateProfileMCP(dir, "ci", "s", MCPUpdateOptions{})
+	if err == nil || !strings.Contains(err.Error(), "at least one flag") {
+		t.Errorf("want no-flags, got %v", err)
+	}
+}
+
+func TestUpdateProfileMCP_UnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := UpdateProfileMCP(dir, "ghost", "s", MCPUpdateOptions{Command: ptr("x")})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+func TestUpdateProfileMCP_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	err := UpdateProfileMCP(dir, "ci", "ghost", MCPUpdateOptions{Command: ptr("x")})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+func TestUpdateProfileMCP_NullEntryRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileMCP(dir, "ci", "s", ProfileMCPAddOptions{Null: true}); err != nil {
+		t.Fatal(err)
+	}
+	err := UpdateProfileMCP(dir, "ci", "s", MCPUpdateOptions{Command: ptr("x")})
+	if err == nil || !strings.Contains(err.Error(), "null entry") {
+		t.Errorf("want null-entry error, got %v", err)
+	}
+}

--- a/internal/harness/names_test.go
+++ b/internal/harness/names_test.go
@@ -1,0 +1,143 @@
+package harness
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+func TestIsValidName(t *testing.T) {
+	cases := []struct {
+		name string
+		ok   bool
+	}{
+		{"simple", true},
+		{"with-dash", true},
+		{"with.dot", true},
+		{"with_underscore", true},
+		{"123-numeric-start", true},
+		{"a", true},
+		{"", false},
+		{"-leading-dash", false},
+		{".leading-dot", false},
+		{"_leading-underscore", false},
+		{"has space", false},
+		{"has/slash", false},
+		{"has@at", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsValidName(c.name); got != c.ok {
+				t.Errorf("IsValidName(%q) = %v, want %v", c.name, got, c.ok)
+			}
+		})
+	}
+}
+
+func TestValidNamePattern(t *testing.T) {
+	p := ValidNamePattern()
+	if p == "" {
+		t.Fatal("expected non-empty pattern")
+	}
+	if !strings.Contains(p, "a-z") {
+		t.Errorf("pattern does not look like a regex: %q", p)
+	}
+}
+
+func TestBadRefError(t *testing.T) {
+	err := BadRefError("")
+	if err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Errorf("empty ref: want 'missing' error, got %v", err)
+	}
+	err = BadRefError("garbage")
+	if err == nil || !strings.Contains(err.Error(), "canonical id") {
+		t.Errorf("garbage ref: want canonical-id hint, got %v", err)
+	}
+}
+
+func TestLoadQualified_BadRef(t *testing.T) {
+	_, err := LoadQualified("not-a-canonical-id")
+	if err == nil || !strings.Contains(err.Error(), "canonical id") {
+		t.Errorf("want canonical-id error, got %v", err)
+	}
+}
+
+func TestLoadQualified_NotInstalled(t *testing.T) {
+	overrideHarnessesDir(t)
+	_, err := LoadQualified("local/missing")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestLoadNS_NotFound(t *testing.T) {
+	overrideHarnessesDir(t)
+	_, err := LoadNS("github.com--acme", "missing")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestInstalledDirNS_NamespacedDir_Match(t *testing.T) {
+	a := InstalledDirNS("github.com/acme/x", "foo")
+	b := NamespacedDir("github.com/acme/x", "foo")
+	if a != b {
+		t.Errorf("InstalledDirNS != NamespacedDir: %q vs %q", a, b)
+	}
+}
+
+func TestInstalledDirNS_UsesFSName(t *testing.T) {
+	got := InstalledDirNS("github.com/acme/x", "foo")
+	// Slashes in namespace are flattened to "--" for filesystem safety.
+	if strings.Contains(filepath.Base(filepath.Dir(got)), "/") {
+		t.Errorf("namespace not sanitized for filesystem: %q", got)
+	}
+	if filepath.Base(got) != "foo" {
+		t.Errorf("expected name as last segment, got %q", got)
+	}
+}
+
+func TestLoadFile_LoadsLegacyManifest(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".harness.json")
+	// Write a minimal legacy manifest (LoadHarnessFile reads a single file form).
+	hj := &plugin.HarnessJSON{
+		Name:          "legacy",
+		Version:       "0.1.0",
+		Description:   "test",
+		DefaultVendor: "claude",
+	}
+	data, err := json.MarshalIndent(hj, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	if got.Name != "legacy" || got.DefaultVendor != "claude" {
+		t.Errorf("unexpected harness: %+v", got)
+	}
+}
+
+func TestLoadFile_FileNotFound(t *testing.T) {
+	_, err := LoadFile(filepath.Join(t.TempDir(), "no-such.json"))
+	if err == nil {
+		t.Fatal("expected error reading missing file")
+	}
+}

--- a/internal/harness/pointer_remove_test.go
+++ b/internal/harness/pointer_remove_test.go
@@ -1,0 +1,38 @@
+package harness
+
+import (
+	"os"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+func TestRemovePointerByID_RemovesExisting(t *testing.T) {
+	overrideHarnessesDir(t)
+	id := "local/h"
+	ptr := &Pointer{
+		ID:            id,
+		Name:          "h",
+		InstalledJSON: plugin.InstalledJSON{SourceType: "local", Source: "/some/path"},
+	}
+	if err := SavePointerByID(ptr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(PointerPathByID(id)); err != nil {
+		t.Fatalf("pointer should exist before remove: %v", err)
+	}
+
+	if err := RemovePointerByID(id); err != nil {
+		t.Fatalf("RemovePointerByID: %v", err)
+	}
+	if _, err := os.Stat(PointerPathByID(id)); !os.IsNotExist(err) {
+		t.Errorf("pointer should be gone after remove, got: %v", err)
+	}
+}
+
+func TestRemovePointerByID_MissingIsNoop(t *testing.T) {
+	overrideHarnessesDir(t)
+	if err := RemovePointerByID("local/never-existed"); err != nil {
+		t.Errorf("removing missing pointer should be no-op, got: %v", err)
+	}
+}

--- a/internal/harness/profile_include_editor_test.go
+++ b/internal/harness/profile_include_editor_test.go
@@ -1,0 +1,216 @@
+package harness
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+func loadProfileIncludes(t *testing.T, dir, profile string) []plugin.IncludeMeta {
+	t.Helper()
+	hj, err := plugin.LoadPluginJSON(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hj.Profiles[profile].Includes
+}
+
+// ---- AddProfileInclude ----------------------------------------------
+
+func TestAddProfileInclude_New(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AddProfileInclude(dir, "ci", "github.com/acme/x", AddOptions{Ref: "v1"}); err != nil {
+		t.Fatalf("AddProfileInclude: %v", err)
+	}
+	incs := loadProfileIncludes(t, dir, "ci")
+	if len(incs) != 1 || incs[0].Git != "github.com/acme/x" || incs[0].Ref != "v1" {
+		t.Errorf("unexpected: %+v", incs)
+	}
+}
+
+func TestAddProfileInclude_DuplicateErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileInclude(dir, "ci", "github.com/x", AddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	err := AddProfileInclude(dir, "ci", "github.com/x", AddOptions{})
+	if err == nil || !strings.Contains(err.Error(), "already present") {
+		t.Errorf("want duplicate, got %v", err)
+	}
+}
+
+func TestAddProfileInclude_Replace(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileInclude(dir, "ci", "github.com/x", AddOptions{Ref: "v1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileInclude(dir, "ci", "github.com/x", AddOptions{Ref: "v2", Replace: true}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	incs := loadProfileIncludes(t, dir, "ci")
+	if len(incs) != 1 || incs[0].Ref != "v2" {
+		t.Errorf("expected single v2, got %+v", incs)
+	}
+}
+
+func TestAddProfileInclude_UnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := AddProfileInclude(dir, "ghost", "github.com/x", AddOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+// ---- RemoveProfileInclude -------------------------------------------
+
+func TestRemoveProfileInclude_Removes(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileInclude(dir, "ci", "github.com/x", AddOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemoveProfileInclude(dir, "ci", "github.com/x", RemoveOptions{}); err != nil {
+		t.Fatalf("RemoveProfileInclude: %v", err)
+	}
+	if incs := loadProfileIncludes(t, dir, "ci"); len(incs) != 0 {
+		t.Errorf("expected empty, got %+v", incs)
+	}
+}
+
+func TestRemoveProfileInclude_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	err := RemoveProfileInclude(dir, "ci", "github.com/missing", RemoveOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+func TestRemoveProfileInclude_AmbiguousRequiresPath(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileInclude(dir, "ci", "github.com/x", AddOptions{Path: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileInclude(dir, "ci", "github.com/x", AddOptions{Path: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	err := RemoveProfileInclude(dir, "ci", "github.com/x", RemoveOptions{})
+	if err == nil || !strings.Contains(err.Error(), "matches multiple") {
+		t.Errorf("want disambiguation error, got %v", err)
+	}
+}
+
+func TestRemoveProfileInclude_WithPath(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileInclude(dir, "ci", "github.com/x", AddOptions{Path: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileInclude(dir, "ci", "github.com/x", AddOptions{Path: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveProfileInclude(dir, "ci", "github.com/x", RemoveOptions{Path: "a"}); err != nil {
+		t.Fatalf("RemoveProfileInclude: %v", err)
+	}
+	incs := loadProfileIncludes(t, dir, "ci")
+	if len(incs) != 1 || incs[0].Path != "b" {
+		t.Errorf("expected only path=b remaining, got %+v", incs)
+	}
+}
+
+func TestRemoveProfileInclude_UnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := RemoveProfileInclude(dir, "ghost", "github.com/x", RemoveOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+// ---- UpdateProfileInclude / FindProfileIncludeUpdateTarget ----------
+
+func TestUpdateProfileInclude_Ref(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileInclude(dir, "ci", "github.com/x", AddOptions{Ref: "v1"}); err != nil {
+		t.Fatal(err)
+	}
+	newRef := "v2"
+	if err := UpdateProfileInclude(dir, "ci", "github.com/x", UpdateOptions{Ref: &newRef}); err != nil {
+		t.Fatalf("UpdateProfileInclude: %v", err)
+	}
+	incs := loadProfileIncludes(t, dir, "ci")
+	if incs[0].Ref != "v2" {
+		t.Errorf("ref = %q, want v2", incs[0].Ref)
+	}
+}
+
+func TestUpdateProfileInclude_UnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	err := UpdateProfileInclude(dir, "ghost", "github.com/x", UpdateOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}
+
+func TestFindProfileIncludeUpdateTarget_ComputesFinalState(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	if err := AddProfile(dir, "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProfileInclude(dir, "ci", "github.com/x", AddOptions{Path: "old", Ref: "v1"}); err != nil {
+		t.Fatal(err)
+	}
+	newPath := "new"
+	newRef := "v2"
+	got, err := FindProfileIncludeUpdateTarget(dir, "ci", "github.com/x", UpdateOptions{NewPath: &newPath, Ref: &newRef})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if got.Path != "new" || got.Ref != "v2" {
+		t.Errorf("unexpected final state: %+v", got)
+	}
+}
+
+func TestFindProfileIncludeUpdateTarget_UnknownProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	_, err := FindProfileIncludeUpdateTarget(dir, "ghost", "github.com/x", UpdateOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found, got %v", err)
+	}
+}

--- a/internal/harness/topology_test.go
+++ b/internal/harness/topology_test.go
@@ -1,0 +1,155 @@
+package harness
+
+import (
+	"testing"
+
+	"github.com/eyelock/ynh/internal/plugin"
+)
+
+func TestIsLocalSource_Nil(t *testing.T) {
+	if IsLocalSource(nil) {
+		t.Error("nil record should not be local")
+	}
+}
+
+func TestIsLocalSource_EmptySource(t *testing.T) {
+	ins := &plugin.InstalledJSON{SourceType: "local", Source: ""}
+	if IsLocalSource(ins) {
+		t.Error("empty Source should not be classified local")
+	}
+}
+
+func TestIsLocalSource_Local(t *testing.T) {
+	ins := &plugin.InstalledJSON{SourceType: "local", Source: "/some/path"}
+	if !IsLocalSource(ins) {
+		t.Error("source_type=local with Source should be local")
+	}
+}
+
+func TestIsLocalSource_Source(t *testing.T) {
+	ins := &plugin.InstalledJSON{SourceType: "source", Source: "/some/path"}
+	if !IsLocalSource(ins) {
+		t.Error("source_type=source with Source should be local")
+	}
+}
+
+func TestIsLocalSource_Git(t *testing.T) {
+	ins := &plugin.InstalledJSON{SourceType: "git", Source: "github.com/x"}
+	if IsLocalSource(ins) {
+		t.Error("source_type=git should not be local")
+	}
+}
+
+func TestIsLocalSource_Registry(t *testing.T) {
+	ins := &plugin.InstalledJSON{SourceType: "registry", Source: "x"}
+	if IsLocalSource(ins) {
+		t.Error("source_type=registry should not be local")
+	}
+}
+
+func TestLoadInstalledRecord_FromPointer(t *testing.T) {
+	overrideHarnessesDir(t)
+	id := "local/h"
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	ptr := &Pointer{
+		ID:            id,
+		Name:          "h",
+		InstalledJSON: plugin.InstalledJSON{SourceType: "local", Source: dir},
+	}
+	if err := SavePointerByID(ptr); err != nil {
+		t.Fatal(err)
+	}
+	h := &Harness{Dir: dir, Name: "h"}
+
+	got, err := LoadInstalledRecord(id, h)
+	if err != nil {
+		t.Fatalf("LoadInstalledRecord: %v", err)
+	}
+	if got == nil || got.SourceType != "local" || got.Source != dir {
+		t.Errorf("unexpected: %+v", got)
+	}
+}
+
+func TestLoadInstalledRecord_FromDisk(t *testing.T) {
+	overrideHarnessesDir(t)
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	ins := &plugin.InstalledJSON{SourceType: "git", Source: "github.com/x"}
+	if err := plugin.SaveInstalledJSON(dir, ins); err != nil {
+		t.Fatal(err)
+	}
+	h := &Harness{Dir: dir, Name: "h"}
+
+	got, err := LoadInstalledRecord("github.com/x/h", h)
+	if err != nil {
+		t.Fatalf("LoadInstalledRecord: %v", err)
+	}
+	if got == nil || got.SourceType != "git" {
+		t.Errorf("unexpected: %+v", got)
+	}
+}
+
+func TestLoadInstalledRecord_NoRecord(t *testing.T) {
+	overrideHarnessesDir(t)
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	h := &Harness{Dir: dir, Name: "h"}
+
+	got, err := LoadInstalledRecord("github.com/x/h", h)
+	if err != nil {
+		t.Fatalf("LoadInstalledRecord: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil record, got %+v", got)
+	}
+}
+
+func TestSaveInstalledRecord_PointerForm(t *testing.T) {
+	overrideHarnessesDir(t)
+	id := "local/h"
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	ptr := &Pointer{
+		ID:            id,
+		Name:          "h",
+		InstalledJSON: plugin.InstalledJSON{SourceType: "local", Source: dir},
+	}
+	if err := SavePointerByID(ptr); err != nil {
+		t.Fatal(err)
+	}
+	h := &Harness{Dir: dir, Name: "h"}
+
+	updated := &plugin.InstalledJSON{SourceType: "local", Source: dir, Ref: "v2"}
+	if err := SaveInstalledRecord(id, h, updated); err != nil {
+		t.Fatalf("SaveInstalledRecord: %v", err)
+	}
+
+	reread, err := LoadPointerByID(id)
+	if err != nil || reread == nil {
+		t.Fatalf("reread pointer: %v / %v", err, reread)
+	}
+	if reread.Ref != "v2" {
+		t.Errorf("ref not persisted in pointer: %+v", reread)
+	}
+}
+
+func TestSaveInstalledRecord_TreeForm(t *testing.T) {
+	overrideHarnessesDir(t)
+	dir := t.TempDir()
+	writeTestHarness(t, dir, "h")
+	h := &Harness{Dir: dir, Name: "h"}
+
+	ins := &plugin.InstalledJSON{SourceType: "git", Source: "github.com/x", Ref: "v3"}
+	if err := SaveInstalledRecord("github.com/x/h", h, ins); err != nil {
+		t.Fatalf("SaveInstalledRecord: %v", err)
+	}
+
+	reread, err := plugin.LoadInstalledJSON(dir)
+	if err != nil {
+		t.Fatalf("LoadInstalledJSON: %v", err)
+	}
+	if reread.Ref != "v3" {
+		t.Errorf("ref not persisted on disk: %+v", reread)
+	}
+}

--- a/internal/vendor/helpers_test.go
+++ b/internal/vendor/helpers_test.go
@@ -1,0 +1,63 @@
+package vendor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDirHasContent_NonExistent(t *testing.T) {
+	if dirHasContent(filepath.Join(t.TempDir(), "no-such")) {
+		t.Error("non-existent dir reported as has content")
+	}
+}
+
+func TestDirHasContent_Empty(t *testing.T) {
+	dir := t.TempDir()
+	if dirHasContent(dir) {
+		t.Error("empty dir reported as has content")
+	}
+}
+
+func TestDirHasContent_WithFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !dirHasContent(dir) {
+		t.Error("dir with file reported as empty")
+	}
+}
+
+func TestDirHasContent_WithSubdir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !dirHasContent(dir) {
+		t.Error("dir with subdir reported as empty")
+	}
+}
+
+func TestFileExists_Missing(t *testing.T) {
+	if fileExists(filepath.Join(t.TempDir(), "no-such")) {
+		t.Error("missing file reported as existing")
+	}
+}
+
+func TestFileExists_RegularFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f")
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !fileExists(p) {
+		t.Error("file reported missing")
+	}
+}
+
+func TestFileExists_Directory(t *testing.T) {
+	if fileExists(t.TempDir()) {
+		t.Error("directory should not be reported as a regular file")
+	}
+}

--- a/internal/vendor/symlinks_plan_test.go
+++ b/internal/vendor/symlinks_plan_test.go
@@ -1,0 +1,95 @@
+package vendor
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestPlanSymlinks_EmptyArtifactDirs(t *testing.T) {
+	staging := t.TempDir()
+	project := t.TempDir()
+
+	entries, err := PlanSymlinks(staging, project, ".claude", map[string]string{})
+	if err != nil {
+		t.Fatalf("PlanSymlinks: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected no entries, got %d", len(entries))
+	}
+}
+
+func TestPlanSymlinks_MissingStagingArtifactDir(t *testing.T) {
+	staging := t.TempDir()
+	project := t.TempDir()
+
+	entries, err := PlanSymlinks(staging, project, ".claude", map[string]string{"skills": "skills"})
+	if err != nil {
+		t.Fatalf("PlanSymlinks: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("missing staging artifact dir should produce no entries, got %d", len(entries))
+	}
+}
+
+func TestPlanSymlinks_PlansFilesAndSubdirs(t *testing.T) {
+	staging := t.TempDir()
+	project := t.TempDir()
+	configDir := ".claude"
+
+	// staging/.claude/skills/{review,format}
+	skillsDir := filepath.Join(staging, configDir, "skills")
+	if err := os.MkdirAll(filepath.Join(skillsDir, "review"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(skillsDir, "format"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// staging/.claude/agents/reviewer.md
+	agentsDir := filepath.Join(staging, configDir, "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "reviewer.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	artifactDirs := map[string]string{"skills": "skills", "agents": "agents"}
+	entries, err := PlanSymlinks(staging, project, configDir, artifactDirs)
+	if err != nil {
+		t.Fatalf("PlanSymlinks: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries (review, format, reviewer.md), got %d: %+v", len(entries), entries)
+	}
+
+	// Sort for deterministic assertions
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Link < entries[j].Link })
+
+	for _, e := range entries {
+		if !filepathHasPrefix(e.Target, staging) {
+			t.Errorf("target should live under staging: %q", e.Target)
+		}
+		if !filepathHasPrefix(e.Link, project) {
+			t.Errorf("link should live under project: %q", e.Link)
+		}
+	}
+}
+
+func filepathHasPrefix(p, prefix string) bool {
+	abs, _ := filepath.Abs(p)
+	pa, _ := filepath.Abs(prefix)
+	rel, err := filepath.Rel(pa, abs)
+	if err != nil {
+		return false
+	}
+	return len(rel) > 0 && rel != ".." && !filepathHasDotDot(rel)
+}
+
+func filepathHasDotDot(rel string) bool {
+	if len(rel) >= 3 && rel[:3] == "../" {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Fill direct unit-test gaps in the largest packages affected by recent work (PR #160 editing commands, PR #158 schema-3 pointers). No code changes — only new tests.

### Coverage delta

| Package | Before | After | Δ |
|---|---:|---:|---:|
| internal/harness | 48.5% | **84.5%** | +36.0pp |
| internal/agent | 43.8% | 48.8% | +5.0pp |
| internal/vendor | 54.0% | 58.7% | +4.7pp |

### What's covered now

**internal/harness** — full editing API from PR #160:
- AddFocus / RemoveFocus / UpdateFocus + focus→profile reference blocking
- AddProfile / RemoveProfile + focus-still-references error path
- AddHook / RemoveHook (harness + profile variants) — event/index validation, empty-key cleanup
- AddMCP / RemoveMCP / UpdateMCP (harness + profile) — command-vs-url mutex, null entries, update-of-null rejection
- Profile-scoped include CRUD with path disambiguation
- IsValidName / ValidNamePattern / BadRefError / LoadQualified / LoadNS / InstalledDirNS / LoadFile
- LoadInstalledRecord (pointer vs disk topology), SaveInstalledRecord routing, IsLocalSource truth table
- RemovePointerByID + idempotent missing

**internal/agent** — pure helpers + control plane:
- dirOf, resolveYNHBinary, openTrajectory (stdout/file/bad-path), newSessionID uniqueness, assembleHarness error path, gitAutoCommit
- waitForApproval — approve / replace_feedback / reject / interrupt / channel-closed

**internal/vendor** — pure FS helpers:
- dirHasContent / fileExists truth tables
- PlanSymlinks empty / missing-dir / multi-artifact

### Why some packages aren't moved

Remaining low-coverage funcs in `internal/{vendor,agent,registry}` are intentional — they shell out to vendor CLIs (`Launch*`, `Install`, `Clean`), git (`gitAutoCommit` covered, `Fetch*` not), or the network. They're exercised through the E2E suite, not unit tests.

`cmd/ynh` and `cmd/ynd` stay at their current numbers — top-level command handlers read `os.Args` and write `os.Stdout`, and adding shallow unit tests there would only duplicate what `test/e2e/` already covers end-to-end.

## Test plan

- [x] `make check` green on this branch
- [ ] CI green on PR