### PR TITLE
fix(uninstall): preserve bare-name resources claimed by another install

### DIFF
--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -684,33 +684,110 @@ func cmdUninstall(args []string) error {
 		}
 	}
 
-	// Remove launcher script
-	launcherPath := filepath.Join(config.BinDir(), bareName)
-	_ = os.Remove(launcherPath) // ignore error if launcher doesn't exist
+	// The launcher (~/.ynh/bin/<name>), run dir (~/.ynh/run/<name>) and
+	// sources entry are keyed by bare name and therefore shared across
+	// installs whose canonical ids differ only in namespace (e.g.
+	// "local/foo" vs "github.com/org/repo/foo"). Remove them only when no
+	// other install still claims the name; otherwise leave them for the
+	// survivor, repointing the launcher if it targeted the install just
+	// removed.
+	uninstalledIDs := map[string]bool{ref: true}
+	if ptr != nil {
+		// Pointer registrations are listed under "local/<name>" regardless
+		// of the ref form used to remove them.
+		uninstalledIDs["local/"+bareName] = true
+	}
+	var launcherNote string
+	survivors, surErr := bareNameSurvivors(bareName, uninstalledIDs)
+	switch {
+	case surErr != nil:
+		// Can't tell whether the name is still claimed — leave the shared
+		// resources in place rather than risk orphaning a surviving install.
+		fmt.Fprintf(os.Stderr, "warning: could not check for other installs named %q: %v\n", bareName, surErr)
+		fmt.Fprintf(os.Stderr, "  launcher, run dir and sources entry left in place\n")
+	case len(survivors) == 0:
+		// Remove launcher script
+		launcherPath := filepath.Join(config.BinDir(), bareName)
+		_ = os.Remove(launcherPath) // ignore error if launcher doesn't exist
 
-	// Remove run directory
-	runDir := filepath.Join(config.RunDir(), bareName)
-	_ = os.RemoveAll(runDir) // ignore error if not present
+		// Remove run directory
+		runDir := filepath.Join(config.RunDir(), bareName)
+		_ = os.RemoveAll(runDir) // ignore error if not present
 
-	// Remove matching sources entry if present
-	if cfg, err := config.Load(); err == nil {
-		remaining := make([]config.Source, 0, len(cfg.Sources))
-		for _, s := range cfg.Sources {
-			if s.Name != bareName {
-				remaining = append(remaining, s)
+		// Remove matching sources entry if present
+		if cfg, err := config.Load(); err == nil {
+			remaining := make([]config.Source, 0, len(cfg.Sources))
+			for _, s := range cfg.Sources {
+				if s.Name != bareName {
+					remaining = append(remaining, s)
+				}
+			}
+			cfg.Sources = remaining
+			if err := cfg.Save(); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not update config after uninstall: %v\n", err)
 			}
 		}
-		cfg.Sources = remaining
-		if err := cfg.Save(); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: could not update config after uninstall: %v\n", err)
-		}
+	default:
+		launcherNote = repointLauncher(bareName, survivors)
 	}
 
 	fmt.Printf("Uninstalled harness %q\n", bareName)
+	if launcherNote != "" {
+		fmt.Printf("  %s\n", launcherNote)
+	}
 	if pointerSource != "" {
 		fmt.Printf("  Source tree left in place: %s\n", pointerSource)
 	}
 	return nil
+}
+
+// bareNameSurvivors returns the canonical ids of installed harnesses that
+// still claim bareName after an uninstall. Runs post-removal, so the removed
+// install is already absent from ListAll; uninstalledIDs additionally drops
+// stale duplicate registrations of the just-removed canonical id (e.g. an
+// unmigrated schema-1 flat tree shadowing the schema-2 dir that was removed).
+// Results keep ListAll order (namespace, then name) so callers that pick one
+// get a deterministic choice.
+func bareNameSurvivors(bareName string, uninstalledIDs map[string]bool) ([]string, error) {
+	entries, err := harness.ListAll()
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, e := range entries {
+		if e.Name != bareName {
+			continue
+		}
+		if id := canonicalIDForEntry(e); !uninstalledIDs[id] {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
+
+// repointLauncher keeps the bare-name launcher usable for the installs that
+// still claim the name after an uninstall. If the launcher already targets
+// one of the survivors it is left untouched; otherwise it is regenerated for
+// the first survivor. Returns a user-facing note for the uninstall summary,
+// or "" when there is nothing to report (reserved names never get a
+// launcher — see cmdInstall).
+func repointLauncher(bareName string, survivors []string) string {
+	if bareName == "ynh" {
+		return ""
+	}
+	launcherPath := filepath.Join(config.BinDir(), bareName)
+	if body, err := os.ReadFile(launcherPath); err == nil {
+		for _, id := range survivors {
+			if strings.Contains(string(body), fmt.Sprintf("ynh run %q", id)) {
+				return fmt.Sprintf("Launcher kept: targets surviving install %s", id)
+			}
+		}
+	}
+	if err := generateLauncher(bareName, survivors[0]); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not regenerate launcher for %s: %v\n", survivors[0], err)
+		return ""
+	}
+	return fmt.Sprintf("Launcher repointed to surviving install %s", survivors[0])
 }
 
 // harnessHasRemoteSource reports whether the harness was installed from a

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -624,6 +624,169 @@ func TestCmdUninstall_RemovesSourcesEntry(t *testing.T) {
 	}
 }
 
+// installSharedBareNameFixtures sets up two installs that share the bare
+// name "foo" but have distinct canonical ids — a schema-1 pointer
+// registration ("local/foo") and a schema-2 git tree
+// ("github.com/org/repo/foo") — plus the bare-name-shared resources:
+// launcher (targeting the git install), run dir, and a sources entry.
+// Returns the git install's tree directory.
+func installSharedBareNameFixtures(t *testing.T) string {
+	t.Helper()
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pointer install: local/foo → source tree with a valid manifest.
+	srcDir := t.TempDir()
+	pluginDir := filepath.Join(srcDir, ".ynh-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"),
+		[]byte(`{"name":"foo","version":"1.0.0","default_vendor":"claude"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := harness.SavePointer(&harness.Pointer{
+		Name: "foo",
+		InstalledJSON: plugin.InstalledJSON{
+			SourceType:  "local",
+			Source:      srcDir,
+			InstalledAt: "2026-05-01T00:00:00Z",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tree install: github.com/org/repo/foo at the schema-2 id-keyed path.
+	treeDir := harness.InstalledDirByID("github.com/org/repo/foo")
+	treePluginDir := filepath.Join(treeDir, ".ynh-plugin")
+	if err := os.MkdirAll(treePluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(treePluginDir, "plugin.json"),
+		[]byte(`{"name":"foo","version":"1.0.0","default_vendor":"claude"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Launcher targets the git install (installed last, regenerated last).
+	if err := os.MkdirAll(config.BinDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	launcher := "#!/bin/bash\nexec ynh run \"github.com/org/repo/foo\" \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(config.BinDir(), "foo"), []byte(launcher), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run dir with state, and a bare-name sources entry.
+	runDir := filepath.Join(config.RunDir(), "foo")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Sources: []config.Source{{Name: "foo", Path: srcDir}}}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	return treeDir
+}
+
+// Uninstalling one of two same-named installs must not destroy the
+// bare-name-shared resources (launcher, run dir, sources entry) the other
+// install still uses.
+func TestCmdUninstall_SharedBareName_PreservesOtherInstallResources(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	treeDir := installSharedBareNameFixtures(t)
+
+	// Remove only the local pointer registration.
+	if err := cmdUninstall([]string{"local/foo"}); err != nil {
+		t.Fatalf("cmdUninstall local/foo failed: %v", err)
+	}
+
+	if _, err := os.Stat(harness.PointerPath("foo")); !os.IsNotExist(err) {
+		t.Errorf("pointer still exists after uninstall: err=%v", err)
+	}
+	if _, err := os.Stat(treeDir); err != nil {
+		t.Errorf("surviving git install tree was removed: %v", err)
+	}
+
+	// Launcher must survive and still target the surviving install.
+	body, err := os.ReadFile(filepath.Join(config.BinDir(), "foo"))
+	if err != nil {
+		t.Fatalf("launcher was removed despite surviving install: %v", err)
+	}
+	if !strings.Contains(string(body), `"github.com/org/repo/foo"`) {
+		t.Errorf("launcher no longer targets surviving install; got:\n%s", body)
+	}
+
+	// Run dir and sources entry must survive.
+	if _, err := os.Stat(filepath.Join(config.RunDir(), "foo")); err != nil {
+		t.Errorf("run dir was removed despite surviving install: %v", err)
+	}
+	loaded, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Sources) != 1 || loaded.Sources[0].Name != "foo" {
+		t.Errorf("sources entry was removed despite surviving install: %+v", loaded.Sources)
+	}
+}
+
+// Uninstalling the install the launcher targets must regenerate the launcher
+// for the survivor — and once the last same-named install goes, the shared
+// resources must be cleaned up as before.
+func TestCmdUninstall_SharedBareName_RepointsLauncherToSurvivor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	treeDir := installSharedBareNameFixtures(t)
+
+	// Remove the git install — the one the launcher targets.
+	if err := cmdUninstall([]string{"github.com/org/repo/foo"}); err != nil {
+		t.Fatalf("cmdUninstall github.com/org/repo/foo failed: %v", err)
+	}
+
+	if _, err := os.Stat(treeDir); !os.IsNotExist(err) {
+		t.Errorf("git install tree still exists after uninstall: err=%v", err)
+	}
+	if _, err := os.Stat(harness.PointerPath("foo")); err != nil {
+		t.Errorf("surviving pointer registration was removed: %v", err)
+	}
+
+	// Launcher must be regenerated to target the surviving local install.
+	body, err := os.ReadFile(filepath.Join(config.BinDir(), "foo"))
+	if err != nil {
+		t.Fatalf("launcher was removed despite surviving install: %v", err)
+	}
+	if !strings.Contains(string(body), `"local/foo"`) {
+		t.Errorf("launcher not repointed to surviving install; got:\n%s", body)
+	}
+	if _, err := os.Stat(filepath.Join(config.RunDir(), "foo")); err != nil {
+		t.Errorf("run dir was removed despite surviving install: %v", err)
+	}
+
+	// Last one out: removing the surviving install cleans up everything.
+	if err := cmdUninstall([]string{"local/foo"}); err != nil {
+		t.Fatalf("cmdUninstall local/foo failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(config.BinDir(), "foo")); !os.IsNotExist(err) {
+		t.Errorf("launcher still exists after last uninstall: err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(config.RunDir(), "foo")); !os.IsNotExist(err) {
+		t.Errorf("run dir still exists after last uninstall: err=%v", err)
+	}
+	loaded, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range loaded.Sources {
+		if s.Name == "foo" {
+			t.Errorf("sources entry still present after last uninstall: %+v", loaded.Sources)
+		}
+	}
+}
+
 func TestCmdList_Empty(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)


### PR DESCRIPTION
## Summary

Launchers (`~/.ynh/bin/<name>`), run dirs (`~/.ynh/run/<name>`), and sources entries are keyed by bare harness name, but installs are identified by canonical id. When two installs shared a bare name (e.g. `local/foo` alongside `github.com/org/repo/foo` — a coexistence `harness.ListAll()` explicitly supports), `ynh uninstall <id>` of one silently destroyed the shared resources the other still used: launcher gone, run-dir state lost, sources entry stripped.

**Severity note:** run-dir removal hits live sessions — `ynh run` assembles the vendor config under `~/.ynh/run/<name>` (run-dir naming uses the bare `p.Name`, see `cmdRun`) and then `syscall.Exec`s the vendor CLI, which runs out of that directory for the entire session. An open session therefore lost its assembled plugin directory mid-session when another install sharing the bare name was uninstalled.

`cmdUninstall` now enumerates the remaining installs after removing the pointer/tree:

- **Another install still claims the name** → launcher, run dir, and sources entry are left in place. If the launcher targeted the install just removed, it is regenerated for the first survivor in `ListAll` order (deterministic when several remain); if it already targets a survivor, it is kept untouched. The uninstall summary reports which.
- **No survivor** → cleanup behaves exactly as before.
- **Enumeration fails** → shared resources are conservatively left in place with a warning, rather than risking orphaning a surviving install.

The survivor scan excludes entries with the just-removed canonical id, so stale schema-1 duplicates of the same install don't suppress cleanup.

## Testing

- `make check` green
- New tests `TestCmdUninstall_SharedBareName_PreservesOtherInstallResources` and `TestCmdUninstall_SharedBareName_RepointsLauncherToSurvivor` — verified red against the old code, green with the fix; covers keep, repoint, and last-one-out cleanup
- Evals: PASS (8 locally-testable tutorials, 0 failures)
- Manual spot-check with the built binary in an isolated `YNH_HOME`: reproduced the issue scenario; launcher kept when targeting the survivor, repointed when it targeted the removed install, fully cleaned up after the last uninstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)
