### PR TITLE
docs(hooks): correct on_stop semantics and document settings.json deployment

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -21,7 +21,7 @@ ynh defines four canonical hook events. Each vendor translates these to its nati
 | `before_tool` | Runs before a tool/command is invoked. Can block execution. |
 | `after_tool` | Runs after a tool/command completes. Can reject the result. |
 | `before_prompt` | Runs before a user prompt is submitted to the model. |
-| `on_stop` | Runs when the agent session ends. |
+| `on_stop` | Runs when the agent finishes responding. On Claude Code this fires at the **end of every turn**, not once at session end — see [on_stop output semantics](#on_stop-output-semantics-claude). |
 
 ## Manifest Format
 
@@ -87,6 +87,38 @@ Claude Code's `--plugin-dir` flag (used by `ynh run` for Claude) only auto-activ
 This means hooks and MCP servers defined in `.ynh-plugin/plugin.json` are correctly **assembled and exported** by ynh, but are **not active during `ynh run` sessions** with Claude. They work correctly with Codex and Cursor (which use symlink-based installation into the project directory).
 
 Hooks and MCP servers in exported plugins (`ynd export`) work as expected when the plugin is installed via Claude Code's `/plugin install` command.
+
+### Running hooks in a plain Claude session
+
+Because `--plugin-dir` hooks don't auto-activate, the way to make hooks — and the sensors that depend on them — fire when you simply open the repo in Claude Code is to declare them in the project's own `.claude/settings.json`, the file Claude auto-loads for every session in that directory. This is a separate deployment mode from `ynh run`:
+
+| Mode | Hooks come from | When hooks fire |
+|------|-----------------|-----------------|
+| `ynh run` (staging dir + `--plugin-dir`) | assembled `.claude/hooks/hooks.json` | only after `/plugin install` (Claude limitation); Codex/Cursor activate via symlink |
+| Plain `claude` in the project | project `.claude/settings.json` | every session, automatically |
+
+For an always-on, sensor-driven repo, put the hooks in `.claude/settings.json`. Three rules:
+
+1. **Use Claude-native event names and the nested shape** — `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `Stop`, each `{ "matcher": …, "hooks": [ { "type": "command", "command": … } ] }`. The canonical names (`before_tool`, `on_stop`, …) are valid **only** in `.ynh-plugin/plugin.json`; Claude silently ignores them in `settings.json`. Don't copy the `plugin.json` shape into `settings.json`.
+2. **Anchor command paths to `$CLAUDE_PROJECT_DIR`** — `$CLAUDE_PROJECT_DIR/tools/hooks/foo.sh`. Claude runs each hook via `/bin/sh` in the **agent's current working directory**, not the project root, so a relative path like `./tools/hooks/foo.sh` silently breaks the moment the agent does `cd` into a subdirectory — and a *blocking* guard hook then fails open (stops guarding) without erroring. `$CLAUDE_PROJECT_DIR` is cwd-independent; it's also more portable than an absolute path, since `settings.json` is checked in and shared across machines.
+3. **Keep the canonical declarations in `plugin.json` too** if you also use `ynh run` or `ynd export` — they activate there via `/plugin install`, Codex, or Cursor.
+
+Example `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      { "matcher": "Edit|Write", "hooks": [ { "type": "command", "command": "$CLAUDE_PROJECT_DIR/tools/hooks/after-edit-sensor.sh" } ] }
+    ],
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "$CLAUDE_PROJECT_DIR/tools/hooks/on-stop-sensors.sh" } ] }
+    ]
+  }
+}
+```
+
+The `Stop` entry above needs the loop-guard and output-routing discipline described in [on_stop output semantics](#on_stop-output-semantics-claude).
 
 ### Claude Code Format
 
@@ -161,6 +193,45 @@ exit 0
 
 The blocking message should be **agent-legible**: tell the agent what to do instead, not just what failed. For example, "Use git push without --force" rather than "Force push not allowed."
 
+## on_stop Output Semantics (Claude)
+
+The `Stop` hook is the subtlest event, and it behaves differently from the other three in ways that matter for sensor sweeps.
+
+**It fires every turn, not once per session.** On Claude Code, `Stop` runs each time the agent finishes responding — not at session end. An on-stop sensor sweep therefore runs *per turn*, so it must be cheap and idempotent.
+
+**Its stdout does not reach the model.** For a `Stop` hook, `stdout` + `exit 0` goes to the transcript (user-visible), **not** into the model's context. A sweep that prints its verdict to stdout and exits 0 runs every turn but the agent never sees the result. To surface a verdict to the model you must either:
+
+- write the message to **stderr** and `exit 2` — Claude feeds stderr to the model and blocks the stop, or
+- print JSON `{"decision": "block", "reason": "…"}` to stdout.
+
+This is why a `PostToolUse` sensor that exits 2 + stderr reaches the model, while an on-stop one that prints to stdout appears dead.
+
+**A naive `exit 2` infinite-loops.** Blocking the stop makes the agent continue; at the next stop the hook fires and blocks again, forever. Claude passes `stop_hook_active: true` in the hook's stdin JSON when the current continuation was itself caused by a stop-hook block. The script must read it and **not block again**.
+
+### Canonical on_stop sensor-sweep template
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+# Claude passes the hook payload as JSON on stdin. stop_hook_active=true means we are
+# already continuing because of a prior block — blocking again would loop forever.
+# Absent (and stdin is a tty) when the script is run manually.
+if [ -t 0 ]; then HOOK_INPUT=""; else HOOK_INPUT=$(cat 2>/dev/null || true); fi
+STOP_ACTIVE=$(printf '%s' "$HOOK_INPUT" | python3 -c 'import json,sys
+try:    print(str(json.load(sys.stdin).get("stop_hook_active", False)).lower())
+except: print("false")' 2>/dev/null || echo false)
+
+# … run sensors, compute fail_count and fail_detail, print a human summary to stdout …
+
+if [ "$fail_count" -gt 0 ] && [ "$STOP_ACTIVE" != "true" ]; then
+  { echo "sensor sweep: $fail_count FAILING — fix before ending the turn:"; printf '%s' "$fail_detail"; } >&2
+  exit 2   # surfaces to the model AND blocks the stop, exactly once
+fi
+exit 0     # green → quiet, end normally
+```
+
+Cursor's `stop` and Codex's `Stop` route output and guard against loops differently; verify per vendor before relying on this exact pattern elsewhere.
+
 ## Root-Harness-Only Rule
 
 Hooks declared in **included harnesses** (via `includes`) are dropped during assembly. Only the root harness's hooks are used. This prevents composed harnesses from silently injecting lifecycle behavior that the harness author didn't explicitly declare.
@@ -175,7 +246,7 @@ When writing hook scripts for use across vendors:
 2. **Use exit code 2 for blocking** — all three vendors recognize exit code 2 as "block this action."
 3. **Include remediation instructions** — tell the agent how to fix the problem, not just that there is one.
 4. **Keep scripts idempotent** — hooks may fire multiple times per session.
-5. **Use absolute paths** — the working directory during hook execution varies by vendor.
+5. **Make command paths cwd-independent** — hooks run in the agent's current working directory, not the project root, and that cwd changes as the agent navigates. A relative command (`./tools/hooks/foo.sh`) breaks after any `cd`. Anchor to the vendor's project-root variable — `$CLAUDE_PROJECT_DIR` on Claude Code — or use an absolute path.
 
 ## Pairing with Sensors
 

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -295,6 +295,8 @@ The most common integration is a hook that produces an artifact a sensor declare
 
 The hook is the runtime mechanism that produces the data; the sensor is the declarative contract over reading it. Coupling is **by shared file path** — implicit, no schema link needed.
 
+> **Making the hook actually fire.** For an always-on sensor loop in a plain Claude session, the hooks must live in the project's `.claude/settings.json`, not just `.ynh-plugin/plugin.json` — and an `on_stop` sweep that feeds a verdict back to the agent has specific output and loop-guard requirements. See [Hooks §"Running hooks in a plain Claude session"](hooks.md#running-hooks-in-a-plain-claude-session) and [Hooks §"on_stop output semantics"](hooks.md#on_stop-output-semantics-claude).
+
 ### Same script, different driver
 
 A sensor with `source.command: "make check"` and an `after_tool` hook running `make check` invoke the same program. The difference is who pulls the trigger. Authors should not feel forced to pick one — both can coexist when the script needs to fire both in-session (hook) and on-demand (sensor).

--- a/docs/tutorial/01-first-harness.md
+++ b/docs/tutorial/01-first-harness.md
@@ -139,8 +139,8 @@ ynh ls
 
 Expected:
 ```
-NAME        KIND   VENDOR  SOURCE                        ARTIFACTS    INCLUDES  DELEGATES TO
-my-harness  local  claude  /tmp/ynh-tutorial/my-harness  1s 1a 1r 1c  0         0
+ID                KIND   VENDOR  SOURCE                        ARTIFACTS    INCLUDES  DELEGATES TO
+local/my-harness  local  claude  /tmp/ynh-tutorial/my-harness  1s 1a 1r 1c  0         0
 ```
 
 The KIND column classifies the install: `local` (installed from a local path), `git`, `registry`, or `local-fork` (a fork registered via `ynh fork`).

--- a/docs/tutorial/19-sensors.md
+++ b/docs/tutorial/19-sensors.md
@@ -245,6 +245,8 @@ ynd validate /tmp/ynh-tutorial/sensor-harness
 
 The hook produces the file mid-session; the sensor consumes it between iterations. Coupling is by shared file path — implicit, no schema link needed.
 
+> **For the hook to actually fire in a plain Claude session**, declare it in the project's `.claude/settings.json` (Claude-native event names, project-relative paths) — not only in `plugin.json`, whose hooks don't auto-activate under `ynh run`. An `on_stop` sweep that feeds its verdict back to the agent must also route output to stderr + `exit 2` and guard against the `stop_hook_active` loop. See [Hooks §"Running hooks in a plain Claude session"](../hooks.md#running-hooks-in-a-plain-claude-session) and [§"on_stop output semantics"](../hooks.md#on_stop-output-semantics-claude).
+
 ## T19.8: Install round-trip preserves sensors
 
 Re-install the harness and confirm sensors still appear in the discovery surface:


### PR DESCRIPTION
## Summary

Doc corrections prompted by a field bug report (`YNH-SENSOR-HOOK-BUGREPORT.md`) on getting YNH-declared sensors to actually fire and feed verdicts back to the agent under Claude Code. Pure documentation — no code, no assembled output, no JSON shape affected.

### `docs/hooks.md`
- **Fix `on_stop` row** — Claude's `Stop` fires at the **end of every turn**, not once at session end (was misframed as a session-end cleanup hook).
- **New "Running hooks in a plain Claude session"** — documents the project `.claude/settings.json` deployment mode vs. `ynh run`'s `--plugin-dir` (whose hooks don't auto-activate without `/plugin install`), with the native-event-name and `$CLAUDE_PROJECT_DIR` rules. This is the path that makes sensors fire first-time.
- **New "on_stop Output Semantics (Claude)"** — `stdout`→transcript vs. `stderr`+`exit 2`→model, the `stop_hook_active` infinite-loop guard, and a vetted on-stop sensor-sweep template.
- **Path-portability** — lead the rule with the cwd reason (relative paths break after `cd`; a blocking guard then fails open), portability second. Rewrote portable-advice item 5 from "use absolute paths" to cwd-independence via `$CLAUDE_PROJECT_DIR`.

### `docs/sensors.md`, `docs/tutorial/19-sensors.md`
- Cross-link the hook→sensor pairing to the new hooks.md sections.

### `docs/tutorial/01-first-harness.md`
- Fix a stale T1.5 `ynh ls` output block (`NAME`/`my-harness` → `ID`/`local/my-harness`) that the canonical-id sweep in #130 missed. Pre-existing; unblocks the eval suite.

## Scope note
The bug report's code/feature recommendations (a `ynh hook export --target settings` path, a validate-time canonical-names check, `$CLAUDE_PROJECT_DIR` codegen rewriting, `ynh doctor`) are intentionally **out of scope** here — this PR ships only the doc corrections.

## Verification
- `make check` — 0 lint issues, all tests pass, build clean
- Eval suite — **PASS** (18 tutorials, 0 failures); T1.5 fix confirmed against real binary output

🤖 Generated with [Claude Code](https://claude.com/claude-code)