### PR TITLE
feat(hooks): wire sensors into plain Claude sessions — export, doctor, path anchoring

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,7 @@ ynh is a harness template manager for AI coding assistants (Claude Code, OpenAI 
 
 ## Two Binaries
 
-- **`ynh`** (`cmd/ynh/`) — Harness manager: init, install, uninstall, update, run, ls, info, vendors, search, registry, image, status, prune
+- **`ynh`** (`cmd/ynh/`) — Harness manager: init, install, uninstall, update, run, ls, info, vendors, search, registry, image, status, prune, hook, doctor
 - **`ynd`** (`cmd/ynd/`) — Developer tools: create, lint, validate, fmt, compress, inspect
 
 Both built by `make build`, released together via goreleaser (single `v*` tag).

--- a/cmd/ynd/validate.go
+++ b/cmd/ynd/validate.go
@@ -337,6 +337,30 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
+// vendorHookEventNames maps known vendor-native hook event names to their
+// canonical equivalent. plugin.json declares hooks with canonical names; a
+// vendor-native name here is a common copy-paste mistake from a settings file,
+// so it earns a targeted hint rather than a generic "unknown event".
+var vendorHookEventNames = map[string]string{
+	"PreToolUse":           "before_tool",
+	"PostToolUse":          "after_tool",
+	"UserPromptSubmit":     "before_prompt",
+	"Stop":                 "on_stop",
+	"beforeShellExecution": "before_tool",
+	"afterFileEdit":        "after_tool",
+	"beforeSubmitPrompt":   "before_prompt",
+	"stop":                 "on_stop",
+}
+
+// hookEventMessage returns the validation message for an invalid hook event,
+// upgrading to a targeted correction when the event is a known vendor name.
+func hookEventMessage(event string) string {
+	if canonical, ok := vendorHookEventNames[event]; ok {
+		return fmt.Sprintf("event %q is a vendor-native name — plugin.json uses canonical events; use %q (ynh translates it per vendor)", event, canonical)
+	}
+	return fmt.Sprintf("unknown event %q (valid: before_tool, after_tool, before_prompt, on_stop)", event)
+}
+
 // validateHarnessHooks validates the hooks section inside harness.json.
 func validateHarnessHooks(hj map[string]any) []string {
 	var issues []string
@@ -353,7 +377,7 @@ func validateHarnessHooks(hj map[string]any) []string {
 
 	for event, entries := range hooksMap {
 		if !plugin.ValidHookEvents[event] {
-			issues = append(issues, fmt.Sprintf("hooks: unknown event %q (valid: before_tool, after_tool, before_prompt, on_stop)", event))
+			issues = append(issues, "hooks: "+hookEventMessage(event))
 		}
 		arr, ok := entries.([]any)
 		if !ok {

--- a/cmd/ynd/validate_test.go
+++ b/cmd/ynd/validate_test.go
@@ -654,6 +654,30 @@ func TestValidateHarness_HooksUnknownEvent(t *testing.T) {
 	}
 }
 
+func TestHookEventMessage(t *testing.T) {
+	tests := []struct {
+		event       string
+		wantContain string
+	}{
+		{"PreToolUse", "before_tool"},
+		{"PostToolUse", "after_tool"},
+		{"afterFileEdit", "after_tool"},
+		{"stop", "on_stop"},
+		{"totally_made_up", "unknown event"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.event, func(t *testing.T) {
+			got := hookEventMessage(tt.event)
+			if !strings.Contains(got, tt.wantContain) {
+				t.Errorf("hookEventMessage(%q) = %q, want contains %q", tt.event, got, tt.wantContain)
+			}
+			if _, isVendor := vendorHookEventNames[tt.event]; isVendor && !strings.Contains(got, "vendor-native") {
+				t.Errorf("vendor name %q should yield a vendor-native hint, got %q", tt.event, got)
+			}
+		})
+	}
+}
+
 func TestValidateHarness_HooksEmptyCommand(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/cmd/ynh/doctor.go
+++ b/cmd/ynh/doctor.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/eyelock/ynh/internal/vendor"
+)
+
+// claudeSettingsFiles are the project files Claude Code auto-loads in a plain
+// session. ynh doctor inspects them for hook-wiring mistakes that fail silently.
+var claudeSettingsFiles = []string{
+	filepath.Join(".claude", "settings.json"),
+	filepath.Join(".claude", "settings.local.json"),
+}
+
+// doctorFinding is one advisory result from a doctor check.
+type doctorFinding struct {
+	file    string
+	message string
+}
+
+func cmdDoctor(args []string) error {
+	return cmdDoctorTo(args, os.Stdout)
+}
+
+func cmdDoctorTo(args []string, stdout io.Writer) error {
+	if len(args) > 0 {
+		return fmt.Errorf("ynh doctor takes no arguments")
+	}
+
+	var findings []doctorFinding
+	anyFile := false
+	for _, rel := range claudeSettingsFiles {
+		present, fs := checkClaudeSettings(rel)
+		if present {
+			anyFile = true
+		}
+		findings = append(findings, fs...)
+	}
+
+	_, _ = fmt.Fprintln(stdout, "ynh doctor — hook wiring")
+
+	if !anyFile {
+		_, _ = fmt.Fprintln(stdout, "  info  no .claude/settings.json found — hooks declared in .ynh-plugin/plugin.json")
+		_, _ = fmt.Fprintln(stdout, "        do not auto-activate in a plain Claude session. To wire them in, run:")
+		_, _ = fmt.Fprintln(stdout, "        ynh hook export <harness> --target settings")
+		return nil
+	}
+
+	if len(findings) == 0 {
+		_, _ = fmt.Fprintln(stdout, "  ok    Claude hook settings look correctly wired.")
+		return nil
+	}
+
+	for _, f := range findings {
+		_, _ = fmt.Fprintf(stdout, "  warn  %s: %s\n", f.file, f.message)
+	}
+	_, _ = fmt.Fprintf(stdout, "\n%d warning(s) found.\n", len(findings))
+	return nil
+}
+
+// checkClaudeSettings inspects one settings file for hook-wiring mistakes.
+// It reports whether the file exists, and any findings.
+func checkClaudeSettings(path string) (present bool, findings []doctorFinding) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, nil
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return true, []doctorFinding{{file: path, message: fmt.Sprintf("not valid JSON: %v", err)}}
+	}
+
+	hooks, ok := doc["hooks"].(map[string]any)
+	if !ok || len(hooks) == 0 {
+		return true, nil
+	}
+
+	events := make([]string, 0, len(hooks))
+	for e := range hooks {
+		events = append(events, e)
+	}
+	sort.Strings(events)
+
+	for _, event := range events {
+		// Canonical name leaked into a vendor-native settings file: Claude
+		// silently ignores it. This is the most common silent failure.
+		if native, isCanonical := vendor.ClaudeHookEvent(event); isCanonical {
+			findings = append(findings, doctorFinding{
+				file:    path,
+				message: fmt.Sprintf("event %q is an ynh canonical name — Claude only recognises %q here; canonical names belong in .ynh-plugin/plugin.json. Run: ynh hook export <harness> --target settings", event, native),
+			})
+		}
+		// cwd-relative commands break after the agent changes directory, and a
+		// blocking guard hook then silently fails open.
+		for _, cmd := range extractHookCommands(hooks[event]) {
+			if strings.HasPrefix(cmd, "./") || strings.HasPrefix(cmd, "../") {
+				findings = append(findings, doctorFinding{
+					file:    path,
+					message: fmt.Sprintf("hook command %q is cwd-relative and breaks after the agent changes directory; anchor it to $CLAUDE_PROJECT_DIR", cmd),
+				})
+			}
+		}
+	}
+	return true, findings
+}
+
+// extractHookCommands pulls every command string out of one event's value,
+// tolerating both Claude's nested shape ([{hooks:[{command}]}]) and the flat
+// shape a confused author might write ([{command}]).
+func extractHookCommands(eventVal any) []string {
+	groups, ok := eventVal.([]any)
+	if !ok {
+		return nil
+	}
+	var cmds []string
+	for _, g := range groups {
+		group, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cmd, ok := group["command"].(string); ok && cmd != "" {
+			cmds = append(cmds, cmd)
+		}
+		inner, ok := group["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, h := range inner {
+			hm, ok := h.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cmd, ok := hm["command"].(string); ok && cmd != "" {
+				cmds = append(cmds, cmd)
+			}
+		}
+	}
+	return cmds
+}

--- a/cmd/ynh/doctor_test.go
+++ b/cmd/ynh/doctor_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeSettings(t *testing.T, name, body string) {
+	t.Helper()
+	if err := os.MkdirAll(".claude", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(".claude", name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCmdDoctor_NoSettingsNudges(t *testing.T) {
+	t.Chdir(t.TempDir())
+	var buf bytes.Buffer
+	if err := cmdDoctorTo(nil, &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "no .claude/settings.json") || !strings.Contains(out, "ynh hook export") {
+		t.Errorf("expected nudge for missing settings, got: %s", out)
+	}
+}
+
+func TestCmdDoctor_CleanSettings(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeSettings(t, "settings.json", `{
+		"hooks": {"PostToolUse": [{"matcher":"Edit","hooks":[{"type":"command","command":"$CLAUDE_PROJECT_DIR/x.sh"}]}]}
+	}`)
+	var buf bytes.Buffer
+	if err := cmdDoctorTo(nil, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "ok") {
+		t.Errorf("expected clean result, got: %s", buf.String())
+	}
+}
+
+func TestCmdDoctor_CanonicalNameLeak(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeSettings(t, "settings.json", `{
+		"hooks": {"after_tool": [{"matcher":"Edit","hooks":[{"type":"command","command":"$CLAUDE_PROJECT_DIR/x.sh"}]}]}
+	}`)
+	var buf bytes.Buffer
+	if err := cmdDoctorTo(nil, &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "canonical name") || !strings.Contains(out, "PostToolUse") {
+		t.Errorf("expected canonical-name warning naming PostToolUse, got: %s", out)
+	}
+}
+
+func TestCmdDoctor_RelativeCommand(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeSettings(t, "settings.json", `{
+		"hooks": {"PreToolUse": [{"matcher":"Bash","hooks":[{"type":"command","command":"./tools/guard.sh"}]}]}
+	}`)
+	var buf bytes.Buffer
+	if err := cmdDoctorTo(nil, &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "cwd-relative") || !strings.Contains(out, "$CLAUDE_PROJECT_DIR") {
+		t.Errorf("expected cwd-relative warning, got: %s", out)
+	}
+}
+
+func TestCmdDoctor_InspectsLocalFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeSettings(t, "settings.local.json", `{
+		"hooks": {"on_stop": [{"hooks":[{"type":"command","command":"sweep.sh"}]}]}
+	}`)
+	var buf bytes.Buffer
+	if err := cmdDoctorTo(nil, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "settings.local.json") {
+		t.Errorf("expected the local settings file to be inspected, got: %s", buf.String())
+	}
+}
+
+func TestCmdDoctor_InvalidJSON(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeSettings(t, "settings.json", `{ not json`)
+	var buf bytes.Buffer
+	if err := cmdDoctorTo(nil, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "not valid JSON") {
+		t.Errorf("expected invalid-JSON warning, got: %s", buf.String())
+	}
+}
+
+func TestCmdDoctor_RejectsArgs(t *testing.T) {
+	if err := cmdDoctor([]string{"extra"}); err == nil {
+		t.Error("expected error for unexpected argument")
+	}
+}
+
+func TestExtractHookCommands_BothShapes(t *testing.T) {
+	nested := []any{map[string]any{"hooks": []any{map[string]any{"command": "a.sh"}, map[string]any{"command": "b.sh"}}}}
+	if got := extractHookCommands(nested); len(got) != 2 || got[0] != "a.sh" {
+		t.Errorf("nested shape: got %v", got)
+	}
+	flat := []any{map[string]any{"command": "c.sh"}}
+	if got := extractHookCommands(flat); len(got) != 1 || got[0] != "c.sh" {
+		t.Errorf("flat shape: got %v", got)
+	}
+	if got := extractHookCommands("not-an-array"); got != nil {
+		t.Errorf("non-array should yield nil, got %v", got)
+	}
+}

--- a/cmd/ynh/hook.go
+++ b/cmd/ynh/hook.go
@@ -1,13 +1,19 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/eyelock/ynh/internal/harness"
+	"github.com/eyelock/ynh/internal/plugin"
+	"github.com/eyelock/ynh/internal/vendor"
 )
 
 func cmdHook(args []string) error {
@@ -16,15 +22,17 @@ func cmdHook(args []string) error {
 
 func cmdHookTo(args []string, stdout io.Writer) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: ynh hook <add|remove>")
+		return fmt.Errorf("usage: ynh hook <add|remove|export>")
 	}
 	switch args[0] {
 	case "add":
 		return cmdHookAdd(args[1:], stdout)
 	case "remove":
 		return cmdHookRemove(args[1:], stdout)
+	case "export":
+		return cmdHookExport(args[1:], stdout)
 	default:
-		return fmt.Errorf("unknown hook subcommand: %s\nUsage: ynh hook <add|remove>", args[0])
+		return fmt.Errorf("unknown hook subcommand: %s\nUsage: ynh hook <add|remove|export>", args[0])
 	}
 }
 
@@ -88,4 +96,171 @@ func cmdHookRemove(args []string, stdout io.Writer) error {
 	}
 	_, _ = fmt.Fprintf(stdout, "Removed hook %d (event %s)\n", index, event)
 	return nil
+}
+
+// hookExportTargets maps the --target value to the project-relative settings
+// file Claude Code auto-loads in a plain session.
+var hookExportTargets = map[string]string{
+	"settings": filepath.Join(".claude", "settings.json"),       // committed, team-wide
+	"local":    filepath.Join(".claude", "settings.local.json"), // gitignored, personal
+}
+
+func cmdHookExport(args []string, stdout io.Writer) error {
+	// settings/local are Claude-only files, so claude is the only meaningful
+	// vendor here; -v stays accepted for explicitness and clear errors.
+	vendorName := vendor.DefaultName
+	var target string
+	var dryRun bool
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-v", "--vendor":
+			if i+1 >= len(args) {
+				return fmt.Errorf("%s requires a value", args[i])
+			}
+			i++
+			vendorName = args[i]
+		case "--target":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--target requires a value (settings or local)")
+			}
+			i++
+			target = args[i]
+		case "--dry-run":
+			dryRun = true
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("unknown flag: %s", args[i])
+			}
+			positional = append(positional, args[i])
+		}
+	}
+	if len(positional) != 1 {
+		return fmt.Errorf("usage: ynh hook export <harness> [-v <vendor>] --target <settings|local> [--dry-run]")
+	}
+	harnessRef := positional[0]
+
+	relFile, ok := hookExportTargets[target]
+	if !ok {
+		return fmt.Errorf("--target must be 'settings' (.claude/settings.json) or 'local' (.claude/settings.local.json); got %q", target)
+	}
+	// settings/local are Claude's auto-loaded project files. Other vendors
+	// auto-load their hooks via symlink install, so there is nothing to export.
+	if vendorName != "claude" {
+		return fmt.Errorf("hook export --target is Claude-specific; vendor %q auto-loads hooks from its config dir when installed", vendorName)
+	}
+
+	dir, _, err := harness.ResolveEditTarget(harnessRef)
+	if err != nil {
+		return err
+	}
+	hj, err := plugin.LoadPluginJSON(dir)
+	if err != nil {
+		return err
+	}
+	if len(hj.Hooks) == 0 {
+		return fmt.Errorf("harness %q declares no hooks to export", harnessRef)
+	}
+
+	adapter, err := vendor.Get(vendorName)
+	if err != nil {
+		return err
+	}
+	gen, err := adapter.GenerateHookConfig(hj.Hooks)
+	if err != nil {
+		return err
+	}
+	// GenerateHookConfig emits a single {"hooks": {...}} document; pull out the
+	// translated hooks object to merge into the target settings file.
+	var genDoc map[string]any
+	for _, data := range gen {
+		if err := json.Unmarshal(data, &genDoc); err != nil {
+			return fmt.Errorf("parsing generated hook config: %w", err)
+		}
+	}
+	genHooks, _ := genDoc["hooks"].(map[string]any)
+	if len(genHooks) == 0 {
+		return fmt.Errorf("harness %q declares no hooks for vendor %q", harnessRef, vendorName)
+	}
+
+	// Load the existing settings file (if any) so non-hook keys are preserved.
+	settings := map[string]any{}
+	existed := false
+	if data, rerr := os.ReadFile(relFile); rerr == nil {
+		existed = true
+		if uerr := json.Unmarshal(data, &settings); uerr != nil {
+			return fmt.Errorf("%s is not valid JSON: %w", relFile, uerr)
+		}
+	}
+
+	added := mergeHookEntries(settings, genHooks)
+
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling settings: %w", err)
+	}
+	out = append(out, '\n')
+
+	if dryRun {
+		_, _ = fmt.Fprintf(stdout, "# dry run — would write %s (%d new hook group(s))\n", relFile, added)
+		_, _ = stdout.Write(out)
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(relFile), 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(relFile), err)
+	}
+	if err := os.WriteFile(relFile, out, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", relFile, err)
+	}
+
+	verb := "Updated"
+	if !existed {
+		verb = "Created"
+	}
+	_, _ = fmt.Fprintf(stdout, "%s %s (%d new hook group(s) from %s)\n", verb, relFile, added, hj.Name)
+	return nil
+}
+
+// mergeHookEntries unions the generated per-event hook groups into the
+// settings map's "hooks" key, skipping any group already present verbatim
+// (so re-running is idempotent and a user's own hooks are never removed).
+// Non-hook keys in settings are left untouched. Returns the count of groups
+// newly added.
+func mergeHookEntries(settings map[string]any, generated map[string]any) int {
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+
+	events := make([]string, 0, len(generated))
+	for e := range generated {
+		events = append(events, e)
+	}
+	sort.Strings(events)
+
+	added := 0
+	for _, event := range events {
+		genArr, _ := generated[event].([]any)
+		existing, _ := hooks[event].([]any)
+		for _, group := range genArr {
+			if !containsEquivalent(existing, group) {
+				existing = append(existing, group)
+				added++
+			}
+		}
+		hooks[event] = existing
+	}
+	settings["hooks"] = hooks
+	return added
+}
+
+// containsEquivalent reports whether arr already holds a value deeply equal to v.
+func containsEquivalent(arr []any, v any) bool {
+	for _, e := range arr {
+		if reflect.DeepEqual(e, v) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/ynh/hook_test.go
+++ b/cmd/ynh/hook_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -134,5 +137,211 @@ func TestCmdHookRemove_NonInteger(t *testing.T) {
 	err := cmdHookTo([]string{"remove", dir, "before_tool", "not-int"}, &buf)
 	if err == nil || !strings.Contains(err.Error(), "must be an integer") {
 		t.Errorf("expected integer error, got: %v", err)
+	}
+}
+
+func writeExportHarness(t *testing.T, dir string) {
+	t.Helper()
+	hj := &plugin.HarnessJSON{
+		Name:    "h",
+		Version: "0.1.0",
+		Hooks: map[string][]plugin.HookEntry{
+			"after_tool": {{Matcher: "Edit|Write", Command: "./tools/x.sh"}},
+			"on_stop":    {{Command: "make check"}},
+		},
+	}
+	if err := plugin.SavePluginJSON(dir, hj); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readSettingsHooks(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var s map[string]any
+	if err := json.Unmarshal(data, &s); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	hooks, _ := s["hooks"].(map[string]any)
+	return hooks
+}
+
+func TestCmdHookExport_CreatesSettingsAnchored(t *testing.T) {
+	proj := t.TempDir()
+	t.Chdir(proj)
+	hdir := filepath.Join(proj, "h")
+	writeExportHarness(t, hdir)
+
+	var buf bytes.Buffer
+	if err := cmdHookTo([]string{"export", hdir, "--target", "settings"}, &buf); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	hooks := readSettingsHooks(t, filepath.Join(".claude", "settings.json"))
+
+	post, ok := hooks["PostToolUse"].([]any)
+	if !ok || len(post) != 1 {
+		t.Fatalf("PostToolUse missing/wrong: %v", hooks["PostToolUse"])
+	}
+	inner := post[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)
+	if inner["command"] != "$CLAUDE_PROJECT_DIR/tools/x.sh" {
+		t.Errorf("command not anchored: %v", inner["command"])
+	}
+	if _, ok := hooks["Stop"]; !ok {
+		t.Error("Stop event missing from export")
+	}
+}
+
+func TestCmdHookExport_LocalTarget(t *testing.T) {
+	proj := t.TempDir()
+	t.Chdir(proj)
+	hdir := filepath.Join(proj, "h")
+	writeExportHarness(t, hdir)
+
+	var buf bytes.Buffer
+	if err := cmdHookTo([]string{"export", hdir, "--target", "local"}, &buf); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(".claude", "settings.local.json")); err != nil {
+		t.Errorf("expected settings.local.json: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(".claude", "settings.json")); !os.IsNotExist(err) {
+		t.Error("settings.json should not be written for --target local")
+	}
+}
+
+func TestCmdHookExport_PreservesAndIdempotent(t *testing.T) {
+	proj := t.TempDir()
+	t.Chdir(proj)
+	hdir := filepath.Join(proj, "h")
+	writeExportHarness(t, hdir)
+
+	// Pre-existing settings with a non-hook key and a user hook.
+	if err := os.MkdirAll(".claude", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := `{"model":"opus","hooks":{"PostToolUse":[{"matcher":"Edit|Write","hooks":[{"type":"command","command":"user.sh"}]}]}}`
+	if err := os.WriteFile(filepath.Join(".claude", "settings.json"), []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := cmdHookTo([]string{"export", hdir, "--target", "settings"}, &buf); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	// Non-hook key preserved.
+	data, _ := os.ReadFile(filepath.Join(".claude", "settings.json"))
+	var s map[string]any
+	_ = json.Unmarshal(data, &s)
+	if s["model"] != "opus" {
+		t.Error("non-hook key 'model' not preserved")
+	}
+	// User hook + ynh hook both present under PostToolUse.
+	post := s["hooks"].(map[string]any)["PostToolUse"].([]any)
+	if len(post) != 2 {
+		t.Errorf("PostToolUse groups = %d, want 2 (user + ynh)", len(post))
+	}
+
+	// Re-run is idempotent: no new groups added.
+	var buf2 bytes.Buffer
+	if err := cmdHookTo([]string{"export", hdir, "--target", "settings"}, &buf2); err != nil {
+		t.Fatalf("re-export: %v", err)
+	}
+	if !strings.Contains(buf2.String(), "0 new") {
+		t.Errorf("re-run should add 0 groups, got: %s", buf2.String())
+	}
+}
+
+func TestCmdHookExport_DryRunWritesNothing(t *testing.T) {
+	proj := t.TempDir()
+	t.Chdir(proj)
+	hdir := filepath.Join(proj, "h")
+	writeExportHarness(t, hdir)
+
+	var buf bytes.Buffer
+	if err := cmdHookTo([]string{"export", hdir, "--target", "settings", "--dry-run"}, &buf); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(".claude", "settings.json")); !os.IsNotExist(err) {
+		t.Error("--dry-run must not write a file")
+	}
+	if !strings.Contains(buf.String(), "dry run") {
+		t.Errorf("expected dry-run notice, got: %s", buf.String())
+	}
+}
+
+func TestCmdHookExport_Errors(t *testing.T) {
+	proj := t.TempDir()
+	t.Chdir(proj)
+	hdir := filepath.Join(proj, "h")
+	writeExportHarness(t, hdir)
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing target", []string{"export", hdir}, "--target"},
+		{"bad target", []string{"export", hdir, "--target", "bogus"}, "must be 'settings'"},
+		{"non-claude vendor", []string{"export", hdir, "-v", "cursor", "--target", "settings"}, "Claude-specific"},
+		{"no positional", []string{"export", "--target", "settings"}, "usage"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := cmdHookTo(tc.args, &buf)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("args %v: got err %v, want contains %q", tc.args, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCmdHookExport_NoHooks(t *testing.T) {
+	proj := t.TempDir()
+	t.Chdir(proj)
+	hdir := filepath.Join(proj, "h")
+	writeHookTestHarness(t, hdir, "h") // no hooks declared
+
+	var buf bytes.Buffer
+	err := cmdHookTo([]string{"export", hdir, "--target", "settings"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "no hooks") {
+		t.Errorf("expected no-hooks error, got: %v", err)
+	}
+}
+
+func TestMergeHookEntries_UnionDedupPreserve(t *testing.T) {
+	mustJSON := func(s string) map[string]any {
+		var m map[string]any
+		if err := json.Unmarshal([]byte(s), &m); err != nil {
+			t.Fatal(err)
+		}
+		return m
+	}
+	settings := mustJSON(`{
+		"model": "opus",
+		"hooks": {"PreToolUse": [{"matcher":"Bash","hooks":[{"type":"command","command":"user.sh"}]}]}
+	}`)
+	generated := mustJSON(`{
+		"PreToolUse": [{"matcher":"Bash","hooks":[{"type":"command","command":"ynh.sh"}]}],
+		"Stop": [{"hooks":[{"type":"command","command":"sweep.sh"}]}]
+	}`)
+
+	added := mergeHookEntries(settings, generated)
+	if added != 2 {
+		t.Errorf("added = %d, want 2", added)
+	}
+	if settings["model"] != "opus" {
+		t.Error("non-hook key not preserved")
+	}
+	pre := settings["hooks"].(map[string]any)["PreToolUse"].([]any)
+	if len(pre) != 2 {
+		t.Errorf("PreToolUse groups = %d, want 2", len(pre))
+	}
+	// Idempotent: same generated input adds nothing.
+	if added2 := mergeHookEntries(settings, generated); added2 != 0 {
+		t.Errorf("re-merge added = %d, want 0", added2)
 	}
 }

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -89,6 +89,8 @@ func main() {
 		err = cmdProfile(os.Args[2:])
 	case "hook":
 		err = cmdHook(os.Args[2:])
+	case "doctor":
+		err = cmdDoctor(os.Args[2:])
 	case "mcp":
 		err = cmdMCP(os.Args[2:])
 	case "sensors":
@@ -169,6 +171,8 @@ Commands:
   profile include update <harness> <profile> <url> [flags]  Update a profile include
   hook add <harness> <event> <command> [--matcher <pattern>] Add a top-level hook
   hook remove <harness> <event> <index>                     Remove a top-level hook by index
+  hook export <harness> --target <settings|local> [--dry-run]  Write a harness's hooks into a Claude settings file
+  doctor                       Check Claude hook wiring in the current project
   mcp add <harness> <name> [flags]                          Add a top-level MCP server
   mcp remove <harness> <name>                               Remove a top-level MCP server
   mcp update <harness> <name> [flags]                       Update a top-level MCP server

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -97,13 +97,31 @@ Because `--plugin-dir` hooks don't auto-activate, the way to make hooks — and 
 | `ynh run` (staging dir + `--plugin-dir`) | assembled `.claude/hooks/hooks.json` | only after `/plugin install` (Claude limitation); Codex/Cursor activate via symlink |
 | Plain `claude` in the project | project `.claude/settings.json` | every session, automatically |
 
-For an always-on, sensor-driven repo, put the hooks in `.claude/settings.json`. Three rules:
+For an always-on, sensor-driven repo, declare the hooks once in `.ynh-plugin/plugin.json` (canonical names) and let ynh write them into the settings file:
+
+```bash
+ynh hook export <harness> --target settings   # → .claude/settings.json (committed, team-wide)
+ynh hook export <harness> --target local      # → .claude/settings.local.json (gitignored, personal)
+ynh hook export <harness> --target settings --dry-run   # preview, write nothing
+```
+
+`hook export` translates canonical events to Claude-native names, applies the nested shape, and anchors relative command paths to `$CLAUDE_PROJECT_DIR` (see rules below). It **merges** — non-hook keys (`permissions`, `env`, …) and your own existing hooks are preserved, and re-running adds nothing already present, so it's safe to run repeatedly. `--target` is required; there is no default, so you always choose committed vs. personal explicitly.
+
+Then confirm the wiring:
+
+```bash
+ynh doctor   # checks .claude/settings.json + settings.local.json for the silent-failure traps below
+```
+
+`ynh doctor` flags canonical names that leaked into a settings file (where Claude ignores them), cwd-relative hook commands, and a project with no settings file at all (hooks declared but not wired).
+
+If you hand-author the settings file instead, three rules:
 
 1. **Use Claude-native event names and the nested shape** — `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `Stop`, each `{ "matcher": …, "hooks": [ { "type": "command", "command": … } ] }`. The canonical names (`before_tool`, `on_stop`, …) are valid **only** in `.ynh-plugin/plugin.json`; Claude silently ignores them in `settings.json`. Don't copy the `plugin.json` shape into `settings.json`.
 2. **Anchor command paths to `$CLAUDE_PROJECT_DIR`** — `$CLAUDE_PROJECT_DIR/tools/hooks/foo.sh`. Claude runs each hook via `/bin/sh` in the **agent's current working directory**, not the project root, so a relative path like `./tools/hooks/foo.sh` silently breaks the moment the agent does `cd` into a subdirectory — and a *blocking* guard hook then fails open (stops guarding) without erroring. `$CLAUDE_PROJECT_DIR` is cwd-independent; it's also more portable than an absolute path, since `settings.json` is checked in and shared across machines.
 3. **Keep the canonical declarations in `plugin.json` too** if you also use `ynh run` or `ynd export` — they activate there via `/plugin install`, Codex, or Cursor.
 
-Example `.claude/settings.json`:
+Example `.claude/settings.json` (what `hook export` produces):
 
 ```json
 {
@@ -267,6 +285,18 @@ ynh profile hook remove <harness> <profile> <event> <index>
 ```
 
 `<event>` is validated against the canonical set: `before_tool`, `after_tool`, `before_prompt`, `on_stop`. `<index>` is zero-based. When the last entry for an event is removed, the event key is dropped from the manifest entirely.
+
+To translate a harness's declared hooks into a Claude settings file (so they fire in a plain session — see [Running hooks in a plain Claude session](#running-hooks-in-a-plain-claude-session)):
+
+```bash
+ynh hook export <harness> --target <settings|local> [-v claude] [--dry-run]
+```
+
+And to check that the project's settings files are correctly wired:
+
+```bash
+ynh doctor
+```
 
 See [reference.md](reference.md) for the complete flag matrix and [profiles.md](profiles.md#cli-editing) for the surrounding profile-editor surface.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -65,6 +65,7 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | `ynh profile include update <harness> <profile> <url>` | `--from-path`, `--path`, `--ref` |
 | `ynh hook add <harness> <event> <command>` | `--matcher` — top-level harness hook |
 | `ynh hook remove <harness> <event> <index>` | top-level harness hook |
+| `ynh hook export <harness>` | `--target <settings\|local>` (required), `-v <vendor>` (claude), `--dry-run` — write a harness's hooks into a Claude settings file ([why](hooks.md#running-hooks-in-a-plain-claude-session)) |
 | `ynh mcp add <harness> <name>` | `--command`, `--url`, `--arg`, `--env`, `--header` — top-level harness MCP server (no `--null`; harness-level entries cannot be null) |
 | `ynh mcp remove <harness> <name>` | top-level harness MCP server |
 | `ynh mcp update <harness> <name>` | `--command`, `--url`, `--arg`, `--env`, `--header`, `--clear-args`, `--clear-env`, `--clear-headers` |
@@ -82,6 +83,7 @@ The harness source defaults to `.` (CWD) for `validate`, `lint`, and `fmt`. For 
 | `ynh paths` | `--format <text\|json>` |
 | `ynh status` | |
 | `ynh prune` | |
+| `ynh doctor` | check Claude hook wiring in `.claude/settings.json` / `settings.local.json` for the current project |
 
 ## ynd Commands
 

--- a/docs/tutorial/02-vendors-and-symlinks.md
+++ b/docs/tutorial/02-vendors-and-symlinks.md
@@ -209,10 +209,10 @@ ynh status
 
 ### Prune stale launchers
 
-Simulate a stale launcher by removing the harness directory but leaving its launcher script:
+Simulate a stale launcher by removing the install record but leaving its launcher script:
 
 ```bash
-rm -rf ~/.ynh/harnesses/local--my-harness
+rm ~/.ynh/installed/local--my-harness.json
 ls ~/.ynh/bin/my-harness
 # Expected: file exists (stale launcher)
 ```
@@ -226,7 +226,6 @@ ynh prune
 Expected:
 ```
 Removed stale launcher: /Users/<you>/.ynh/bin/my-harness
-Removed stale run dir: /Users/<you>/.ynh/run/my-harness
 ```
 
 Verify the launcher was removed:

--- a/internal/vendor/claude.go
+++ b/internal/vendor/claude.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"syscall"
 
 	"github.com/eyelock/ynh/internal/plugin"
@@ -116,6 +117,27 @@ var claudeHookEventMap = map[string]string{
 	"on_stop":       "Stop",
 }
 
+// anchorHookCommand rewrites a leading "./" in a hook command so it resolves
+// from the project root via $CLAUDE_PROJECT_DIR, which Claude Code injects into
+// the hook subprocess. Without this, a relative command breaks the moment the
+// agent's working directory moves into a subdirectory — and a blocking guard
+// hook then silently fails open. Commands that are absolute, already anchored
+// to a variable, or PATH-style (no leading "./") are left unchanged.
+func anchorHookCommand(cmd string) string {
+	if strings.HasPrefix(cmd, "./") {
+		return "$CLAUDE_PROJECT_DIR/" + cmd[2:]
+	}
+	return cmd
+}
+
+// ClaudeHookEvent returns the Claude-native event name for a canonical event
+// (e.g. "after_tool" → "PostToolUse"), or ("", false) if the name is not a
+// canonical event. It is the single source of the canonical→Claude mapping.
+func ClaudeHookEvent(canonical string) (string, bool) {
+	native, ok := claudeHookEventMap[canonical]
+	return native, ok
+}
+
 func (c *Claude) GenerateHookConfig(hooks map[string][]plugin.HookEntry) (map[string][]byte, error) {
 	if len(hooks) == 0 {
 		return nil, nil
@@ -171,7 +193,7 @@ func (c *Claude) GenerateHookConfig(hooks map[string][]plugin.HookEntry) (map[st
 		for _, g := range groups {
 			var inner []claudeInnerHook
 			for _, cmd := range g.cmds {
-				inner = append(inner, claudeInnerHook{Type: "command", Command: cmd})
+				inner = append(inner, claudeInnerHook{Type: "command", Command: anchorHookCommand(cmd)})
 			}
 			hookGroups = append(hookGroups, claudeHookGroup{
 				Matcher: g.matcher,

--- a/internal/vendor/claude_test.go
+++ b/internal/vendor/claude_test.go
@@ -272,6 +272,65 @@ func TestClaudeGenerateHookConfig_ThreeLevelNesting(t *testing.T) {
 	}
 }
 
+func TestAnchorHookCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"relative dot-slash", "./tools/hooks/x.sh", "$CLAUDE_PROJECT_DIR/tools/hooks/x.sh"},
+		{"relative with args", "./tools/hooks/x.sh --flag a", "$CLAUDE_PROJECT_DIR/tools/hooks/x.sh --flag a"},
+		{"absolute path untouched", "/usr/local/bin/x.sh", "/usr/local/bin/x.sh"},
+		{"already anchored untouched", "$CLAUDE_PROJECT_DIR/x.sh", "$CLAUDE_PROJECT_DIR/x.sh"},
+		{"path-style command untouched", "make build", "make build"},
+		{"bare relative untouched", "tools/hooks/x.sh", "tools/hooks/x.sh"},
+		{"parent relative untouched", "../x.sh", "../x.sh"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := anchorHookCommand(tt.in); got != tt.want {
+				t.Errorf("anchorHookCommand(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClaudeGenerateHookConfig_AnchorsRelativePaths(t *testing.T) {
+	c := &Claude{}
+	hooks := map[string][]plugin.HookEntry{
+		"before_tool": {
+			{Matcher: "Bash", Command: "./tools/hooks/guard.sh"},
+		},
+		"on_stop": {
+			{Command: "make check"},
+		},
+	}
+
+	result, err := c.GenerateHookConfig(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := result[filepath.Join(".claude", "hooks", "hooks.json")]
+
+	var settings struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if got := settings.Hooks["PreToolUse"][0].Hooks[0].Command; got != "$CLAUDE_PROJECT_DIR/tools/hooks/guard.sh" {
+		t.Errorf("relative command not anchored: got %q", got)
+	}
+	if got := settings.Hooks["Stop"][0].Hooks[0].Command; got != "make check" {
+		t.Errorf("path-style command should be untouched: got %q", got)
+	}
+}
+
 func TestClaudeGenerateMCPConfig_NilServers(t *testing.T) {
 	c := &Claude{}
 	result, err := c.GenerateMCPConfig(nil)


### PR DESCRIPTION
## Summary

Implements the **code-side** findings from the sensor/hook field bug report (`YNH-SENSOR-HOOK-BUGREPORT.md`) — getting YNH-declared hooks to actually fire and feed verdicts back in a normal `claude` session, where plugin-dir hooks don't auto-activate. (The doc-only findings shipped earlier in #171.)

## What's in this PR

### Finding 7.1 — path anchoring (`internal/vendor/claude.go`)
`GenerateHookConfig` rewrites a leading `./` in a hook command to `$CLAUDE_PROJECT_DIR/…`. Claude runs hooks in the agent's **cwd**, so a relative command broke the moment the agent did `cd` into a subdirectory — and a *blocking guard* hook then failed open. Absolute, `$VAR`-anchored, and PATH-style commands are untouched. Adds `ClaudeHookEvent()` as the single source of the canonical→native event map.

### Finding 1 — `ynh hook export <harness> --target <settings|local>`
Translates a harness's canonical hooks into the Claude settings file that auto-loads in a plain session.
- `--target` is **required** (no default — committed `settings.json` vs gitignored `settings.local.json` is always explicit)
- **Additive union + dedup**: non-hook keys (`permissions`, `env`, …) and the user's own hooks are preserved; re-running adds nothing already present (idempotent)
- `--dry-run` previews; Claude-only (other vendors auto-load hooks via symlink install)

### Findings 5 + 2 — `ynh doctor`
Static diagnostic over `.claude/settings.json` + `settings.local.json`:
- canonical names that leaked into a settings file (where Claude silently ignores them)
- cwd-relative hook commands
- a project with no settings file (hooks declared but unwired → nudges to `hook export`)

Text output only — no structured-output schema introduced.

### Finding 2 — `ynd validate` hint
An invalid hook event that is a known **vendor-native** name (`PreToolUse`, `afterFileEdit`, …) now gets a targeted hint pointing to the canonical equivalent. Genuinely unknown events produce the identical prior message.

### Docs
`hooks.md` and `reference.md` document `hook export` + `doctor`; the `hooks.md` "plain Claude session" section now leads with the commands. Command list refreshed in `.claude/CLAUDE.md`.

## Out of scope (deliberately)
Cross-vendor path rewriting for Cursor/Codex (no project-root env var exposed by their adapters — flagged in docs instead) and a `doctor` self-test that injects a sentinel hook (Finding 5 stretch). Can follow up.

## Incidental fix
Tutorial 02 T2.7 had a pre-existing stale-doc bug (unrelated to this branch): the prune simulation deleted `~/.ynh/harnesses/local--my-harness` (empty for local installs), so prune correctly reported nothing stale. Corrected to remove the actual install record (`~/.ynh/installed/local--my-harness.json`) and dropped the spurious `Removed stale run dir` line. Unblocks the eval suite.

## Verification
- `make check` — 0 lint, all tests pass (race + coverage), build clean
- Manual spot-check in `/tmp`: `hook export` anchors `./` paths and translates events; `doctor` flags the leak/relative-command/empty-project cases; prune fix reproduced
- Eval suite — **PASS** (21 cases, 0 failures); T2.7 + T1.5 verified
- No `--format json` response shape changed → no capability bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)