### PR TITLE
test: expand E2E coverage for 0.4.0 surface

### DIFF
--- a/test/e2e/focus_clear_profile_test.go
+++ b/test/e2e/focus_clear_profile_test.go
@@ -1,0 +1,46 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestFocus_UpdateClearProfile_LocalInstall asserts that
+// `ynh focus update --clear-profile` drops the focus's profile binding while
+// preserving the prompt. The flag mirrors the cleared-pointer semantics
+// documented in docs/focus.md.
+func TestFocus_UpdateClearProfile_LocalInstall(t *testing.T) {
+	s := newSandbox(t)
+	clone := cloneAssistantsAtSHA(t)
+	sourceDir := filepath.Join(clone, "e2e-fixtures", "minimal")
+
+	s.mustRunYnh(t, "install", sourceDir)
+
+	// Seed: profile + focus that binds to it.
+	s.mustRunYnh(t, "profile", "add", "local/minimal", "audit")
+	s.mustRunYnh(t, "focus", "add", "local/minimal", "scan", "scan everything", "--profile", "audit")
+
+	mf := readExtendedManifest(t, sourceDir)
+	if mf.Focuses["scan"].Profile != "audit" {
+		t.Fatalf("seed: expected profile=audit, got %+v", mf.Focuses["scan"])
+	}
+
+	// Clear the profile binding.
+	s.mustRunYnh(t, "focus", "update", "local/minimal", "scan", "--clear-profile")
+
+	mf = readExtendedManifest(t, sourceDir)
+	got := mf.Focuses["scan"]
+	if got.Profile != "" {
+		t.Errorf("--clear-profile should drop the binding, got %q", got.Profile)
+	}
+	if got.Prompt != "scan everything" {
+		t.Errorf("--clear-profile must preserve prompt, got %q", got.Prompt)
+	}
+
+	// And the now-unreferenced profile must be removable.
+	if _, _, err := s.runYnh(t, "profile", "remove", "local/minimal", "audit"); err != nil {
+		t.Errorf("profile remove failed after clear-profile: %v", err)
+	}
+}

--- a/test/e2e/ynd_fmt_extras_test.go
+++ b/test/e2e/ynd_fmt_extras_test.go
@@ -1,0 +1,85 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFmtHarness creates a minimal harness with a markdown file containing
+// the supplied body. Returns the harness dir and the markdown path.
+func writeFmtHarness(t *testing.T, name, body string) (dir, mdPath string) {
+	t.Helper()
+	dir = filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plug := `{"$schema":"https://eyelock.github.io/ynh/schema/plugin.schema.json","name":"` + name + `","version":"0.1.0"}`
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(plug), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mdPath = filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(mdPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir, mdPath
+}
+
+// TestYnd_Fmt_TrailingWhitespace asserts ynd fmt strips trailing whitespace.
+func TestYnd_Fmt_TrailingWhitespace(t *testing.T) {
+	dir, mdPath := writeFmtHarness(t, "fmt-ws", "# heading\n\ntext with trailing   \n")
+	mustRunYnd(t, "fmt", "--harness", dir)
+	body, err := os.ReadFile(mdPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, line := range strings.Split(string(body), "\n") {
+		if strings.HasSuffix(line, " ") || strings.HasSuffix(line, "\t") {
+			t.Errorf("line %d still has trailing whitespace: %q", i, line)
+		}
+	}
+}
+
+// TestYnd_Fmt_Idempotent asserts a second `ynd fmt` is a no-op — the second
+// invocation should not report any changes.
+func TestYnd_Fmt_Idempotent(t *testing.T) {
+	dir, _ := writeFmtHarness(t, "fmt-idem", "# heading\n\nclean content\n")
+	mustRunYnd(t, "fmt", "--harness", dir)
+	stdout, _ := mustRunYnd(t, "fmt", "--harness", dir)
+	if strings.Contains(stdout, "Formatted ") && !strings.Contains(stdout, "Formatted 0 of") {
+		// Either "all formatted" wording or "Formatted 0 of N" is acceptable;
+		// reject only if the second run claims it reformatted something.
+		if strings.Contains(stdout, "Formatted AGENTS.md") {
+			t.Errorf("second fmt pass should be no-op, got:\n%s", stdout)
+		}
+	}
+}
+
+// TestYnd_Fmt_PreservesContent asserts fmt's whitespace normalisation does
+// not mangle the semantic content of the file (headings, paragraphs, lists).
+func TestYnd_Fmt_PreservesContent(t *testing.T) {
+	body := "# Title\n\n## Section\n\n- item one\n- item two\n\nA paragraph.\n"
+	dir, mdPath := writeFmtHarness(t, "fmt-content", body+"   \n\n\n")
+	mustRunYnd(t, "fmt", "--harness", dir)
+	got, err := os.ReadFile(mdPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// All original tokens must survive.
+	for _, want := range []string{"# Title", "## Section", "- item one", "- item two", "A paragraph."} {
+		if !bytes.Contains(got, []byte(want)) {
+			t.Errorf("fmt dropped content %q\noutput:\n%s", want, got)
+		}
+	}
+	// And the file must end with exactly one trailing newline.
+	if !bytes.HasSuffix(got, []byte("\n")) {
+		t.Errorf("output should end with newline:\n%q", got)
+	}
+	if bytes.HasSuffix(got, []byte("\n\n\n")) {
+		t.Errorf("multiple trailing blank lines should be collapsed:\n%q", got)
+	}
+}

--- a/test/e2e/ynd_focus_test.go
+++ b/test/e2e/ynd_focus_test.go
@@ -1,0 +1,160 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newSyntheticHarnessWithFocus writes a harness directory carrying one skill,
+// one profile, and one focus that references the profile. Used to exercise the
+// `--focus` flag on `ynd preview/diff/export`.
+func newSyntheticHarnessWithFocus(t *testing.T, name string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".ynh-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "skills", "hello"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := `{
+  "$schema": "https://eyelock.github.io/ynh/schema/plugin.schema.json",
+  "name": "` + name + `",
+  "version": "0.1.0",
+  "default_vendor": "claude",
+  "hooks": {
+    "before_tool": [{"command": "echo base"}]
+  },
+  "profiles": {
+    "review": {
+      "hooks": {
+        "before_tool": [{"command": "echo REVIEW"}]
+      }
+    }
+  },
+  "focuses": {
+    "code-review": {"profile": "review", "prompt": "review this code"}
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, ".ynh-plugin", "plugin.json"), []byte(plugin), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skill := "---\nname: hello\ndescription: A trivial skill for focus E2E tests.\n---\n\n# hello\n"
+	if err := os.WriteFile(filepath.Join(dir, "skills", "hello", "SKILL.md"), []byte(skill), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestYnd_Preview_WithFocus asserts that `ynd preview --focus <name>` resolves
+// the focus's profile binding — the assembled output should reflect the
+// profile's hook overrides, not the harness-level defaults.
+func TestYnd_Preview_WithFocus(t *testing.T) {
+	harness := newSyntheticHarnessWithFocus(t, "focus-preview")
+	out := filepath.Join(t.TempDir(), "preview")
+
+	mustRunYnd(t, "preview", harness, "-v", "claude", "-o", out, "--focus", "code-review")
+
+	// Claude vendor writes hooks as .claude/settings.json — look for the
+	// profile-resolved REVIEW command rather than the base.
+	hookFile := filepath.Join(out, ".claude", "hooks", "hooks.json")
+	body, err := os.ReadFile(hookFile)
+	if err != nil {
+		t.Fatalf("reading preview hook config: %v", err)
+	}
+	if !strings.Contains(string(body), "echo REVIEW") {
+		t.Errorf("focus did not resolve to profile — expected echo REVIEW, got:\n%s", body)
+	}
+	if strings.Contains(string(body), "echo base") {
+		t.Errorf("base hook leaked despite focus resolution:\n%s", body)
+	}
+}
+
+// TestYnd_Preview_FocusAndProfileMutex locks the documented constraint that
+// `ynd preview --focus X --profile Y` is rejected.
+func TestYnd_Preview_FocusAndProfileMutex(t *testing.T) {
+	harness := newSyntheticHarnessWithFocus(t, "focus-mutex")
+	_, errOut, err := runYnd(t, "preview", harness, "--focus", "code-review", "--profile", "review")
+	if err == nil {
+		t.Fatal("expected --focus + --profile to be rejected")
+	}
+	if !strings.Contains(errOut, "focus") || !strings.Contains(errOut, "profile") {
+		t.Errorf("error should mention both focus and profile, got:\n%s", errOut)
+	}
+}
+
+// TestYnd_Preview_UnknownFocus asserts a missing focus name fails loudly.
+func TestYnd_Preview_UnknownFocus(t *testing.T) {
+	harness := newSyntheticHarnessWithFocus(t, "focus-unknown")
+	_, errOut, err := runYnd(t, "preview", harness, "--focus", "nope")
+	if err == nil {
+		t.Fatal("expected unknown focus to be rejected")
+	}
+	if !strings.Contains(errOut, "focus") {
+		t.Errorf("error should mention focus, got:\n%s", errOut)
+	}
+}
+
+// TestYnd_Diff_WithFocus mirrors the preview test: --focus on diff must
+// resolve through to the profile and produce profile-resolved hook content.
+func TestYnd_Diff_WithFocus(t *testing.T) {
+	harness := newSyntheticHarnessWithFocus(t, "focus-diff")
+	// diff between two vendors with focus applied — output should not error.
+	stdout, stderr, err := runYnd(t, "diff", harness, "-v", "claude,cursor", "--focus", "code-review")
+	if err != nil {
+		t.Fatalf("ynd diff --focus failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	// Diff only enumerates files, not their content — assert the command
+	// produced the focus-resolved hook layout for at least one vendor.
+	if !strings.Contains(stdout, "hooks") {
+		t.Errorf("diff output should reference hook files:\n%s", stdout)
+	}
+}
+
+// TestYnd_Export_WithFocus asserts --focus on export produces hooks resolved
+// through the focus's bound profile.
+func TestYnd_Export_WithFocus(t *testing.T) {
+	harness := newSyntheticHarnessWithFocus(t, "focus-export")
+	out := filepath.Join(t.TempDir(), "export")
+
+	mustRunYnd(t, "export", harness, "-v", "claude", "-o", out, "--focus", "code-review", "--clean")
+
+	// Export writes hook configuration under <out>/claude/.claude/hooks/hooks.json
+	// (Claude's hooks namespace). Search for any hooks.json under the export tree
+	// to tolerate layout variation.
+	var hookFile string
+	_ = filepath.Walk(out, func(path string, info os.FileInfo, _ error) error {
+		if info != nil && !info.IsDir() && strings.HasSuffix(path, "hooks.json") {
+			hookFile = path
+		}
+		return nil
+	})
+	if hookFile == "" {
+		t.Fatalf("no hooks.json produced under %s", out)
+	}
+	body, err := os.ReadFile(hookFile)
+	if err != nil {
+		t.Fatalf("reading export hook config: %v", err)
+	}
+	if !strings.Contains(string(body), "echo REVIEW") {
+		t.Errorf("focus did not resolve to profile on export — got:\n%s", body)
+	}
+}
+
+// TestYnd_Export_FocusAndProfileMutex locks the focus+profile rejection on the
+// export command.
+func TestYnd_Export_FocusAndProfileMutex(t *testing.T) {
+	harness := newSyntheticHarnessWithFocus(t, "focus-export-mutex")
+	_, errOut, err := runYnd(t, "export", harness, "--focus", "code-review", "--profile", "review")
+	if err == nil {
+		t.Fatal("expected --focus + --profile to be rejected")
+	}
+	if !strings.Contains(errOut, "focus") || !strings.Contains(errOut, "profile") {
+		t.Errorf("error should mention both focus and profile, got:\n%s", errOut)
+	}
+}


### PR DESCRIPTION
## Summary

Add E2E tests for the two surfaces with thin coverage going into 0.4.0:

- `ynd preview/diff/export --focus` — focus selection on the developer tools
- `ynd fmt` edge cases — trailing whitespace, idempotency, content preservation
- `ynh focus update --clear-profile` round trip including the unblocked profile-remove path

No code changes — tests only. The full `make e2e` suite (~120 tests) remains green.

## Coverage gaps addressed

| Test | Locks |
|---|---|
| `TestYnd_Preview_WithFocus` | `--focus` resolves to its profile in preview output |
| `TestYnd_Preview_FocusAndProfileMutex` | both flags rejected |
| `TestYnd_Preview_UnknownFocus` | unknown focus is hard error |
| `TestYnd_Diff_WithFocus` | `--focus` accepted on diff, no error |
| `TestYnd_Export_WithFocus` | `--focus` resolves to its profile in export |
| `TestYnd_Export_FocusAndProfileMutex` | both flags rejected on export |
| `TestYnd_Fmt_TrailingWhitespace` | strips trailing space/tab |
| `TestYnd_Fmt_Idempotent` | second pass is no-op |
| `TestYnd_Fmt_PreservesContent` | headings/lists survive, multiple trailing blanks collapsed |
| `TestFocus_UpdateClearProfile_LocalInstall` | `--clear-profile` drops binding but preserves prompt; profile is then removable |

## Test plan

- [x] `make check` green
- [x] `make e2e` green (34.7s)
- [ ] CI green on PR