### PR TITLE
fix(run): key run dirs by canonical id so same-named installs can't clobber each other

### DIFF
--- a/.claude/skills/ynh-dev/references/architecture.md
+++ b/.claude/skills/ynh-dev/references/architecture.md
@@ -8,7 +8,7 @@
 
 1. **Detect** harness format and load manifest (`internal/harness/`, `internal/plugin/`)
 2. **Resolve** Git includes from local cache (`internal/resolver/`) — repos are pre-fetched at install time; run uses cache-only with fallback fetch on miss
-3. **Assemble** vendor config into `~/.ynh/run/<name>/` (`internal/assembler/`)
+3. **Assemble** vendor config into `~/.ynh/run/<id-fsname>/` (e.g. `run/local--foo/`) (`internal/assembler/`)
 4. **Launch** vendor CLI, adapting to each vendor's capabilities (`internal/vendor/`)
 
 ## Package structure
@@ -39,7 +39,7 @@ testdata/                 Test fixtures (sample-harness, monorepo, etc.)
 - **Vendor is a deployment concern** - harnesses define what, adapters decide where/how
 - **Git is the package manager** - no registry, content cached locally by URL+ref hash
 - **Vendor-adaptive launch** - Claude uses `syscall.Exec` (native `--plugin-dir`), Codex/Cursor use child process with signal forwarding (symlink-based install)
-- **Deterministic run dir** - `~/.ynh/run/<name>/` overwritten each run (no temp dir leaks)
+- **Deterministic run dir** - `~/.ynh/run/<id-fsname>/` (keyed by canonical id) overwritten each run (no temp dir leaks; same-named installs don't clobber each other)
 - **Single manifest** - `.harness.json` for all config (identity, includes, hooks, MCP servers, profiles)
 
 ## Adapter interface

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -412,7 +412,7 @@ The resolver clones Git repos into `~/.ynh/cache/` using a deterministic directo
 
 ### Assembler
 
-The assembler builds a deterministic run directory (`~/.ynh/run/<name>/`) with the vendor's expected layout. It accepts the narrow `LayoutProvider` interface (not the full `Adapter`) and copies files from resolved content into the right artifact directories (e.g., `skills/` files go into `.claude/skills/`), and copies instructions (`instructions.md` or `AGENTS.md` as fallback) to the vendor's project instructions file (e.g., `CLAUDE.md`). After assembly, hook and MCP configs are generated via the adapter's `GenerateHookConfig()` and `GenerateMCPConfig()` methods, and plugin manifests via `GeneratePluginManifest()`. The run directory is cleaned and repopulated on each run. Two modes:
+The assembler builds a deterministic run directory (`~/.ynh/run/<idfsname>/`, e.g. `run/local--foo/`) with the vendor's expected layout. It accepts the narrow `LayoutProvider` interface (not the full `Adapter`) and copies files from resolved content into the right artifact directories (e.g., `skills/` files go into `.claude/skills/`), and copies instructions (`instructions.md` or `AGENTS.md` as fallback) to the vendor's project instructions file (e.g., `CLAUDE.md`). After assembly, hook and MCP configs are generated via the adapter's `GenerateHookConfig()` and `GenerateMCPConfig()` methods, and plugin manifests via `GeneratePluginManifest()`. The run directory is cleaned and repopulated on each run. Two modes:
 
 - **With pick list**: Only specified paths are copied
 - **Without pick list**: All recognized artifact directories are scanned and copied
@@ -538,7 +538,7 @@ When `ynh run` is invoked, the harness source is resolved in this order:
 2. **`--harness-file`**: `ynh run --harness-file path/.harness.json` → loads a legacy single-file manifest directly from the given path. Path-based, no canonical-id classification.
 3. **Auto-discovery**: bare `ynh run` → migrates the current working directory if needed, then loads `.ynh-plugin/plugin.json` from cwd.
 
-For `--harness-file` and auto-discovery, the harness is assembled into `~/.ynh/run/_inline-<hash>/` (hash of the source directory for stable run dirs). For positional refs, the run-dir is named after the manifest's bare `Name` field — keeping `~/.ynh/run/` paths flat (no `/` characters).
+For `--harness-file` and auto-discovery, the harness is assembled into `~/.ynh/run/_inline-<hash>/` (hash of the source directory for stable run dirs). For positional refs, the run-dir is the canonical id's fs name (`local/foo` → `~/.ynh/run/local--foo/`) — keeping `~/.ynh/run/` paths flat while giving same-named installs with distinct canonical ids distinct run dirs. While a bare name is unambiguous (one install claims it), run also maintains a legacy alias symlink (`run/<name>` → `<idfsname>`) so project symlinks planted before the id-keyed re-key keep resolving; when several installs claim the name the alias is removed and dangling project symlinks are re-planted on the next run (see `symlinkIntact`).
 
 ### Install Lifecycle
 
@@ -564,7 +564,7 @@ During install:
 - The source `.ynh-plugin/plugin.json` is never modified.
 
 At runtime:
-- `ynh run` reads the installed copy at `~/.ynh/harnesses/<idfsname>/.ynh-plugin/plugin.json` to resolve includes, delegates, and vendor settings. Run-dir naming uses the bare `name` field from the manifest, not the canonical id, so paths under `~/.ynh/run/` stay flat.
+- `ynh run` reads the installed copy at `~/.ynh/harnesses/<idfsname>/.ynh-plugin/plugin.json` to resolve includes, delegates, and vendor settings. Run-dir naming uses the canonical id's fs name (`run/<idfsname>/`), so same-named installs with distinct canonical ids can't clobber each other's assembled layouts or live sessions.
 - Cached repos are used as-is without hitting the network. If a cache entry is missing (e.g. manually cleared), ynh falls back to a network fetch with a warning.
 - Launchers at `~/.ynh/bin/<name>` invoke `ynh run "<canonical-id>" "$@"` — the schema-2 resolver rejects bare names, so the embedded ref must be the canonical id.
 

--- a/cmd/ynh/image.go
+++ b/cmd/ynh/image.go
@@ -26,21 +26,27 @@ type imageTemplateData struct {
 
 // imageDockerfileTmpl is the Dockerfile template for harness images.
 // It layers pre-assembled vendor layouts on top of the base ynh image.
+//
+// All baked paths use the canonical-id layout: the harness source lands at
+// the schema-2 install path (harnesses/local--<name>) and vendor layouts at
+// the id-keyed run dirs (run/local--<name>/<vendor>), so the entrypoint's
+// "ynh run local/<name>" resolves them directly. The entrypoint must be a
+// canonical id — LoadQualified hard-rejects bare names.
 var imageDockerfileTmpl = template.Must(template.New("Dockerfile").Parse(`FROM {{.Base}}
 
 # Pre-assembled vendor layouts (all three, ready to use)
-COPY --link --chown=ynh:ynh vendors/claude/ /home/ynh/.ynh/run/{{.Name}}/claude/
-COPY --link --chown=ynh:ynh vendors/codex/ /home/ynh/.ynh/run/{{.Name}}/codex/
-COPY --link --chown=ynh:ynh vendors/cursor/ /home/ynh/.ynh/run/{{.Name}}/cursor/
+COPY --link --chown=ynh:ynh vendors/claude/ /home/ynh/.ynh/run/local--{{.Name}}/claude/
+COPY --link --chown=ynh:ynh vendors/codex/ /home/ynh/.ynh/run/local--{{.Name}}/codex/
+COPY --link --chown=ynh:ynh vendors/cursor/ /home/ynh/.ynh/run/local--{{.Name}}/cursor/
 
 # Harness source (metadata for ynh run)
-COPY --link --chown=ynh:ynh harness/ /home/ynh/.ynh/harnesses/{{.Name}}/
+COPY --link --chown=ynh:ynh harness/ /home/ynh/.ynh/harnesses/local--{{.Name}}/
 
 # Default vendor (override: docker run -e YNH_VENDOR=codex)
 ENV YNH_VENDOR={{.DefaultVendor}}
 
 # Baked entrypoint — just pass the prompt as CMD
-ENTRYPOINT ["tini", "-s", "--", "ynh", "run", "{{.Name}}"]
+ENTRYPOINT ["tini", "-s", "--", "ynh", "run", "local/{{.Name}}"]
 CMD []
 
 LABEL dev.ynh.harness="{{.Name}}" \

--- a/cmd/ynh/image_test.go
+++ b/cmd/ynh/image_test.go
@@ -154,15 +154,17 @@ func TestGenerateDockerfile(t *testing.T) {
 		t.Fatalf("generateDockerfile failed: %v", err)
 	}
 
-	// Check key lines are present
+	// Check key lines are present. Baked paths use the canonical-id layout
+	// (run/local--<name>, harnesses/local--<name>) and the entrypoint passes
+	// a canonical id — LoadQualified rejects bare names.
 	checks := []string{
 		"FROM ghcr.io/eyelock/ynh:latest",
-		"vendors/claude/ /home/ynh/.ynh/run/david/claude/",
-		"vendors/codex/ /home/ynh/.ynh/run/david/codex/",
-		"vendors/cursor/ /home/ynh/.ynh/run/david/cursor/",
-		"harness/ /home/ynh/.ynh/harnesses/david/",
+		"vendors/claude/ /home/ynh/.ynh/run/local--david/claude/",
+		"vendors/codex/ /home/ynh/.ynh/run/local--david/codex/",
+		"vendors/cursor/ /home/ynh/.ynh/run/local--david/cursor/",
+		"harness/ /home/ynh/.ynh/harnesses/local--david/",
 		"ENV YNH_VENDOR=claude",
-		`ENTRYPOINT ["tini", "-s", "--", "ynh", "run", "david"]`,
+		`ENTRYPOINT ["tini", "-s", "--", "ynh", "run", "local/david"]`,
 		`dev.ynh.harness="david"`,
 		`dev.ynh.harness.default-vendor="claude"`,
 		`dev.ynh.assembled-by="v1.2.3"`,

--- a/cmd/ynh/main.go
+++ b/cmd/ynh/main.go
@@ -688,19 +688,27 @@ func cmdUninstall(args []string) error {
 		}
 	}
 
-	// The launcher (~/.ynh/bin/<name>), run dir (~/.ynh/run/<name>) and
-	// sources entry are keyed by bare name and therefore shared across
-	// installs whose canonical ids differ only in namespace (e.g.
-	// "local/foo" vs "github.com/org/repo/foo"). Remove them only when no
-	// other install still claims the name; otherwise leave them for the
-	// survivor, repointing the launcher if it targeted the install just
-	// removed.
+	// Run dirs are keyed by canonical id ("local--foo"), so the removed
+	// install's run dirs are exclusively its own — remove them outright.
+	// Both id forms in uninstalledIDs may have dirs; removing a missing one
+	// is a no-op.
 	uninstalledIDs := map[string]bool{ref: true}
 	if ptr != nil {
 		// Pointer registrations are listed under "local/<name>" regardless
 		// of the ref form used to remove them.
 		uninstalledIDs["local/"+bareName] = true
 	}
+	for id := range uninstalledIDs {
+		_ = os.RemoveAll(filepath.Join(config.RunDir(), namespace.IDToFSName(id)))
+	}
+
+	// The launcher (~/.ynh/bin/<name>), legacy bare-name run path
+	// (~/.ynh/run/<name>) and sources entry are keyed by bare name and
+	// therefore shared across installs whose canonical ids differ only in
+	// namespace (e.g. "local/foo" vs "github.com/org/repo/foo"). Remove
+	// them only when no other install still claims the name; otherwise
+	// leave them for the survivor, repointing the launcher and the legacy
+	// run alias if they targeted the install just removed.
 	var launcherNote string
 	survivors, surErr := bareNameSurvivors(bareName, uninstalledIDs)
 	switch {
@@ -708,13 +716,14 @@ func cmdUninstall(args []string) error {
 		// Can't tell whether the name is still claimed — leave the shared
 		// resources in place rather than risk orphaning a surviving install.
 		fmt.Fprintf(os.Stderr, "warning: could not check for other installs named %q: %v\n", bareName, surErr)
-		fmt.Fprintf(os.Stderr, "  launcher, run dir and sources entry left in place\n")
+		fmt.Fprintf(os.Stderr, "  launcher, run alias and sources entry left in place\n")
 	case len(survivors) == 0:
 		// Remove launcher script
 		launcherPath := filepath.Join(config.BinDir(), bareName)
 		_ = os.Remove(launcherPath) // ignore error if launcher doesn't exist
 
-		// Remove run directory
+		// Remove legacy bare-name run path (pre-re-key real dir or alias
+		// symlink — RemoveAll removes a symlink without following it)
 		runDir := filepath.Join(config.RunDir(), bareName)
 		_ = os.RemoveAll(runDir) // ignore error if not present
 
@@ -733,6 +742,7 @@ func cmdUninstall(args []string) error {
 		}
 	default:
 		launcherNote = repointLauncher(bareName, survivors)
+		repointLegacyRunAlias(bareName, uninstalledIDs, survivors)
 	}
 
 	fmt.Printf("Uninstalled harness %q\n", bareName)
@@ -792,6 +802,35 @@ func repointLauncher(bareName string, survivors []string) string {
 		return ""
 	}
 	return fmt.Sprintf("Launcher repointed to surviving install %s", survivors[0])
+}
+
+// repointLegacyRunAlias keeps the legacy bare-name run path (run/<name>,
+// a symlink to an id-keyed run dir — see updateLegacyRunAlias) coherent
+// after an uninstall with survivors. An alias targeting a removed install's
+// run dir is repointed to the sole survivor, or removed when several
+// survivors make the bare name ambiguous. A real directory (stale
+// pre-re-key assembly) or an alias already targeting a survivor is left
+// alone. Best-effort: failures leave a dangling alias, which run repairs.
+func repointLegacyRunAlias(bareName string, uninstalledIDs map[string]bool, survivors []string) {
+	alias := filepath.Join(config.RunDir(), bareName)
+	target, err := os.Readlink(alias)
+	if err != nil {
+		return // no alias (or a real dir) — nothing to repoint
+	}
+	removed := false
+	for id := range uninstalledIDs {
+		if target == namespace.IDToFSName(id) {
+			removed = true
+			break
+		}
+	}
+	if !removed {
+		return
+	}
+	_ = os.Remove(alias)
+	if len(survivors) == 1 {
+		_ = os.Symlink(namespace.IDToFSName(survivors[0]), alias)
+	}
 }
 
 // harnessHasRemoteSource reports whether the harness was installed from a
@@ -1014,14 +1053,12 @@ func cmdRun(args []string) error {
 
 	// Resolve harness source: name > --harness-file > .harness.json in cwd > error
 	var p *harness.Harness
-	var name string
 	var harnessDir string // directory containing harness content (for local artifacts)
 	var err error
 
 	switch {
 	case ra.HarnessName != "":
-		name = ra.HarnessName
-		p, err = harness.LoadQualified(name)
+		p, err = harness.LoadQualified(ra.HarnessName)
 		if err != nil {
 			return err
 		}
@@ -1053,7 +1090,6 @@ func cmdRun(args []string) error {
 		}
 		harnessDir = cwd
 	}
-	_ = name // run-dir naming uses p.Name; this var is retained only for legacy logging paths above
 
 	// Resolve focus → profile + prompt
 	if ra.FocusFlag != "" {
@@ -1137,22 +1173,25 @@ func cmdRun(args []string) error {
 	// We use a stable path instead of a temp dir because syscall.Exec
 	// replaces this process — deferred cleanup would never run.
 	//
-	// Run-dir naming uses the harness's bare Name (not the user-typed
-	// canonical id) so that paths under run/ stay flat and don't contain
-	// slashes. p.Name is set when the harness loaded successfully.
-	runDirName := p.Name
+	// Run-dir naming uses the canonical id's fs name ("local/foo" →
+	// "local--foo") so same-named installs with distinct canonical ids get
+	// distinct run dirs and can't clobber each other's live sessions.
+	// LoadQualified already enforced that ra.HarnessName is a canonical id.
+	// Inline/discovered harnesses have no canonical id and use a hash-based
+	// name instead.
+	runDirName := namespace.IDToFSName(ra.HarnessName)
 	if ra.HarnessFile != "" || ra.HarnessName == "" {
 		// Inline/discovered harness: use a hash-based stable dir name
 		h := fmt.Sprintf("%x", hashString(harnessDir))
 		runDirName = "_inline-" + h[:8]
 	}
 	runDir := filepath.Join(config.RunDir(), runDirName)
-	vendorRunDir := filepath.Join(runDir, vendorName)
-	if info, err := os.Stat(vendorRunDir); err == nil && info.IsDir() {
+	preassembledDir, preassembled := findPreassembledVendorDir(runDirName, p.Name, vendorName)
+	if preassembled {
 		// Pre-assembled layout (baked harness image) — use directly.
 		// Skip AssembleTo, delegate allow-list check, AND AssembleDelegates —
 		// everything was vetted and assembled at image build time.
-		runDir = vendorRunDir
+		runDir = preassembledDir
 	} else {
 		// Normal host flow — assemble now
 		if err := assembler.AssembleTo(runDir, adapter, content); err != nil {
@@ -1219,6 +1258,12 @@ func cmdRun(args []string) error {
 			if err := os.WriteFile(absPath, content, 0o644); err != nil {
 				return fmt.Errorf("writing manifest %s: %w", relPath, err)
 			}
+		}
+
+		// Keep the legacy bare-name run path resolving for project symlinks
+		// planted before run dirs were keyed by canonical id.
+		if ra.HarnessName != "" {
+			updateLegacyRunAlias(p.Name, runDirName)
 		}
 	}
 
@@ -1297,6 +1342,70 @@ func cmdRun(args []string) error {
 			return adapter.LaunchNonInteractive(runDir, prompt, vendorArgs)
 		}
 		return adapter.LaunchInteractive(runDir, vendorArgs)
+	}
+}
+
+// findPreassembledVendorDir looks for a baked vendor layout (harness image)
+// under the id-keyed run dir first, then under the legacy bare-name run dir
+// for images assembled by older ynh. Host-assembled run dirs never contain a
+// bare vendor-name subdirectory (vendor config dirs are dot-prefixed:
+// .claude, .codex, .cursor), so a match is always a baked layout.
+func findPreassembledVendorDir(runDirName, bareName, vendorName string) (string, bool) {
+	candidates := []string{filepath.Join(config.RunDir(), runDirName, vendorName)}
+	if bareName != "" && bareName != runDirName {
+		candidates = append(candidates, filepath.Join(config.RunDir(), bareName, vendorName))
+	}
+	for _, dir := range candidates {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir, true
+		}
+	}
+	return "", false
+}
+
+// updateLegacyRunAlias maintains a bare-name symlink run/<name> →
+// <id-fsname> beside the id-keyed run dir. Project symlinks planted by
+// older ynh point through the bare-name path; the alias keeps them
+// resolving after the id-keyed re-key. When several installs claim the
+// name the alias is removed instead — a bare-name path can't say which
+// install it means, and a dangling project link surfaces loudly (run
+// re-plants it, see symlinkIntact) where a silently re-bound one wouldn't.
+// Best-effort: alias failures degrade to the dangling-link path, never
+// fail the run.
+func updateLegacyRunAlias(bareName, runDirName string) {
+	if bareName == "" || bareName == runDirName {
+		return
+	}
+	alias := filepath.Join(config.RunDir(), bareName)
+	entries, err := harness.ListAll()
+	if err != nil {
+		return // can't tell who claims the name — leave the alias alone
+	}
+	// Count distinct canonical ids, not entries: a stale schema-1 duplicate
+	// of the same install (flat tree beside the id-keyed tree) is one
+	// logical claimant, not two.
+	claimants := map[string]bool{}
+	for _, e := range entries {
+		if e.Name == bareName {
+			claimants[canonicalIDForEntry(e)] = true
+		}
+	}
+	if len(claimants) > 1 {
+		// Only remove an alias we own (a symlink); never a real directory.
+		if fi, err := os.Lstat(alias); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+			_ = os.Remove(alias)
+		}
+		return
+	}
+	// Unambiguous: (re)point the alias. A real directory here is a stale
+	// pre-re-key assembly — the old flow clobbered it via AssembleTo on
+	// every run anyway, so replacing it with the alias loses nothing.
+	if err := os.RemoveAll(alias); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not refresh legacy run alias %s: %v\n", alias, err)
+		return
+	}
+	if err := os.Symlink(runDirName, alias); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not create legacy run alias %s: %v\n", alias, err)
 	}
 }
 
@@ -1762,10 +1871,16 @@ func cmdPrune() error {
 	// harness.Load(<bare-name>) no longer resolves an install whose
 	// canonical id is e.g. "local/<name>" — using ListAll names directly
 	// is both correct under schema 2 and faster than N Load calls.
+	//
+	// Membership covers both name forms: bare names (launchers, legacy run
+	// dirs, and the bare-name run alias — load-bearing for project symlinks
+	// planted before the id-keyed re-key) and id fs-names (run dirs keyed
+	// by canonical id, e.g. "local--foo").
 	installedNames := map[string]bool{}
 	if installs, err := harness.ListAll(); err == nil {
 		for _, e := range installs {
 			installedNames[e.Name] = true
+			installedNames[namespace.IDToFSName(canonicalIDForEntry(e))] = true
 		}
 	}
 
@@ -1821,12 +1936,19 @@ func cmdPrune() error {
 }
 
 // symlinkIntact returns true if at least one symlink from the installation
-// still exists on disk. Returns false if all symlinks are missing (e.g. the
-// user deleted the vendor config directory).
+// still exists on disk AND resolves to a live target. Returns false if all
+// symlinks are missing (e.g. the user deleted the vendor config directory)
+// or dangling (e.g. the run dir they point into was removed or re-keyed) —
+// either way the installation needs re-planting against the current run dir.
 func symlinkIntact(inst *symlink.Installation) bool {
 	for _, entry := range inst.Symlinks {
 		info, err := os.Lstat(entry.Link)
-		if err == nil && info.Mode()&os.ModeSymlink != 0 {
+		if err != nil || info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		// Stat follows the link: an error here means the target is gone —
+		// a dangling link is not intact.
+		if _, err := os.Stat(entry.Link); err == nil {
 			return true
 		}
 	}

--- a/cmd/ynh/main_test.go
+++ b/cmd/ynh/main_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/eyelock/ynh/internal/config"
 	"github.com/eyelock/ynh/internal/harness"
 	"github.com/eyelock/ynh/internal/plugin"
+	"github.com/eyelock/ynh/internal/symlink"
+	"github.com/eyelock/ynh/internal/vendor"
 )
 
 func TestParseRunArgs(t *testing.T) {
@@ -485,10 +487,11 @@ func installTestHarness(t *testing.T, name string) string {
 		t.Fatal(err)
 	}
 
-	// Create run directory
-	runDir := filepath.Join(config.RunDir(), name)
-	if err := os.MkdirAll(runDir, 0o755); err != nil {
-		t.Fatal(err)
+	// Create run directories: legacy bare-name path and id-keyed path
+	for _, dir := range []string{name, "local--" + name} {
+		if err := os.MkdirAll(filepath.Join(config.RunDir(), dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
 	}
 	return id
 }
@@ -520,10 +523,12 @@ func TestCmdUninstall_RemovesEverything(t *testing.T) {
 		t.Error("launcher still exists after uninstall")
 	}
 
-	// Run dir should be gone
-	runDir := filepath.Join(config.RunDir(), "david")
-	if _, err := os.Stat(runDir); !os.IsNotExist(err) {
-		t.Error("run directory still exists after uninstall")
+	// Run dirs should be gone — both the legacy bare-name path and the
+	// id-keyed path
+	for _, dir := range []string{"david", "local--david"} {
+		if _, err := os.Stat(filepath.Join(config.RunDir(), dir)); !os.IsNotExist(err) {
+			t.Errorf("run directory %q still exists after uninstall", dir)
+		}
 	}
 }
 
@@ -678,11 +683,18 @@ func installSharedBareNameFixtures(t *testing.T) string {
 		t.Fatal(err)
 	}
 
-	// Run dir with state, and a bare-name sources entry.
-	runDir := filepath.Join(config.RunDir(), "foo")
-	if err := os.MkdirAll(runDir, 0o755); err != nil {
+	// Id-keyed run dirs for both installs, plus the legacy bare-name alias
+	// pointing at the git install (run last). See updateLegacyRunAlias.
+	for _, fsName := range []string{"local--foo", "github.com--org--repo--foo"} {
+		if err := os.MkdirAll(filepath.Join(config.RunDir(), fsName), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink("github.com--org--repo--foo", filepath.Join(config.RunDir(), "foo")); err != nil {
 		t.Fatal(err)
 	}
+
+	// Bare-name sources entry.
 	cfg := &config.Config{Sources: []config.Source{{Name: "foo", Path: srcDir}}}
 	if err := cfg.Save(); err != nil {
 		t.Fatal(err)
@@ -720,9 +732,16 @@ func TestCmdUninstall_SharedBareName_PreservesOtherInstallResources(t *testing.T
 		t.Errorf("launcher no longer targets surviving install; got:\n%s", body)
 	}
 
-	// Run dir and sources entry must survive.
-	if _, err := os.Stat(filepath.Join(config.RunDir(), "foo")); err != nil {
-		t.Errorf("run dir was removed despite surviving install: %v", err)
+	// The removed install's id-keyed run dir goes; the survivor's stays,
+	// and the legacy alias still targets the survivor.
+	if _, err := os.Stat(filepath.Join(config.RunDir(), "local--foo")); !os.IsNotExist(err) {
+		t.Errorf("uninstalled install's run dir still exists: err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(config.RunDir(), "github.com--org--repo--foo")); err != nil {
+		t.Errorf("surviving install's run dir was removed: %v", err)
+	}
+	if target, err := os.Readlink(filepath.Join(config.RunDir(), "foo")); err != nil || target != "github.com--org--repo--foo" {
+		t.Errorf("legacy run alias disturbed: target=%q err=%v", target, err)
 	}
 	loaded, err := config.Load()
 	if err != nil {
@@ -762,8 +781,18 @@ func TestCmdUninstall_SharedBareName_RepointsLauncherToSurvivor(t *testing.T) {
 	if !strings.Contains(string(body), `"local/foo"`) {
 		t.Errorf("launcher not repointed to surviving install; got:\n%s", body)
 	}
-	if _, err := os.Stat(filepath.Join(config.RunDir(), "foo")); err != nil {
-		t.Errorf("run dir was removed despite surviving install: %v", err)
+
+	// The removed install's id-keyed run dir goes; the survivor's stays.
+	// The legacy alias targeted the removed install — it must be repointed
+	// to the sole survivor.
+	if _, err := os.Stat(filepath.Join(config.RunDir(), "github.com--org--repo--foo")); !os.IsNotExist(err) {
+		t.Errorf("uninstalled install's run dir still exists: err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(config.RunDir(), "local--foo")); err != nil {
+		t.Errorf("surviving install's run dir was removed: %v", err)
+	}
+	if target, err := os.Readlink(filepath.Join(config.RunDir(), "foo")); err != nil || target != "local--foo" {
+		t.Errorf("legacy run alias not repointed to survivor: target=%q err=%v", target, err)
 	}
 
 	// Last one out: removing the surviving install cleans up everything.
@@ -773,8 +802,11 @@ func TestCmdUninstall_SharedBareName_RepointsLauncherToSurvivor(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(config.BinDir(), "foo")); !os.IsNotExist(err) {
 		t.Errorf("launcher still exists after last uninstall: err=%v", err)
 	}
-	if _, err := os.Stat(filepath.Join(config.RunDir(), "foo")); !os.IsNotExist(err) {
-		t.Errorf("run dir still exists after last uninstall: err=%v", err)
+	if _, err := os.Stat(filepath.Join(config.RunDir(), "local--foo")); !os.IsNotExist(err) {
+		t.Errorf("id-keyed run dir still exists after last uninstall: err=%v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(config.RunDir(), "foo")); !os.IsNotExist(err) {
+		t.Errorf("legacy run alias still exists after last uninstall: err=%v", err)
 	}
 	loaded, err := config.Load()
 	if err != nil {
@@ -784,6 +816,145 @@ func TestCmdUninstall_SharedBareName_RepointsLauncherToSurvivor(t *testing.T) {
 		if s.Name == "foo" {
 			t.Errorf("sources entry still present after last uninstall: %+v", loaded.Sources)
 		}
+	}
+}
+
+// updateLegacyRunAlias must plant the bare-name alias for a single-claimant
+// name, repoint it when the target changes, and replace a stale pre-re-key
+// real directory.
+func TestUpdateLegacyRunAlias_PlantsRepointsAndReplaces(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	installTestHarness(t, "foo") // single claimant of "foo"
+	alias := filepath.Join(config.RunDir(), "foo")
+	// installTestHarness pre-creates run/foo as a real dir (legacy layout);
+	// the first alias update must replace it.
+	updateLegacyRunAlias("foo", "local--foo")
+	if target, err := os.Readlink(alias); err != nil || target != "local--foo" {
+		t.Fatalf("alias not planted over stale real dir: target=%q err=%v", target, err)
+	}
+	// Repoint to a different id-keyed dir.
+	updateLegacyRunAlias("foo", "github.com--org--repo--foo")
+	if target, err := os.Readlink(alias); err != nil || target != "github.com--org--repo--foo" {
+		t.Fatalf("alias not repointed: target=%q err=%v", target, err)
+	}
+}
+
+// With several installs claiming the bare name, the alias is ambiguous and
+// must be removed, not silently re-bound.
+func TestUpdateLegacyRunAlias_AmbiguousRemovesAlias(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+
+	installSharedBareNameFixtures(t) // two installs named "foo", alias planted
+
+	alias := filepath.Join(config.RunDir(), "foo")
+	updateLegacyRunAlias("foo", "local--foo")
+	if _, err := os.Lstat(alias); !os.IsNotExist(err) {
+		t.Errorf("ambiguous alias should be removed: err=%v", err)
+	}
+}
+
+// findPreassembledVendorDir must prefer the id-keyed baked layout and fall
+// back to the legacy bare-name layout for images baked by older ynh.
+func TestFindPreassembledVendorDir_LegacyFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Nothing baked: not found.
+	if dir, ok := findPreassembledVendorDir("local--foo", "foo", "claude"); ok {
+		t.Fatalf("expected no pre-assembled dir, got %q", dir)
+	}
+
+	// Legacy bare-name layout only (old image): found via fallback.
+	legacy := filepath.Join(config.RunDir(), "foo", "claude")
+	if err := os.MkdirAll(legacy, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if dir, ok := findPreassembledVendorDir("local--foo", "foo", "claude"); !ok || dir != legacy {
+		t.Fatalf("legacy fallback failed: dir=%q ok=%v", dir, ok)
+	}
+
+	// Id-keyed layout present: preferred over legacy.
+	idKeyed := filepath.Join(config.RunDir(), "local--foo", "claude")
+	if err := os.MkdirAll(idKeyed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if dir, ok := findPreassembledVendorDir("local--foo", "foo", "claude"); !ok || dir != idKeyed {
+		t.Fatalf("id-keyed layout not preferred: dir=%q ok=%v", dir, ok)
+	}
+}
+
+// A symlink whose target is gone (run dir removed or re-keyed) must not
+// count as intact — ynh run uses this to re-plant project symlinks.
+func TestSymlinkIntact_DanglingNotIntact(t *testing.T) {
+	dir := t.TempDir()
+
+	target := filepath.Join(dir, "target")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	inst := &symlink.Installation{
+		Symlinks: []vendor.SymlinkEntry{{Target: target, Link: link}},
+	}
+	if !symlinkIntact(inst) {
+		t.Fatal("live symlink should be intact")
+	}
+
+	// Remove the target: the link now dangles.
+	if err := os.RemoveAll(target); err != nil {
+		t.Fatal(err)
+	}
+	if symlinkIntact(inst) {
+		t.Error("dangling symlink should not be intact")
+	}
+}
+
+// Prune must keep id-keyed run dirs and the legacy bare-name alias of
+// installed harnesses, and still remove genuinely stale run dirs.
+func TestCmdPrune_RunDirKeying(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YNH_HOME", home)
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	installTestHarness(t, "foo")
+	// installTestHarness creates run/foo (real dir) and run/local--foo.
+	// Replace the legacy real dir with the alias form and add an orphan.
+	if err := os.RemoveAll(filepath.Join(config.RunDir(), "foo")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("local--foo", filepath.Join(config.RunDir(), "foo")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(config.RunDir(), "orphan"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdPrune(); err != nil {
+		t.Fatalf("cmdPrune failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(config.RunDir(), "local--foo")); err != nil {
+		t.Errorf("id-keyed run dir of installed harness was pruned: %v", err)
+	}
+	if target, err := os.Readlink(filepath.Join(config.RunDir(), "foo")); err != nil || target != "local--foo" {
+		t.Errorf("legacy run alias of installed harness was pruned: target=%q err=%v", target, err)
+	}
+	if _, err := os.Stat(filepath.Join(config.RunDir(), "orphan")); !os.IsNotExist(err) {
+		t.Errorf("stale run dir survived prune: err=%v", err)
 	}
 }
 

--- a/docs/tutorial/01-first-harness.md
+++ b/docs/tutorial/01-first-harness.md
@@ -248,7 +248,7 @@ my-harness --focus code-review --instructions "PR #22 in eyelock/assistants"
 > **Note:** The run directory is created by `ynh run`, which requires a vendor CLI. This step is only verifiable after running T1.6/T1.7/T1.8.
 
 ```bash
-ls -Ra ~/.ynh/run/my-harness/
+ls -Ra ~/.ynh/run/local--my-harness/
 ```
 
 Expected (stylized — actual `ls -Ra` format uses directory headers):
@@ -284,7 +284,7 @@ The `remove` alias also works: `ynh remove local/my-harness`.
 - `instructions.md` becomes vendor-specific project instructions
 - `ynh install` copies the harness and generates a launcher script
 - The launcher is a shell script that calls `ynh run`
-- `ynh run` assembles artifacts into `~/.ynh/run/<name>/` and launches the vendor CLI
+- `ynh run` assembles artifacts into `~/.ynh/run/<id>/` (the canonical id with `/` as `--`, e.g. `local--my-harness`) and launches the vendor CLI
 
 ## Next
 

--- a/docs/tutorial/02-vendors-and-symlinks.md
+++ b/docs/tutorial/02-vendors-and-symlinks.md
@@ -89,7 +89,7 @@ Expected:
 cursor requires symlinks in your project directory.
 The following symlinks will be created in /tmp/ynh-tutorial/project:
 
-  .cursor/skills/ping -> /Users/<you>/.ynh/run/my-harness/.cursor/skills/ping
+  .cursor/skills/ping -> /Users/<you>/.ynh/run/local--my-harness/.cursor/skills/ping
 
 Install 1 symlinks? [Y/n]
 ```
@@ -112,7 +112,7 @@ Expected:
 ```
 Installed 1 symlinks for my-harness (cursor) in /tmp/ynh-tutorial/project:
 
-  .cursor/skills/ping -> /Users/<you>/.ynh/run/my-harness/.cursor/skills/ping
+  .cursor/skills/ping -> /Users/<you>/.ynh/run/local--my-harness/.cursor/skills/ping
 ```
 
 ### Verify symlinks
@@ -121,7 +121,7 @@ Installed 1 symlinks for my-harness (cursor) in /tmp/ynh-tutorial/project:
 ls -la .cursor/skills/
 ```
 
-Symlinks point back to `~/.ynh/run/my-harness/`.
+Symlinks point back to `~/.ynh/run/local--my-harness/`.
 
 ### Check installation status
 

--- a/docs/tutorial/03-composition.md
+++ b/docs/tutorial/03-composition.md
@@ -73,7 +73,7 @@ my-dev "list your skills"
 ```
 
 ```bash
-ls ~/.ynh/run/my-dev/.claude/skills/
+ls ~/.ynh/run/local--my-dev/.claude/skills/
 # Expected: dev-project/ dev-quality/ go-lang/ help-me-answer/ (only the 4 picked skills)
 # NOT: dev-review/ dev-backend/ dev-ui/ etc.
 ```
@@ -212,7 +212,7 @@ full-stack "list your skills"
 ```
 
 ```bash
-ls ~/.ynh/run/full-stack/.claude/skills/
+ls ~/.ynh/run/local--full-stack/.claude/skills/
 # Expected: dev-project/ dev-quality/ dev-review/ go-lang/ frontend-design/
 ```
 
@@ -258,7 +258,7 @@ mixed "what skills do you have?"
 ```
 
 ```bash
-ls ~/.ynh/run/mixed/.claude/skills/
+ls ~/.ynh/run/local--mixed/.claude/skills/
 # Expected: my-custom-skill/ take-a-moment/ (local + remote)
 ```
 
@@ -316,7 +316,7 @@ local-ref "what skills do you have?"
 ```
 
 ```bash
-ls ~/.ynh/run/local-ref/.claude/skills/
+ls ~/.ynh/run/local--local-ref/.claude/skills/
 # Expected: fast-deploy/
 ```
 
@@ -351,7 +351,7 @@ with-bundled "what skills do you have?"
 ```
 
 ```bash
-ls ~/.ynh/run/with-bundled/.claude/skills/
+ls ~/.ynh/run/local--with-bundled/.claude/skills/
 # Expected: team-standards/
 ```
 
@@ -397,7 +397,7 @@ pinned "what skills do you have?"
 ```
 
 ```bash
-ls ~/.ynh/run/pinned/.claude/skills/
+ls ~/.ynh/run/local--pinned/.claude/skills/
 # Expected: help-me-answer/
 ```
 

--- a/docs/tutorial/04-delegation.md
+++ b/docs/tutorial/04-delegation.md
@@ -112,13 +112,13 @@ team-lead "list your available agents"
 Check what was generated:
 
 ```bash
-ls ~/.ynh/run/team-lead/.claude/agents/
+ls ~/.ynh/run/local--team-lead/.claude/agents/
 ```
 
 Expected: `specialist.md` and `researcher.md` — generated agent files with the delegate's instructions, rules, and skill lists inlined.
 
 ```bash
-cat ~/.ynh/run/team-lead/.claude/agents/specialist.md
+cat ~/.ynh/run/local--team-lead/.claude/agents/specialist.md
 ```
 
 Expected: frontmatter with name/description, then sections for Instructions, Rules, and Available Skills — all pulled from the specialist harness.

--- a/docs/tutorial/09-docker-image.md
+++ b/docs/tutorial/09-docker-image.md
@@ -82,7 +82,7 @@ Expected:
 
 ```
 Installed harness "docker-demo"
-  Location: ~/.ynh/harnesses/docker-demo
+  Location: /tmp/ynh-tutorial/docker-harness
   Launcher: ~/.ynh/bin/docker-demo
   Vendor:   claude
 ```
@@ -90,7 +90,7 @@ Installed harness "docker-demo"
 ## T9.3: Build a harness image
 
 ```bash
-ynh image docker-demo --tag docker-demo:latest
+ynh image local/docker-demo --tag docker-demo:latest
 ```
 
 Expected:
@@ -177,7 +177,7 @@ docker run --rm -v $(pwd):/workspace -e OPENAI_API_KEY \
 Preview the generated Dockerfile without building:
 
 ```bash
-ynh image docker-demo --dry-run
+ynh image local/docker-demo --dry-run
 ```
 
 Expected output (Dockerfile printed to stdout):
@@ -186,18 +186,18 @@ Expected output (Dockerfile printed to stdout):
 FROM ghcr.io/eyelock/ynh:latest
 
 # Pre-assembled vendor layouts (all three, ready to use)
-COPY --link --chown=ynh:ynh vendors/claude/ /home/ynh/.ynh/run/docker-demo/claude/
-COPY --link --chown=ynh:ynh vendors/codex/ /home/ynh/.ynh/run/docker-demo/codex/
-COPY --link --chown=ynh:ynh vendors/cursor/ /home/ynh/.ynh/run/docker-demo/cursor/
+COPY --link --chown=ynh:ynh vendors/claude/ /home/ynh/.ynh/run/local--docker-demo/claude/
+COPY --link --chown=ynh:ynh vendors/codex/ /home/ynh/.ynh/run/local--docker-demo/codex/
+COPY --link --chown=ynh:ynh vendors/cursor/ /home/ynh/.ynh/run/local--docker-demo/cursor/
 
 # Harness source (metadata for ynh run)
-COPY --link --chown=ynh:ynh harness/ /home/ynh/.ynh/harnesses/docker-demo/
+COPY --link --chown=ynh:ynh harness/ /home/ynh/.ynh/harnesses/local--docker-demo/
 
 # Default vendor (override: docker run -e YNH_VENDOR=codex)
 ENV YNH_VENDOR=claude
 
 # Baked entrypoint — just pass the prompt as CMD
-ENTRYPOINT ["tini", "-s", "--", "ynh", "run", "docker-demo"]
+ENTRYPOINT ["tini", "-s", "--", "ynh", "run", "local/docker-demo"]
 CMD []
 
 LABEL dev.ynh.harness="docker-demo" \
@@ -222,11 +222,11 @@ Verify the remote includes were resolved and baked in:
 
 ```bash
 docker run --rm --entrypoint sh tester:latest -c \
-  "find /home/ynh/.ynh/run/tester/claude -type f | sort"
+  "find /home/ynh/.ynh/run/local--tester/claude -type f | sort"
 # Expected: skills from github.com/eyelock/assistants assembled into the image:
-#   /home/ynh/.ynh/run/tester/claude/.claude/skills/dev-quality/SKILL.md
-#   /home/ynh/.ynh/run/tester/claude/.claude/skills/go-lang/SKILL.md
-#   /home/ynh/.ynh/run/tester/claude/.claude/skills/go-lang/assets/...
+#   /home/ynh/.ynh/run/local--tester/claude/.claude/skills/dev-quality/SKILL.md
+#   /home/ynh/.ynh/run/local--tester/claude/.claude/skills/go-lang/SKILL.md
+#   /home/ynh/.ynh/run/local--tester/claude/.claude/skills/go-lang/assets/...
 ```
 
 ## T9.9: Override entrypoint


### PR DESCRIPTION
## Summary

Follow-up to #173. That PR fixed the *uninstall* path destroying bare-name-shared resources; this one fixes the same root cause on the *run* path: run dirs were keyed by bare harness name, so two installs sharing a leaf name (`local/foo` vs `github.com/org/repo/foo`) assembled into the same `~/.ynh/run/foo`. `AssembleTo` begins with a clean-previous-run `RemoveAll`, so running one install wiped the other's assembled layout — including out from under a live vendor session (run dirs are stable paths precisely because `syscall.Exec` replaces the process and cleanup can never run).

**Run dirs are now keyed by the canonical id's fs name** (`run/local--foo`, `run/github.com--org--repo--foo`). Inline/discovered harnesses keep `_inline-<hash>`.

### Continuity for existing project symlinks

Cursor/codex installs plant project symlinks pointing into the run dir, so a bare re-key would dangle every existing installation — silently, because `symlinkIntact` only checked the link existed, not that it resolved. Two complementary mechanisms:

- **Legacy alias**: `ynh run` maintains `run/<name>` → `<id-fsname>` while the bare name is unambiguous (counted by distinct canonical ids, so stale schema-1 duplicates of the same install don't suppress it). With several claimants the alias is removed — a bare-name path can't say which install it means.
- **`symlinkIntact` dangle fix**: a link whose target is gone no longer counts as intact, so `ynh run` re-prompts and re-plants project symlinks against the current run dir. This was a standalone bug (deleting `~/.ynh/run` produced the same silent dangle).

### Adjacent fixes in the same keyspace

- **uninstall**: removes the uninstalled install's id-keyed run dirs unconditionally (exclusively its own now); the legacy bare-name path is removed when no survivor claims the name, and the alias is repointed to a sole survivor when it targeted the removed install.
- **prune**: the stale-run-dir scan now recognises id-fsnames — without this it would have deleted every id-keyed run dir as stale — and keeps the load-bearing legacy alias of installed harnesses.
- **harness images**: the Dockerfile template baked `run/<name>/<vendor>` and used a bare-name entrypoint (`ynh run <name>`) which `LoadQualified` already hard-rejects — pre-existing breakage hidden by Docker-gated evals. The template now bakes id-keyed paths (`run/local--<name>/<vendor>`, `harnesses/local--<name>`) with a canonical-id entrypoint, and `cmdRun` falls back to the legacy bare-name baked layout for images built by older ynh. T09's bare-name `ynh image <name>` commands had the same problem and now use canonical ids.

### Docs

Tutorials 01–04 and 09, `CONTRIBUTING.md`, and the ynh-dev architecture reference updated to the id-keyed paths in one pass.

No structured-output shape changes — no capability bump.

## Testing

- `make check` green
- New tests: alias plant/repoint/replace + ambiguity removal, pre-assembled legacy fallback, `symlinkIntact` dangling, prune keyspace, shared-bare-name uninstall flows extended to id-keyed dirs (one real logic bug found and fixed by the tests: alias ambiguity must count distinct canonical ids, not ListAll entries)
- Evals: PASS (19 tutorials evaluated, 0 failures)
- Manual spot-check with built binaries in isolated `YNH_HOME`: id-keyed assembly + alias planting, alias removal on collision, uninstall repoint, last-one-out full cleanup, image dry-run output

🤖 Generated with [Claude Code](https://claude.com/claude-code)